### PR TITLE
[Work in Progress] Fix #143 mstump sort

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ docs/_build
 *DS_Store*
 .venv
 .mypy_cache
+.directory

--- a/stumpy/mstumped.py
+++ b/stumpy/mstumped.py
@@ -133,7 +133,6 @@ def mstumped(dask_client, T, m):
                 σ_Q_future,
                 k,
                 start + 1,
-                1,
             )
         )
 

--- a/stumpy/mstumped.py
+++ b/stumpy/mstumped.py
@@ -133,6 +133,7 @@ def mstumped(dask_client, T, m):
                 σ_Q_future,
                 k,
                 start + 1,
+                1,
             )
         )
 


### PR DESCRIPTION
So this here is a first draft for improving performance in `mstump` using parallel numpy sorting instead of numba. `mstumped` uses single core numpy sorting, but we should look for ways to use multiprocessing.

I did a really small benchmark to get a feeling (times always excluding compilation): 

```
>>> T = numpy.random.uniform(size=(5, 10000))
>>> m = 10

>>> stumpy.stump(T[0], m)
around 1.5s
>>> stumpy.mstump(T, m) # As in this PR
around 18s
>>> stumpy.mstump(T, m) # Sorting using single core, default numpy
around 12s
>>> stumpy.mstump(T, m) # stumpy v1.3.1
around 72s
```

```
>>> T = numpy.random.uniform(size=(5, 50000))
>>> m = 10

>>> stumpy.stump(T[0], m)
around 10s
>>> stumpy.mstump(T, m) # As in this PR, 8 Cores
around 212s
>>> stumpy.mstump(T, m) # Sorting using single core, default numpy
around 268s
```

```
>>> T = numpy.random.uniform(size=(15, 10000))
>>> m = 10

>>> stumpy.mstump(T, m) # As in this PR, 8 Cores
around 37s
>>> stumpy.mstump(T, m) # Sorting using single core, default numpy
around 45s
```

We can see that for small time series the single core variant outperforms the multi core one because of overhead, but this changes for larger `n`. Yet, using eight cores compared to one does not make amazing improvements. Still, it is way faster than the current implementation. `mstump` runtime should be `O(d log d n²)` according to the paper, but the jump from `stump` to `mstump` seams still really high.

I'm not sure if there are other improvements that can be made. I feel like it should be able to mitigate some overhead, because in this PR we have a numba function that spawns different processes (`_compute_multi_D`), than `Pool.map` spawning different processes, and then again a parallel numba function (`_compute_PI`)