### PR TITLE
Fixed #117 and #130

### DIFF
--- a/stumpy/mstump.py
+++ b/stumpy/mstump.py
@@ -373,7 +373,7 @@ def mstump(T, m):
         start, T_A, T_B, m, excl_zone, M_T, Σ_T
     )
 
-    T_B[np.isnan(T_A)] = 0
+    T_B[np.isnan(T_B)] = 0
 
     QT, QT_first = _get_multi_QT(start, T_A, m)
 

--- a/stumpy/mstump.py
+++ b/stumpy/mstump.py
@@ -59,7 +59,7 @@ def _multi_mass(Q, T, m, M_T, Σ_T):
     return D
 
 
-def _get_first_mstump_profile(start, T, m, excl_zone, M_T, Σ_T):
+def _get_first_mstump_profile(start, T_A, T_B, m, excl_zone, M_T, Σ_T):
     """
     Multi-dimensional wrapper to compute the multi-dimensional matrix profile
     and multi-dimensional matrix profile index for a given window within the
@@ -72,9 +72,12 @@ def _get_first_mstump_profile(start, T, m, excl_zone, M_T, Σ_T):
         The window index to calculate the first matrix profile, matrix profile
         index, left matrix profile index, and right matrix profile index for.
 
-    T : ndarray
+    T_A : ndarray
         The time series or sequence for which the matrix profile index will
         be returned
+
+    T_B : ndarray
+        The time series or sequence that contains your query subsequences
 
     m : int
         Window size
@@ -98,8 +101,8 @@ def _get_first_mstump_profile(start, T, m, excl_zone, M_T, Σ_T):
         equal to `start`
     """
 
-    d, n = T.shape
-    D = _multi_mass(T[:, start : start + m], T, m, M_T, Σ_T)
+    d, n = T_A.shape
+    D = _multi_mass(T_B[:, start : start + m], T_A, m, M_T, Σ_T)
 
     zone_start = max(0, start - excl_zone)
     zone_stop = min(n - m + 1, start + excl_zone)
@@ -159,22 +162,7 @@ def _get_multi_QT(start, T, m):
 
 @njit(parallel=True, fastmath=True)
 def _mstump(
-    T,
-    m,
-    P,
-    I,
-    D,
-    D_prime,
-    range_stop,
-    excl_zone,
-    M_T,
-    Σ_T,
-    QT,
-    QT_first,
-    μ_Q,
-    σ_Q,
-    k,
-    range_start=1,
+    T, m, range_stop, excl_zone, M_T, Σ_T, QT, QT_first, μ_Q, σ_Q, k, range_start=1
 ):
     """
     A Numba JIT-compiled version of mSTOMP, a variant of mSTAMP, for parallel
@@ -189,18 +177,6 @@ def _mstump(
 
     m : int
         Window size
-
-    P : ndarray
-        The output multi-dimensional matrix profile
-
-    I : ndarray
-        The output multi-dimensional matrix profile index
-
-    D : ndarray
-        Storage for the distance profile
-
-    D_prime : ndarray
-        Storage for the cumulative sum of the distance profile
 
     range_stop : int
         The index value along T for which to stop the matrix profile
@@ -260,8 +236,12 @@ def _mstump(
     QT_even = QT.copy()
     d = T.shape[0]
 
+    P = np.empty((d, range_stop - range_start))
+    I = np.empty((d, range_stop - range_start))
+    D = np.empty((d, k))
+    D_prime = np.empty(k)
+
     for idx in range(range_start, range_stop):
-        D[:, :] = 0.0
         for i in range(d):
             # Numba's prange requires incrementing a range by 1 so replace
             # `for j in range(k-1,0,-1)` with its incrementing compliment
@@ -311,10 +291,11 @@ def _mstump(
             D_prime = D_prime + D[i]
 
             min_index = np.argmin(D_prime)
-            I[i, idx] = min_index
-            P[i, idx] = D_prime[min_index] / (i + 1)
-            if np.isinf(P[i, idx]):  # pragma nocover
-                I[i, idx] = -1
+            pos = idx - range_start
+            I[i, pos] = min_index
+            P[i, pos] = D_prime[min_index] / (i + 1)
+            if np.isinf(P[i, pos]):  # pragma nocover
+                I[i, pos] = -1
 
     return P, I
 
@@ -359,55 +340,45 @@ def mstump(T, m):
     See mSTAMP Algorithm
     """
 
-    T = np.asarray(core.transpose_dataframe(T))
+    T_A = np.asarray(core.transpose_dataframe(T)).copy()
+    T_B = T_A.copy()
 
-    core.check_dtype(T)
-    core.check_nan(T)
-    if T.ndim <= 1:  # pragma: no cover
-        err = f"T is {T.ndim}-dimensional and must be greater than 1-dimensional"
+    T_A[np.isinf(T_A)] = np.nan
+    T_B[np.isinf(T_B)] = np.nan
+
+    core.check_dtype(T_A)
+    if T_A.ndim <= 1:  # pragma: no cover
+        err = f"T is {T_A.ndim}-dimensional and must be at least 1-dimensional"
         raise ValueError(f"{err}")
 
     core.check_window_size(m)
 
