### PR TITLE
Fixed Issue #136 and improved mstump tests

### DIFF
--- a/stumpy/mstumped.py
+++ b/stumpy/mstumped.py
@@ -41,12 +41,12 @@ def mstumped(dask_client, T, m):
     Returns
     -------
     P : ndarray
-        The multi-dimensional matrix profile. Each row of the array corresponds
-        to each matrix profile for a given dimension (i.e., the first row is the
-        1-D matrix profile and the second row is the 2-D matrix profile).
+        The multi-dimensional matrix profile. Each column of the array corresponds
+        to each matrix profile for a given dimension (i.e., the first column is
+        the 1-D matrix profile and the second column is the 2-D matrix profile).
 
     I : ndarray
-        The multi-dimensional matrix profile index where each row of the array
+        The multi-dimensional matrix profile index where each column of the array
         corresponds to each matrix profile index for a given dimension.
 
     Notes
@@ -79,7 +79,7 @@ def mstumped(dask_client, T, m):
     M_T, Σ_T = core.compute_mean_std(T, m)
     μ_Q, σ_Q = core.compute_mean_std(T, m)
 
-    P = np.empty((nworkers, d, k), dtype="float64")
+    P = np.full((nworkers, d, k), np.inf, dtype="float64")
     D = np.zeros((nworkers, d, k), dtype="float64")
     D_prime = np.zeros((nworkers, k), dtype="float64")
     I = np.ones((nworkers, d, k), dtype="int64") * -1
@@ -100,7 +100,9 @@ def mstumped(dask_client, T, m):
     D_prime_futures = []
 
     for i, start in enumerate(range(0, k, step)):
-        P[i], I[i] = _get_first_mstump_profile(start, T, m, excl_zone, M_T, Σ_T)
+        P[i, :, start], I[i, :, start] = _get_first_mstump_profile(
+            start, T, m, excl_zone, M_T, Σ_T
+        )
 
         P_future = dask_client.scatter(P[i], workers=[hosts[i]])
         I_future = dask_client.scatter(I[i], workers=[hosts[i]])

--- a/tests/test_mstump.py
+++ b/tests/test_mstump.py
@@ -13,66 +13,12 @@ import pytest
 import utils
 
 
-def naive_mass(Q, T, m, trivial_idx, excl_zone):
-    D = np.linalg.norm(
-        utils.z_norm(core.rolling_window(T, m), 1) - utils.z_norm(Q), axis=1
-    )
-    start = max(0, trivial_idx - excl_zone)
-    stop = min(T.shape[0] - Q.shape[0] + 1, trivial_idx + excl_zone)
-    D[start : stop + 1] = np.inf
-
-    return D
-
-
-def naive_PI(D, trivial_idx):
-    P = np.full((D.shape[0], D.shape[1]), np.inf)
-    I = np.ones((D.shape[0], D.shape[1]), dtype="int64") * -1
-
-    D = np.sort(D, axis=0)
-
-    D_prime = np.zeros(D.shape[1])
-    for i in range(D.shape[0]):
-        D_prime = D_prime + D[i]
-        D_prime_prime = D_prime / (i + 1)
-        # Element-wise Min
-        # col_idx = np.argmin([left_P[i, :], D_prime_prime], axis=0)
-        # col_mask = col_idx > 0
-        col_mask = P[i] > D_prime_prime
-        P[i, col_mask] = D_prime_prime[col_mask]
-        I[i, col_mask] = trivial_idx
-
-    return P, I
-
-
 def naive_rolling_window_dot_product(Q, T):
     window = len(Q)
     result = np.zeros(len(T) - window + 1)
     for i in range(len(result)):
         result[i] = np.dot(T[i : i + window], Q)
     return result
