### PR TITLE
Fixed Issue #129 Rolling stddev in MSTUMP/MSTUMPED

### DIFF
--- a/stumpy/__init__.py
+++ b/stumpy/__init__.py
@@ -8,7 +8,6 @@ from .mstump import (  # noqa: F401
     _mstump,
     _get_first_mstump_profile,
     _get_multi_QT,
-    _multi_compute_mean_std,
     _multi_mass,
 )
 from .mstumped import mstumped  # noqa: F401

--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -307,20 +307,22 @@ def compute_mean_std(T, m, num_chunks=1, max_iter=10):
     Note that Mueen's algorithm has an off-by-one bug where the
     sum for the first subsequence is omitted and we fixed that!
     """
+    if T.ndim > 2:  # pragma nocover
+        raise ValueError("T has to be one or two dimensional!")
 
     for iteration in range(max_iter):
         try:
-            chunk_size = math.ceil((T.shape[0] + 1) / num_chunks)
+            chunk_size = math.ceil((T.shape[-1] + 1) / num_chunks)
 
             mean_chunks = []
             std_chunks = []
             for chunk in range(num_chunks):
                 start = chunk * chunk_size
-                stop = min(start + chunk_size + m - 1, T.shape[0])
+                stop = min(start + chunk_size + m - 1, T.shape[-1])
 
-                tmp_mean = np.mean(rolling_window(T[start:stop], m), axis=1)
+                tmp_mean = np.mean(rolling_window(T[start:stop], m), axis=T.ndim)
                 mean_chunks.append(tmp_mean)
-                tmp_std = np.nanstd(rolling_window(T[start:stop], m), axis=1)
+                tmp_std = np.nanstd(rolling_window(T[start:stop], m), axis=T.ndim)
                 std_chunks.append(tmp_std)
 
             M_T = np.hstack(mean_chunks)

--- a/stumpy/mstumped.py
+++ b/stumpy/mstumped.py
@@ -6,7 +6,7 @@ import logging
 
 import numpy as np
 
-from . import _mstump, _get_first_mstump_profile, _get_multi_QT, _multi_compute_mean_std
+from . import _mstump, _get_first_mstump_profile, _get_multi_QT
 from . import core
 
 logger = logging.getLogger(__name__)
@@ -76,8 +76,8 @@ def mstumped(dask_client, T, m):
     k = n - m + 1
     excl_zone = int(np.ceil(m / 4))  # See Definition 3 and Figure 3
 
-    M_T, Σ_T = _multi_compute_mean_std(T, m)
-    μ_Q, σ_Q = _multi_compute_mean_std(T, m)
+    M_T, Σ_T = core.compute_mean_std(T, m)
+    μ_Q, σ_Q = core.compute_mean_std(T, m)
 
     P = np.empty((nworkers, d, k), dtype="float64")
     D = np.zeros((nworkers, d, k), dtype="float64")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,6 +4,8 @@ from stumpy import core
 import pytest
 import os
 
+import utils
+
 
 def naive_rolling_window_dot_product(Q, T):
     window = len(Q)
@@ -47,12 +49,30 @@ def test_sliding_dot_product(Q, T):
 @pytest.mark.parametrize("Q, T", test_data)
 def test_compute_mean_std(Q, T):
     m = Q.shape[0]
-    left_μ_Q = np.sum(Q) / m
-    left_σ_Q = np.sqrt(np.sum(np.square(Q - left_μ_Q) / m))
-    left_M_T = np.mean(core.rolling_window(T, m), axis=1)
-    left_Σ_T = np.std(core.rolling_window(T, m), axis=1)
+
+    left_μ_Q, left_σ_Q = utils.naive_compute_mean_std(Q, m)
+    left_M_T, left_Σ_T = utils.naive_compute_mean_std(T, m)
     right_μ_Q, right_σ_Q = core.compute_mean_std(Q, m)
     right_M_T, right_Σ_T = core.compute_mean_std(T, m)
+
+    npt.assert_almost_equal(left_μ_Q, right_μ_Q)
+    npt.assert_almost_equal(left_σ_Q, right_σ_Q)
+    npt.assert_almost_equal(left_M_T, right_M_T)
+    npt.assert_almost_equal(left_Σ_T, right_Σ_T)
+
+
+@pytest.mark.parametrize("Q, T", test_data)
+def test_compute_mean_std_multidimensional(Q, T):
+    m = Q.shape[0]
+
+    Q = np.array([Q, np.random.uniform(-1000, 1000, [Q.shape[0]])])
+    T = np.array([T, T, np.random.uniform(-1000, 1000, [T.shape[0]])])
+
+    left_μ_Q, left_σ_Q = utils.naive_compute_mean_std_multidimensional(Q, m)
+    left_M_T, left_Σ_T = utils.naive_compute_mean_std_multidimensional(T, m)
+    right_μ_Q, right_σ_Q = core.compute_mean_std(Q, m)
+    right_M_T, right_Σ_T = core.compute_mean_std(T, m)
+
     npt.assert_almost_equal(left_μ_Q, right_μ_Q)
     npt.assert_almost_equal(left_σ_Q, right_σ_Q)
     npt.assert_almost_equal(left_M_T, right_M_T)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -29,6 +29,47 @@ def test_check_window_size():
             core.check_window_size(m)
 
 
+def naive_compute_mean_std(T, m):
+    n = T.shape[0]
+
+    cumsum_T = np.empty(len(T) + 1)
+    np.cumsum(T, out=cumsum_T[1:])  # store output in cumsum_T[1:]
+    cumsum_T[0] = 0
+
+    cumsum_T_squared = np.empty(len(T) + 1)
+    np.cumsum(np.square(T), out=cumsum_T_squared[1:])
+    cumsum_T_squared[0] = 0
+
+    subseq_sum_T = cumsum_T[m:] - cumsum_T[: n - m + 1]
+    subseq_sum_T_squared = cumsum_T_squared[m:] - cumsum_T_squared[: n - m + 1]
+    M_T = subseq_sum_T / m
+    Σ_T = np.abs((subseq_sum_T_squared / m) - np.square(M_T))
+    Σ_T = np.sqrt(Σ_T)
+
+    return M_T, Σ_T
+
+
+def naive_compute_mean_std_multidimensional(T, m):
+    n = T.shape[1]
+    nrows, ncols = T.shape
+
+    cumsum_T = np.empty((nrows, ncols + 1))
+    np.cumsum(T, axis=1, out=cumsum_T[:, 1:])  # store output in cumsum_T[1:]
+    cumsum_T[:, 0] = 0
+
+    cumsum_T_squared = np.empty((nrows, ncols + 1))
+    np.cumsum(np.square(T), axis=1, out=cumsum_T_squared[:, 1:])
+    cumsum_T_squared[:, 0] = 0
+
+    subseq_sum_T = cumsum_T[:, m:] - cumsum_T[:, : n - m + 1]
+    subseq_sum_T_squared = cumsum_T_squared[:, m:] - cumsum_T_squared[:, : n - m + 1]
+    M_T = subseq_sum_T / m
+    Σ_T = np.abs((subseq_sum_T_squared / m) - np.square(M_T))
+    Σ_T = np.sqrt(Σ_T)
+
+    return M_T, Σ_T
+
+
 test_data = [
     (np.array([-1, 1, 2], dtype=np.float64), np.array(range(5), dtype=np.float64)),
     (
@@ -50,8 +91,8 @@ def test_sliding_dot_product(Q, T):
 def test_compute_mean_std(Q, T):
     m = Q.shape[0]
 
-    left_μ_Q, left_σ_Q = utils.naive_compute_mean_std(Q, m)
-    left_M_T, left_Σ_T = utils.naive_compute_mean_std(T, m)
+    left_μ_Q, left_σ_Q = naive_compute_mean_std(Q, m)
+    left_M_T, left_Σ_T = naive_compute_mean_std(T, m)
     right_μ_Q, right_σ_Q = core.compute_mean_std(Q, m)
     right_M_T, right_Σ_T = core.compute_mean_std(T, m)
 
@@ -68,8 +109,8 @@ def test_compute_mean_std_multidimensional(Q, T):
     Q = np.array([Q, np.random.uniform(-1000, 1000, [Q.shape[0]])])
     T = np.array([T, T, np.random.uniform(-1000, 1000, [T.shape[0]])])
 
-    left_μ_Q, left_σ_Q = utils.naive_compute_mean_std_multidimensional(Q, m)
-    left_M_T, left_Σ_T = utils.naive_compute_mean_std_multidimensional(T, m)
+    left_μ_Q, left_σ_Q = naive_compute_mean_std_multidimensional(Q, m)
+    left_M_T, left_Σ_T = naive_compute_mean_std_multidimensional(T, m)
     right_μ_Q, right_σ_Q = core.compute_mean_std(Q, m)
     right_M_T, right_Σ_T = core.compute_mean_std(T, m)
 

--- a/tests/test_mstump.py
+++ b/tests/test_mstump.py
@@ -5,7 +5,6 @@ from stumpy import core
 from stumpy import (
     mstump,
     _mstump,
-    _multi_compute_mean_std,
     _multi_mass,
     _get_first_mstump_profile,
     _get_multi_QT,
@@ -80,19 +79,6 @@ test_data = [
     (np.array([[584, -11, 23, 79, 1001, 0, -19]], dtype=np.float64), 3),
     (np.random.uniform(-1000, 1000, [3, 10]).astype(np.float64), 5),
 ]
-
-
-@pytest.mark.parametrize("T, m", test_data)
-def test_multi_compute_mean_std(T, m):
-    Q = core.rolling_window(T, m)
-    left_M_T = np.empty((Q.shape[0], Q.shape[1]))
-    left_Σ_T = np.empty((Q.shape[0], Q.shape[1]))
-    for i in range(Q.shape[0]):
-        left_M_T[i] = np.mean(Q[i], axis=1)
-        left_Σ_T[i] = np.std(Q[i], axis=1)
-    right_M_T, right_Σ_T = _multi_compute_mean_std(T, m)
-    npt.assert_almost_equal(left_M_T, right_M_T)
-    npt.assert_almost_equal(left_Σ_T, right_Σ_T)
 
 
 @pytest.mark.parametrize("T, m", test_data)
@@ -174,8 +160,8 @@ def test_mstump(T, m):
     k = n - m + 1
     excl_zone = int(np.ceil(m / 4))  # See Definition 3 and Figure 3
 
-    M_T, Σ_T = _multi_compute_mean_std(T, m)
-    μ_Q, σ_Q = _multi_compute_mean_std(T, m)
+    M_T, Σ_T = core.compute_mean_std(T, m)
+    μ_Q, σ_Q = core.compute_mean_std(T, m)
 
     P = np.empty((d, k), dtype="float64")
     D = np.zeros((d, k), dtype="float64")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -54,47 +54,6 @@ def naive_mass(Q, T, m, trivial_idx=None, excl_zone=0, ignore_trivial=False):
     return P, I, IL, IR
 
 
-def naive_compute_mean_std(T, m):
-    n = T.shape[0]
-
-    cumsum_T = np.empty(len(T) + 1)
-    np.cumsum(T, out=cumsum_T[1:])  # store output in cumsum_T[1:]
-    cumsum_T[0] = 0
-
-    cumsum_T_squared = np.empty(len(T) + 1)
-    np.cumsum(np.square(T), out=cumsum_T_squared[1:])
-    cumsum_T_squared[0] = 0
-
-    subseq_sum_T = cumsum_T[m:] - cumsum_T[: n - m + 1]
-    subseq_sum_T_squared = cumsum_T_squared[m:] - cumsum_T_squared[: n - m + 1]
-    M_T = subseq_sum_T / m
-    Σ_T = np.abs((subseq_sum_T_squared / m) - np.square(M_T))
-    Σ_T = np.sqrt(Σ_T)
-
-    return M_T, Σ_T
-
-
-def naive_compute_mean_std_multidimensional(T, m):
-    n = T.shape[1]
-    nrows, ncols = T.shape
-
-    cumsum_T = np.empty((nrows, ncols + 1))
-    np.cumsum(T, axis=1, out=cumsum_T[:, 1:])  # store output in cumsum_T[1:]
-    cumsum_T[:, 0] = 0
-
-    cumsum_T_squared = np.empty((nrows, ncols + 1))
-    np.cumsum(np.square(T), axis=1, out=cumsum_T_squared[:, 1:])
-    cumsum_T_squared[:, 0] = 0
-
-    subseq_sum_T = cumsum_T[:, m:] - cumsum_T[:, : n - m + 1]
-    subseq_sum_T_squared = cumsum_T_squared[:, m:] - cumsum_T_squared[:, : n - m + 1]
-    M_T = subseq_sum_T / m
-    Σ_T = np.abs((subseq_sum_T_squared / m) - np.square(M_T))
-    Σ_T = np.sqrt(Σ_T)
-
-    return M_T, Σ_T
-
-
 def replace_inf(x, value=0):
     x[x == np.inf] = value
     x[x == -np.inf] = value

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -54,6 +54,47 @@ def naive_mass(Q, T, m, trivial_idx=None, excl_zone=0, ignore_trivial=False):
     return P, I, IL, IR
 
 
+def naive_compute_mean_std(T, m):
+    n = T.shape[0]
+
+    cumsum_T = np.empty(len(T) + 1)
+    np.cumsum(T, out=cumsum_T[1:])  # store output in cumsum_T[1:]
+    cumsum_T[0] = 0
+
+    cumsum_T_squared = np.empty(len(T) + 1)
+    np.cumsum(np.square(T), out=cumsum_T_squared[1:])
+    cumsum_T_squared[0] = 0
+
+    subseq_sum_T = cumsum_T[m:] - cumsum_T[: n - m + 1]
+    subseq_sum_T_squared = cumsum_T_squared[m:] - cumsum_T_squared[: n - m + 1]
+    M_T = subseq_sum_T / m
+    Σ_T = np.abs((subseq_sum_T_squared / m) - np.square(M_T))
+    Σ_T = np.sqrt(Σ_T)
+
+    return M_T, Σ_T
+
+
+def naive_compute_mean_std_multidimensional(T, m):
+    n = T.shape[1]
+    nrows, ncols = T.shape
+
+    cumsum_T = np.empty((nrows, ncols + 1))
+    np.cumsum(T, axis=1, out=cumsum_T[:, 1:])  # store output in cumsum_T[1:]
+    cumsum_T[:, 0] = 0
+
+    cumsum_T_squared = np.empty((nrows, ncols + 1))
+    np.cumsum(np.square(T), axis=1, out=cumsum_T_squared[:, 1:])
+    cumsum_T_squared[:, 0] = 0
+
+    subseq_sum_T = cumsum_T[:, m:] - cumsum_T[:, : n - m + 1]
+    subseq_sum_T_squared = cumsum_T_squared[:, m:] - cumsum_T_squared[:, : n - m + 1]
+    M_T = subseq_sum_T / m
+    Σ_T = np.abs((subseq_sum_T_squared / m) - np.square(M_T))
+    Σ_T = np.sqrt(Σ_T)
+
+    return M_T, Σ_T
+
+
 def replace_inf(x, value=0):
     x[x == np.inf] = value
     x[x == -np.inf] = value


### PR DESCRIPTION
This PR fixes issue #129 and improves the tests of `core.compute_mean_std`.