-    d = T.shape[0]
-    n = T.shape[1]
+    d = T_A.shape[0]
+    n = T_A.shape[1]
     k = n - m + 1
     excl_zone = int(np.ceil(m / 4))  # See Definition 3 and Figure 3
 
-    M_T, Σ_T = core.compute_mean_std(T, m)
-    μ_Q, σ_Q = core.compute_mean_std(T, m)
+    M_T, Σ_T = core.compute_mean_std(T_A, m)
+    μ_Q, σ_Q = core.compute_mean_std(T_B, m)
 
-    P = np.full((d, k), np.inf, dtype="float64")
-    D = np.zeros((d, k), dtype="float64")
-    D_prime = np.zeros(k, dtype="float64")
-    I = np.ones((d, k), dtype="int64") * -1
+    T_A[np.isnan(T_A)] = 0
+
+    P = np.empty((d, k), dtype="float64")
+    I = np.empty((d, k), dtype="int64")
 
     start = 0
     stop = k
 
     P[:, start], I[:, start] = _get_first_mstump_profile(
-        start, T, m, excl_zone, M_T, Σ_T
+        start, T_A, T_B, m, excl_zone, M_T, Σ_T
     )
 
-    QT, QT_first = _get_multi_QT(start, T, m)
+    T_B[np.isnan(T_A)] = 0
 