-
-
-def naive_mstump(T, m):
-    zone = int(np.ceil(m / 4))
-    Q = core.rolling_window(T, m)
-    D = np.empty((Q.shape[0], Q.shape[1]))
-    P = np.full((Q.shape[0], Q.shape[1]), np.inf)
-    I = np.ones((Q.shape[0], Q.shape[1]), dtype="int64") * -1
-
-    # Left
-    for i in range(Q.shape[1]):
-        D[:] = 0.0
-        for dim in range(T.shape[0]):
-            D[dim] = naive_mass(Q[dim, i], T[dim], m, i, zone)
-
-        P_i, I_i = naive_PI(D, i)
-
-        for dim in range(T.shape[0]):
-            col_mask = P[dim] > P_i[dim]
-            P[dim, col_mask] = P_i[dim, col_mask]
-            I[dim, col_mask] = I_i[dim, col_mask]
-
-    return P, I
 
 
 test_data = [
@@ -83,48 +29,27 @@ test_data = [
 
 @pytest.mark.parametrize("T, m", test_data)
 def test_multi_mass(T, m):
-
-    excl_zone = int(np.ceil(m / 4))
     trivial_idx = 2
-    Q = core.rolling_window(T, m)
-    # left
-    D = np.empty((Q.shape[0], Q.shape[1]))
+    Q = T[:, trivial_idx : trivial_idx + m]
 
-    for i in range(T.shape[0]):
-        D[i] = naive_mass(Q[i, 0], T[i], m, trivial_idx, excl_zone)
+    left = utils.naive_multi_mass(Q, T, m)
 
-    left_P, left_I = naive_PI(D, trivial_idx)
+    M_T, Σ_T = core.compute_mean_std(T, m)
+    right = _multi_mass(Q, T, m, M_T, Σ_T)
 
-    # right
-    M_T = np.empty((Q.shape[0], Q.shape[1]))
-    Σ_T = np.empty((Q.shape[0], Q.shape[1]))
-    for i in range(Q.shape[0]):
-        M_T[i] = np.mean(Q[i], axis=1)
-        Σ_T[i] = np.std(Q[i], axis=1)
-    right_P, right_I = _multi_mass(Q[:, 0], T, m, M_T, Σ_T, trivial_idx, excl_zone)
-
-    npt.assert_almost_equal(left_P, right_P)
-    npt.assert_equal(left_I, right_I)
+    npt.assert_almost_equal(left, right)
 
 
 @pytest.mark.parametrize("T, m", test_data)
 def test_get_first_mstump_profile(T, m):
     excl_zone = int(np.ceil(m / 4))
     start = 0
-    Q = core.rolling_window(T, m)
-    # left
-    D = np.empty((Q.shape[0], Q.shape[1]))
-    for i in range(T.shape[0]):
-        D[i] = naive_mass(Q[i, 0], T[i], m, start, excl_zone)
 
-    left_P, left_I = naive_PI(D, start)
+    left_P, left_I = utils.naive_mstump(T, m, excl_zone)
+    left_P = left_P[start, :]
+    left_I = left_I[start, :]
 
-    # right
-    M_T = np.empty((Q.shape[0], Q.shape[1]))
-    Σ_T = np.empty((Q.shape[0], Q.shape[1]))
-    for i in range(Q.shape[0]):
-        M_T[i] = np.mean(Q[i], axis=1)
-        Σ_T[i] = np.std(Q[i], axis=1)
+    M_T, Σ_T = core.compute_mean_std(T, m)
     right_P, right_I = _get_first_mstump_profile(start, T, m, excl_zone, M_T, Σ_T)
 
     npt.assert_almost_equal(left_P, right_P)
@@ -150,49 +75,36 @@ def test_get_multi_QT(T, m):
     npt.assert_almost_equal(left_QT_first, right_QT_first)
 
 
+def test_naive_mstump():
+    T = np.random.uniform(-1000, 1000, [1, 1000]).astype(np.float64)
+    m = 20
+
+    excl_zone = int(np.ceil(m / 4))
+
+    left = np.array(
+        [
+            utils.naive_mass(
+                Q, T[0], m, trivial_idx=i, ignore_trivial=True, excl_zone=excl_zone
+            )
+            for i, Q in enumerate(core.rolling_window(T[0], m))
+        ],
+        dtype=object,
+    )
+    left_P = left[np.newaxis, :, 0].T
+    left_I = left[np.newaxis, :, 1].T
+
+    right_P, right_I = utils.naive_mstump(T, m, excl_zone)
+
+    npt.assert_almost_equal(left_P, right_P)
+    npt.assert_almost_equal(left_I, right_I)
+
+
 @pytest.mark.parametrize("T, m", test_data)
 def test_mstump(T, m):
-    left_P, left_I = naive_mstump(T, m)
+    excl_zone = int(np.ceil(m / 4))
 
-    # Right
-    d = T.shape[0]
-    n = T.shape[1]
-    k = n - m + 1
-    excl_zone = int(np.ceil(m / 4))  # See Definition 3 and Figure 3
-
-    M_T, Σ_T = core.compute_mean_std(T, m)
-    μ_Q, σ_Q = core.compute_mean_std(T, m)
-
-    P = np.empty((d, k), dtype="float64")
-    D = np.zeros((d, k), dtype="float64")
-    D_prime = np.zeros(k, dtype="float64")
-    I = np.ones((d, k), dtype="int64") * -1
-
-    start = 0
-    stop = k
-
-    P, I = _get_first_mstump_profile(start, T, m, excl_zone, M_T, Σ_T)
-
-    QT, QT_first = _get_multi_QT(start, T, m)
-
-    right_P, right_I = _mstump(
-        T,
-        m,
-        P,
-        I,
-        D,
-        D_prime,
-        stop,
-        excl_zone,
-        M_T,
-        Σ_T,
-        QT,
-        QT_first,
-        μ_Q,
-        σ_Q,
-        k,
-        start + 1,
-    )
+    left_P, left_I = utils.naive_mstump(T, m, excl_zone)
+    right_P, right_I = mstump(T, m)
 
     npt.assert_almost_equal(left_P, right_P)
     npt.assert_almost_equal(left_I, right_I)
@@ -200,17 +112,19 @@ def test_mstump(T, m):
 
 @pytest.mark.parametrize("T, m", test_data)
 def test_mstump_wrapper(T, m):
-    left_P, left_I = naive_mstump(T, m)
+    excl_zone = int(np.ceil(m / 4))
+
+    left_P, left_I = utils.naive_mstump(T, m, excl_zone)
     right_P, right_I = mstump(T, m)
 
-    npt.assert_almost_equal(left_P.T, right_P)
-    npt.assert_almost_equal(left_I.T, right_I)
+    npt.assert_almost_equal(left_P, right_P)
+    npt.assert_almost_equal(left_I, right_I)
 
     df = pd.DataFrame(T.T)
     right_P, right_I = mstump(df, m)
 
-    npt.assert_almost_equal(left_P.T, right_P)
-    npt.assert_almost_equal(left_I.T, right_I)
+    npt.assert_almost_equal(left_P, right_P)
+    npt.assert_almost_equal(left_I, right_I)
 
 
 def test_constant_subsequence_self_join():
@@ -218,7 +132,9 @@ def test_constant_subsequence_self_join():
     T = np.array([T_A, T_A, np.random.rand(T_A.shape[0])])
     m = 3
 
-    left_P, left_I = naive_mstump(T, m)
+    excl_zone = int(np.ceil(m / 4))
+
+    left_P, left_I = utils.naive_mstump(T, m, excl_zone)
     right_P, right_I = mstump(T, m)
 
-    npt.assert_almost_equal(left_P.T, right_P)  # ignore indices
+    npt.assert_almost_equal(left_P, right_P)  # ignore indices

--- a/tests/test_mstumped.py
+++ b/tests/test_mstumped.py
@@ -18,60 +18,6 @@ def dask_client():
     cluster.close()
 
 
-def naive_mass(Q, T, m, trivial_idx, excl_zone):
-    D = np.linalg.norm(
-        utils.z_norm(core.rolling_window(T, m), 1) - utils.z_norm(Q), axis=1
-    )
-    start = max(0, trivial_idx - excl_zone)
-    stop = min(T.shape[0] - Q.shape[0] + 1, trivial_idx + excl_zone)
-    D[start : stop + 1] = np.inf
-
-    return D
-
-
-def naive_PI(D, trivial_idx):
-    P = np.full((D.shape[0], D.shape[1]), np.inf)
-    I = np.ones((D.shape[0], D.shape[1]), dtype="int64") * -1
-
-    D = np.sort(D, axis=0)
-
-    D_prime = np.zeros(D.shape[1])
-    for i in range(D.shape[0]):
-        D_prime = D_prime + D[i]
-        D_prime_prime = D_prime / (i + 1)
-        # Element-wise Min
-        # col_idx = np.argmin([left_P[i, :], D_prime_prime], axis=0)
-        # col_mask = col_idx > 0
-        col_mask = P[i] > D_prime_prime
-        P[i, col_mask] = D_prime_prime[col_mask]
-        I[i, col_mask] = trivial_idx
-
-    return P, I
-
-
-def naive_mstump(T, m):
-    zone = int(np.ceil(m / 4))
-    Q = core.rolling_window(T, m)
-    D = np.empty((Q.shape[0], Q.shape[1]))
-    P = np.full((Q.shape[0], Q.shape[1]), np.inf)
-    I = np.ones((Q.shape[0], Q.shape[1]), dtype="int64") * -1
-
-    # Left
-    for i in range(Q.shape[1]):
-        D[:] = 0.0
-        for dim in range(T.shape[0]):
-            D[dim] = naive_mass(Q[dim, i], T[dim], m, i, zone)
-
-        P_i, I_i = naive_PI(D, i)
-
-        for dim in range(T.shape[0]):
-            col_mask = P[dim] > P_i[dim]
-            P[dim, col_mask] = P_i[dim, col_mask]
-            I[dim, col_mask] = I_i[dim, col_mask]
-
-    return P, I
-
-
 test_data = [
     (np.array([[584, -11, 23, 79, 1001, 0, -19]], dtype=np.float64), 3),
     (np.random.uniform(-1000, 1000, [3, 10]).astype(np.float64), 5),
@@ -81,22 +27,26 @@ test_data = [
 @pytest.mark.filterwarnings("ignore:\\s+Port 8787 is already in use:UserWarning")
 @pytest.mark.parametrize("T, m", test_data)
 def test_mstumped(T, m, dask_client):
-    left_P, left_I = naive_mstump(T, m)
+    excl_zone = int(np.ceil(m / 4))
+
+    left_P, left_I = utils.naive_mstump(T, m, excl_zone)
     right_P, right_I = mstumped(dask_client, T, m)
 
-    npt.assert_almost_equal(left_P.T, right_P)
-    npt.assert_almost_equal(left_I.T, right_I)
+    npt.assert_almost_equal(left_P, right_P)
+    npt.assert_almost_equal(left_I, right_I)
 
 
 @pytest.mark.filterwarnings("ignore:\\s+Port 8787 is already in use:UserWarning")
 @pytest.mark.parametrize("T, m", test_data)
 def test_mstumped_df(T, m, dask_client):
-    left_P, left_I = naive_mstump(T, m)
+    excl_zone = int(np.ceil(m / 4))
+
+    left_P, left_I = utils.naive_mstump(T, m, excl_zone)
     df = pd.DataFrame(T.T)
     right_P, right_I = mstumped(dask_client, df, m)
 
-    npt.assert_almost_equal(left_P.T, right_P)
-    npt.assert_almost_equal(left_I.T, right_I)
+    npt.assert_almost_equal(left_P, right_P)
+    npt.assert_almost_equal(left_I, right_I)
 
 
 @pytest.mark.filterwarnings("ignore:\\s+Port 8787 is already in use:UserWarning")
@@ -105,7 +55,9 @@ def test_constant_subsequence_self_join(dask_client):
     T = np.array([T_A, T_A, np.random.rand(T_A.shape[0])])
     m = 3
 
-    left_P, left_I = naive_mstump(T, m)
+    excl_zone = int(np.ceil(m / 4))
+
+    left_P, left_I = utils.naive_mstump(T, m, excl_zone)
     right_P, right_I = mstumped(dask_client, T, m)
 
-    npt.assert_almost_equal(left_P.T, right_P)  # ignore indices
+    npt.assert_almost_equal(left_P, right_P)  # ignore indices


### PR DESCRIPTION
I tried to stick as much to the issue #136 as I could, but I had to make some changes that touch issue #135 .

- The main change is that I converted `_multi_mass` to return the multidimensional distance profile as discussed. 
- I also changed `_get_first_mstump_profile` in a way so that it only returns the profile values and indices at index `start` so that this function is consistent with `stump._get_first_stump_profile`. I made this change in this PR because I had to move things to this function, e.g. the application of an exclusion zone, and it made sense to do it here. This does break the anytime ability of mstump though (because the distance profile of `T[start:start+m]` does not influence the whole matrix profile anymore). This is why I had to slightly change the logic of `_mstump`. I tried to leave it as untouched as possible. Also minor changes to `mstumped` had to be made.
- Some tests were improved to actually use the defined functions. I also moved the `naive_mstump` function to `utils.py` to be able to reuse it in `test_mstumped.py`.

Let me know what you think.