### PR TITLE
Added TDA requirement for language in code of conduct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 *csv
 *checkout
 *pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/.idea
+.idea
 *csv
 *checkout
 *pyc

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -65,6 +65,9 @@ Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other
 members of the project's leadership.
 
+In addition to this Contributor Code of Conduct, TD Ameritrade Associates remain
+subject to all company policy including our internal Code of Conduct.
+
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,


### PR DESCRIPTION
I've added the language the the code of conduct at the tail of the **Enforcement** section.