-    _mstump(
-        T,
-        m,
-        P,
-        I,
-        D,
-        D_prime,
-        stop,
-        excl_zone,
-        M_T,
-        Σ_T,
-        QT,
-        QT_first,
-        μ_Q,
-        σ_Q,
-        k,
-        start + 1,
+    QT, QT_first = _get_multi_QT(start, T_A, m)
+
+    P[:, start + 1 : stop], I[:, start + 1 : stop] = _mstump(
+        T_A, m, stop, excl_zone, M_T, Σ_T, QT, QT_first, μ_Q, σ_Q, k, start + 1
     )
 
     return P.T, I.T

--- a/stumpy/stump.py
+++ b/stumpy/stump.py
@@ -30,7 +30,7 @@ def _get_first_stump_profile(start, T_A, T_B, m, excl_zone, M_T, Σ_T, ignore_tr
         be returned
 
     T_B : ndarray
-        The time series or sequence that contain your query subsequences
+        The time series or sequence that contains your query subsequences
 
     m : int
         Window size

--- a/test.sh
+++ b/test.sh
@@ -32,6 +32,8 @@ py.test -x -W ignore::RuntimeWarning -W ignore::DeprecationWarning tests/test_st
 check_errs $?
 py.test -x -W ignore::RuntimeWarning -W ignore::DeprecationWarning tests/test_stumped_two_subsequences_nan_A_B_join.py tests/test_stumped_two_subsequences_inf_A_B_join.py tests/test_stumped_two_subsequences_nan_inf_A_B_join.py tests/test_stumped_two_subsequences_nan_inf_A_B_join_swap.py
 check_errs $?
+py.test -x -W ignore::RuntimeWarning -W ignore::DeprecationWarning tests/test_mstumped_one_subsequence_nan_self_join.py tests/test_mstumped_one_subsequence_nan_self_join.py
+check_errs $?
 py.test -rsx -W ignore::RuntimeWarning -W ignore::DeprecationWarning tests/test_scrimp.py
 check_errs $?
 

--- a/tests/test_mstumped_one_subsequence_inf_self_join.py
+++ b/tests/test_mstumped_one_subsequence_inf_self_join.py
@@ -1,0 +1,62 @@
+import numpy as np
+import numpy.testing as npt
+import pandas as pd
+from stumpy import core, mstumped
+import pytest
+from dask.distributed import Client, LocalCluster
+import warnings
+import utils
+
+
+@pytest.fixture(scope="module")
+def dask_client():
+    cluster = LocalCluster(n_workers=2, threads_per_worker=2)
+    client = Client(cluster)
+    yield client
+    # teardown
+    client.close()
+    cluster.close()
+
+
+test_data = [
+    (np.array([[584, -11, 23, 79, 1001, 0, -19]], dtype=np.float64), 3),
+    (np.random.uniform(-1000, 1000, [3, 10]).astype(np.float64), 5),
+]
+
+substitution_locations = [slice(0, 0), 0, -1, slice(1, 3), [0, 3]]
+
+
+@pytest.mark.filterwarnings("ignore:\\s+Port 8787 is already in use:UserWarning")
+@pytest.mark.parametrize("T, m", test_data)
+@pytest.mark.parametrize("substitution_location", substitution_locations)
+def test_mstumped_one_subsequence_inf_self_join_first_dimension(
+    T, m, substitution_location, dask_client
+):
+    excl_zone = int(np.ceil(m / 4))
+
+    T_sub = T.copy()
+    T_sub[0, substitution_location] = np.inf
+
+    left_P, left_I = utils.naive_mstump(T_sub, m, excl_zone)
+    right_P, right_I = mstumped(dask_client, T_sub, m)
+
+    npt.assert_almost_equal(left_P, right_P)
+    npt.assert_almost_equal(left_I, right_I)
+
+
+@pytest.mark.filterwarnings("ignore:\\s+Port 8787 is already in use:UserWarning")
+@pytest.mark.parametrize("T, m", test_data)
+@pytest.mark.parametrize("substitution_location", substitution_locations)
+def test_mstumped_one_subsequence_inf_self_join_all_dimensions(
+    T, m, substitution_location, dask_client
+):
+    excl_zone = int(np.ceil(m / 4))
+
+    T_sub = T.copy()
+    T_sub[:, substitution_location] = np.inf
+
+    left_P, left_I = utils.naive_mstump(T_sub, m, excl_zone)
+    right_P, right_I = mstumped(dask_client, T_sub, m)
+
+    npt.assert_almost_equal(left_P, right_P)
+    npt.assert_almost_equal(left_I, right_I)

--- a/tests/test_mstumped_one_subsequence_nan_self_join.py
+++ b/tests/test_mstumped_one_subsequence_nan_self_join.py
@@ -1,0 +1,62 @@
+import numpy as np
+import numpy.testing as npt
+import pandas as pd
+from stumpy import core, mstumped
+import pytest
+from dask.distributed import Client, LocalCluster
+import warnings
+import utils
+
+
+@pytest.fixture(scope="module")
+def dask_client():
+    cluster = LocalCluster(n_workers=2, threads_per_worker=2)
+    client = Client(cluster)
+    yield client
+    # teardown
+    client.close()
+    cluster.close()
+
+
+test_data = [
+    (np.array([[584, -11, 23, 79, 1001, 0, -19]], dtype=np.float64), 3),
+    (np.random.uniform(-1000, 1000, [3, 10]).astype(np.float64), 5),
+]
+
+substitution_locations = [slice(0, 0), 0, -1, slice(1, 3), [0, 3]]
+
+
+@pytest.mark.filterwarnings("ignore:\\s+Port 8787 is already in use:UserWarning")
+@pytest.mark.parametrize("T, m", test_data)
+@pytest.mark.parametrize("substitution_location", substitution_locations)
+def test_mstumped_one_subsequence_nan_self_join_first_dimension(
+    T, m, substitution_location, dask_client
+):
+    excl_zone = int(np.ceil(m / 4))
+
+    T_sub = T.copy()
+    T_sub[0, substitution_location] = np.nan
+
+    left_P, left_I = utils.naive_mstump(T_sub, m, excl_zone)
+    right_P, right_I = mstumped(dask_client, T_sub, m)
+
+    npt.assert_almost_equal(left_P, right_P)
+    npt.assert_almost_equal(left_I, right_I)
+
+
+@pytest.mark.filterwarnings("ignore:\\s+Port 8787 is already in use:UserWarning")
+@pytest.mark.parametrize("T, m", test_data)
+@pytest.mark.parametrize("substitution_location", substitution_locations)
+def test_mstumped_one_subsequence_nan_self_join_all_dimensions(
+    T, m, substitution_location, dask_client
+):
+    excl_zone = int(np.ceil(m / 4))
+
+    T_sub = T.copy()
+    T_sub[:, substitution_location] = np.nan
+
+    left_P, left_I = utils.naive_mstump(T_sub, m, excl_zone)
+    right_P, right_I = mstumped(dask_client, T_sub, m)
+
+    npt.assert_almost_equal(left_P, right_P)
+    npt.assert_almost_equal(left_I, right_I)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,6 +11,7 @@ def z_norm(a, axis=0, threshold=1e-7):
 
 def naive_mass(Q, T, m, trivial_idx=None, excl_zone=0, ignore_trivial=False):
     T = T.copy()
+    Q = Q.copy()
 
     T[np.isinf(T)] = np.nan
     Q[np.isinf(Q)] = np.nan
@@ -63,6 +64,12 @@ def replace_inf(x, value=0):
 
 
 def naive_multi_mass(Q, T, m):
+    T = T.copy()
+    Q = Q.copy()
+
+    T[np.isinf(T)] = np.nan
+    Q[np.isinf(Q)] = np.nan
+
     d, n = T.shape
 
     D = np.empty((d, n - m + 1))
@@ -70,6 +77,7 @@ def naive_multi_mass(Q, T, m):
         D[i] = np.linalg.norm(
             z_norm(core.rolling_window(T[i], m), 1) - z_norm(Q[i]), axis=1
         )
+    D[np.isnan(D)] = np.inf
 
     D = np.sort(D, axis=0)
 


### PR DESCRIPTION
This PR fixes the handling of nans in mstump and mstumped (issues #117  and #130 ). It also contains a bit of refactoring in order to clean the code (issue #135 )

The refactoring was done to improve readability and to have the internals more or less identical to `stump`.