### PR TITLE
Added preprocess function

### DIFF
--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -697,8 +697,8 @@ def apply_exclusion_zone(D, idx, excl_zone):
     """
 
     zone_start = max(0, idx - excl_zone)
-    zone_stop = min(D.shape[0], idx + excl_zone)
-    D[zone_start : zone_stop + 1] = np.inf
+    zone_stop = min(D.shape[-1], idx + excl_zone)
+    D[..., zone_start : zone_stop + 1] = np.inf
 
 
 def preprocess(T, m):

--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -663,15 +663,79 @@ def mass(Q, T, M_T=None, Σ_T=None):
     if np.any(np.isnan(Q)):
         distance_profile[:] = np.inf
     else:
+        if M_T is None or Σ_T is None:
+            T, M_T, Σ_T = preprocess(T, m)
+
         QT = sliding_dot_product(Q, T)
         μ_Q, σ_Q = compute_mean_std(Q, m)
         μ_Q = μ_Q[0]
         σ_Q = σ_Q[0]
-        if M_T is None or Σ_T is None:
-            M_T, Σ_T = compute_mean_std(T, m)
         distance_profile[:] = _mass(Q, T, QT, μ_Q, σ_Q, M_T, Σ_T)
 
     return distance_profile
+
+
+@njit(fastmath=True)
+def apply_exclusion_zone(D, idx, excl_zone):
+    """
+    Apply an exclusion zone to an array (inplace), i.e. set all values
+    to np.inf in a window around a given index.
+
+    All values in D in [idx - excl_zone, idx + excl_zone] (endpoints included)
+    will be set to np.inf.
+
+    Parameters
+    ----------
+    D : ndarray
+        The array you want to apply the exclusion zone to
+
+    idx : int
+        The index around which the window should be centered
+
+    excl_zone : int
+        Size of the exclusion zone.
+    """
+
+    zone_start = max(0, idx - excl_zone)
+    zone_stop = min(D.shape[0], idx + excl_zone)
+    D[zone_start : zone_stop + 1] = np.inf
+
+
+def preprocess(T, m):
+    """
+    Creates a copy of the time series where all NaN and inf values
+    are replaced with zero. Also computes mean and standard deviation
+    for every subsequence. Every subsequence that contains at least
+    one NaN or inf value, will have a mean of np.inf. For the standard
+    deviation these values are ignored. If all values are illegal, the
+    standard deviation will be 0 (see `core.compute_mean_std`)
+
+    Parameters
+    ----------
+    T : ndarray
+        Time series or sequence
+
+    m : int
+        Window size
+
+    Returns
+    -------
+    T : ndarray
+        Modified time series
+    M_T : ndarray
+        Rolling mean
+    Σ_T : ndarray
+        Rolling standard deviation
+    """
+
+    T = T.copy()
+    T = np.asarray(T)
+
+    T[np.isinf(T)] = np.nan
+    M_T, Σ_T = compute_mean_std(T, m)
+    T[np.isnan(T)] = 0
+
+    return T, M_T, Σ_T
 
 
 def array_to_temp_file(a):

--- a/stumpy/mstump.py
+++ b/stumpy/mstump.py
@@ -157,9 +157,7 @@ def _get_first_mstump_profile(
         include,
     )
 
-    zone_start = max(0, start - excl_zone)
-    zone_stop = min(n - m + 1, start + excl_zone)
-    D[:, zone_start : zone_stop + 1] = np.inf
+    core.apply_exclusion_zone(D, start, excl_zone)
 
     P = np.full(d, np.inf, dtype="float64")
     I = np.ones(d, dtype="int64") * -1
@@ -251,9 +249,7 @@ def _compute_multi_D(
                 m, QT_odd[i], μ_Q[i, idx], σ_Q[i, idx], M_T[i], Σ_T[i]
             )
 
-    zone_start = max(0, idx - excl_zone)
-    zone_stop = min(k, idx + excl_zone)
-    D[:, zone_start : zone_stop + 1] = np.inf
+    core.apply_exclusion_zone(D, idx, excl_zone)
 
 
 @njit(parallel=True, fastmath=True)

--- a/stumpy/mstumped.py
+++ b/stumpy/mstumped.py
@@ -66,16 +66,18 @@ def mstumped(dask_client, T, m, include=None):
     See mSTAMP Algorithm
     """
 
-    T_A = np.asarray(core.transpose_dataframe(T)).copy()
-    T_B = T_A.copy()
+    T_A = core.transpose_dataframe(T)
+    T_B = T_A
 
-    T_A[np.isinf(T_A)] = np.nan
-    T_B[np.isinf(T_B)] = np.nan
+    T_A, M_T, Σ_T = core.preprocess(T_A, m)
+    T_B, μ_Q, σ_Q = core.preprocess(T_B, m)
 
-    core.check_dtype(T_A)
     if T_A.ndim <= 1:  # pragma: no cover
         err = f"T is {T_A.ndim}-dimensional and must be at least 1-dimensional"
         raise ValueError(f"{err}")
+
+    core.check_dtype(T_A)
+    core.check_dtype(T_B)
 
     core.check_window_size(m)
 
@@ -86,14 +88,9 @@ def mstumped(dask_client, T, m, include=None):
             logger.warning("Removed repeating indices in `include`")
             include = include[np.sort(idx)]
 
-    d, n = T_A.shape
+    d, n = T_B.shape
     k = n - m + 1
     excl_zone = int(np.ceil(m / 4))  # See Definition 3 and Figure 3
-
-    M_T, Σ_T = core.compute_mean_std(T_A, m)
-    μ_Q, σ_Q = core.compute_mean_std(T_B, m)
-
-    T_A[np.isnan(T_A)] = 0
 
     P = np.empty((d, k), dtype="float64")
     I = np.empty((d, k), dtype="int64")
@@ -105,10 +102,8 @@ def mstumped(dask_client, T, m, include=None):
 
     for i, start in enumerate(range(0, k, step)):
         P[:, start], I[:, start] = _get_first_mstump_profile(
-            start, T_A, T_B, m, excl_zone, M_T, Σ_T, include
+            start, T_A, T_B, m, excl_zone, M_T, Σ_T, μ_Q, σ_Q, include
         )
-
-    T_B[np.isnan(T_B)] = 0
 
     # Scatter data to Dask cluster
     T_A_future = dask_client.scatter(T_A, broadcast=True)

--- a/stumpy/stamp.py
+++ b/stumpy/stamp.py
@@ -51,9 +51,7 @@ def mass(Q, T, M_T, Σ_T, trivial_idx=None, excl_zone=0, left=False, right=False
     D = core.mass(Q, T, M_T, Σ_T)
 
     if trivial_idx is not None:
-        zone_start = max(0, trivial_idx - excl_zone)
-        zone_stop = min(T.shape[0] - Q.shape[0] + 1, trivial_idx + excl_zone)
-        D[zone_start : zone_stop + 1] = np.inf
+        core.apply_exclusion_zone(D, trivial_idx, excl_zone)
 
         # Get left and right matrix profiles
         IL = -1
@@ -61,7 +59,7 @@ def mass(Q, T, M_T, Σ_T, trivial_idx=None, excl_zone=0, left=False, right=False
         if D[:trivial_idx].size:
             IL = np.argmin(D[:trivial_idx])
             PL = D[IL]
-        if PL == np.inf or zone_start <= IL < zone_stop:
+        if PL == np.inf:
             IL = -1
 
         IR = -1
@@ -69,7 +67,7 @@ def mass(Q, T, M_T, Σ_T, trivial_idx=None, excl_zone=0, left=False, right=False
         if D[trivial_idx + 1 :].size:
             IR = trivial_idx + 1 + np.argmin(D[trivial_idx + 1 :])
             PR = D[IR]
-        if PR == np.inf or zone_start <= IR < zone_stop:
+        if PR == np.inf:
             IR = -1
 
     # Element-wise Min
@@ -130,25 +128,22 @@ def stamp(T_A, T_B, m, ignore_trivial=False):
     T_B.shape[0]-m+1
     """
 
+    T_A, M_T, Σ_T = core.preprocess(T_A, m)
+    T_B = T_B.copy()
+    T_B[np.isinf(T_B)] = np.nan
+
     if T_A.ndim != 1:  # pragma: no cover
         raise ValueError(f"T_A is {T_A.ndim}-dimensional and must be 1-dimensional. ")
 
-    T_A = T_A.copy()
-    T_A[np.isinf(T_A)] = np.nan
-    core.check_dtype(T_A)
-
-    T_B = T_B.copy()
-    T_B[np.isinf(T_B)] = np.nan
     if T_B.ndim != 1:  # pragma: no cover
         raise ValueError(f"T_B is {T_B.ndim}-dimensional and must be 1-dimensional. ")
+
+    core.check_dtype(T_A)
     core.check_dtype(T_B)
 
     core.check_window_size(m)
     subseq_T_B = core.rolling_window(T_B, m)
     excl_zone = int(np.ceil(m / 2))
-    M_T, Σ_T = core.compute_mean_std(T_A, m)
-
-    T_A[np.isnan(T_A)] = 0
 
     # Add exclusionary zone
     if ignore_trivial:

--- a/stumpy/stomp.py
+++ b/stumpy/stomp.py
@@ -73,24 +73,22 @@ def _stomp(T_A, m, T_B=None, ignore_trivial=True):
         "Please use the Numba JIT-compiled stumpy.stump or stumpy.gpu_stump instead."
     )
 
-    T_A = np.asarray(T_A)
-    if T_A.ndim != 1:  # pragma: no cover
-        raise ValueError(f"T_A is {T_A.ndim}-dimensional and must be 1-dimensional. ")
-    n = T_A.shape[0]
-
-    T_A = T_A.copy()
-    T_A[np.isinf(T_A)] = np.nan
-    core.check_dtype(T_A)
-
     if T_B is None:
         T_B = T_A
         ignore_trivial = True
 
-    T_B = np.asarray(T_B)
-    T_B = T_B.copy()
+    T_A, M_T, Σ_T = core.preprocess(T_A, m)
+    T_B, μ_Q, σ_Q = core.preprocess(T_B, m)
+
+    if T_A.ndim != 1:  # pragma: no cover
+        raise ValueError(f"T_A is {T_A.ndim}-dimensional and must be 1-dimensional. ")
+
+    n = T_A.shape[0]
+
     if T_B.ndim != 1:  # pragma: no cover
         raise ValueError(f"T_B is {T_B.ndim}-dimensional and must be 1-dimensional. ")
-    T_B[np.isinf(T_B)] = np.nan
+
+    core.check_dtype(T_A)
     core.check_dtype(T_B)
 
     core.check_window_size(m)
@@ -107,23 +105,22 @@ def _stomp(T_A, m, T_B=None, ignore_trivial=True):
     l = n - m + 1
     excl_zone = int(np.ceil(m / 4))  # See Definition 3 and Figure 3
 
-    M_T, Σ_T = core.compute_mean_std(T_A, m)
-    μ_Q, σ_Q = core.compute_mean_std(T_B, m)
-
-    T_A[np.isnan(T_A)] = 0
-
     out = np.empty((l, 4), dtype=object)
 
     # Handle first subsequence, add exclusionary zone
-    if ignore_trivial:
-        P, I = stamp.mass(T_B[:m], T_A, M_T, Σ_T, 0, excl_zone)
-        PR, IR = stamp.mass(T_B[:m], T_A, M_T, Σ_T, 0, excl_zone, right=True)
+    if not np.isinf(μ_Q[0]):
+        if ignore_trivial:
+            P, I = stamp.mass(T_B[:m], T_A, M_T, Σ_T, 0, excl_zone)
+            PR, IR = stamp.mass(T_B[:m], T_A, M_T, Σ_T, 0, excl_zone, right=True)
+        else:
+            P, I = stamp.mass(T_B[:m], T_A, M_T, Σ_T)
+            IR = -1  # No left and right matrix profile available
     else:
-        P, I = stamp.mass(T_B[:m], T_A, M_T, Σ_T)
-        IR = -1  # No left and right matrix profile available
-    out[0] = P, I, -1, IR
+        P = np.inf
+        I = -1
+        IR = -1
 
-    T_B[np.isnan(T_B)] = 0
+    out[0] = P, I, -1, IR
 
     QT = core.sliding_dot_product(T_B[:m], T_A)
     QT_first = core.sliding_dot_product(T_A[:m], T_B)
@@ -139,9 +136,7 @@ def _stomp(T_A, m, T_B=None, ignore_trivial=True):
             m, QT, μ_Q[i].item(0), σ_Q[i].item(0), M_T, Σ_T
         )
         if ignore_trivial:
-            zone_start = max(0, i - excl_zone)
-            zone_stop = min(k, i + excl_zone)
-            D[zone_start : zone_stop + 1] = np.inf
+            core.apply_exclusion_zone(D, i, excl_zone)
 
         I = np.argmin(D)
         P = np.sqrt(D[I])
@@ -154,7 +149,7 @@ def _stomp(T_A, m, T_B=None, ignore_trivial=True):
         if ignore_trivial and i > 0:
             IL = np.argmin(D[:i])
             PL = D[IL]
-        if PL == np.inf or zone_start <= IL < zone_stop:
+        if PL == np.inf:
             IL = -1
 
         IR = -1
@@ -162,7 +157,7 @@ def _stomp(T_A, m, T_B=None, ignore_trivial=True):
         if ignore_trivial and i + 1 < D.shape[0]:
             IR = i + 1 + np.argmin(D[i + 1 :])
             PR = D[IR]
-        if PR == np.inf or zone_start <= IR < zone_stop:
+        if PR == np.inf:
             IR = -1
 
         out[i] = P, I, IL, IR

--- a/stumpy/stomp.py
+++ b/stumpy/stomp.py
@@ -83,8 +83,6 @@ def _stomp(T_A, m, T_B=None, ignore_trivial=True):
     if T_A.ndim != 1:  # pragma: no cover
         raise ValueError(f"T_A is {T_A.ndim}-dimensional and must be 1-dimensional. ")
 
-    n = T_A.shape[0]
-
     if T_B.ndim != 1:  # pragma: no cover
         raise ValueError(f"T_B is {T_B.ndim}-dimensional and must be 1-dimensional. ")
 
@@ -108,17 +106,17 @@ def _stomp(T_A, m, T_B=None, ignore_trivial=True):
     out = np.empty((l, 4), dtype=object)
 
     # Handle first subsequence, add exclusionary zone
-    if not np.isinf(μ_Q[0]):
+    if np.isinf(μ_Q[0]):
+        P = np.inf
+        I = -1
+        IR = -1
+    else:
         if ignore_trivial:
             P, I = stamp.mass(T_B[:m], T_A, M_T, Σ_T, 0, excl_zone)
             PR, IR = stamp.mass(T_B[:m], T_A, M_T, Σ_T, 0, excl_zone, right=True)
         else:
             P, I = stamp.mass(T_B[:m], T_A, M_T, Σ_T)
             IR = -1  # No left and right matrix profile available
-    else:
-        P = np.inf
-        I = -1
-        IR = -1
 
     out[0] = P, I, -1, IR
 

--- a/stumpy/stump.py
+++ b/stumpy/stump.py
@@ -12,7 +12,9 @@ from . import core, stamp
 logger = logging.getLogger(__name__)
 
 
-def _get_first_stump_profile(start, T_A, T_B, m, excl_zone, M_T, Σ_T, ignore_trivial):
+def _get_first_stump_profile(
+    start, T_A, T_B, m, excl_zone, M_T, Σ_T, μ_Q, σ_Q, ignore_trivial
+):
     """
     Compute the matrix profile, matrix profile index, left matrix profile
     index, and right matrix profile index for given window within the times
@@ -44,6 +46,12 @@ def _get_first_stump_profile(start, T_A, T_B, m, excl_zone, M_T, Σ_T, ignore_tr
     Σ_T : ndarray
         Sliding standard deviation for `T_A`
 
+    μ_Q : ndarray
+        Sliding mean for `T_B`
+
+    σ_Q : ndarray
+        Sliding standard deviation for `T_B`
+
     ignore_trivial : bool
         `True` if this is a self join and `False` otherwise (i.e., AB-join).
 
@@ -63,19 +71,29 @@ def _get_first_stump_profile(start, T_A, T_B, m, excl_zone, M_T, Σ_T, ignore_tr
     """
 
     # Handle first subsequence, add exclusionary zone
-    if ignore_trivial:
-        P, I = stamp.mass(T_B[start : start + m], T_A, M_T, Σ_T, start, excl_zone)
-        PL, IL = stamp.mass(
-            T_B[start : start + m], T_A, M_T, Σ_T, start, excl_zone, left=True
-        )
-        PR, IR = stamp.mass(
-            T_B[start : start + m], T_A, M_T, Σ_T, start, excl_zone, right=True
-        )
+
+    if not np.isinf(μ_Q[start]):
+        if ignore_trivial:
+            P, I = stamp.mass(T_B[start : start + m], T_A, M_T, Σ_T, start, excl_zone)
+            PL, IL = stamp.mass(
+                T_B[start : start + m], T_A, M_T, Σ_T, start, excl_zone, left=True
+            )
+            PR, IR = stamp.mass(
+                T_B[start : start + m], T_A, M_T, Σ_T, start, excl_zone, right=True
+            )
+        else:
+            P, I = stamp.mass(T_B[start : start + m], T_A, M_T, Σ_T)
+            # No left and right matrix profile available
+            PL = np.inf
+            PR = np.inf
+            IL = -1
+            IR = -1
     else:
-        P, I = stamp.mass(T_B[start : start + m], T_A, M_T, Σ_T)
-        # No left and right matrix profile available
+        P = np.inf
         PL = np.inf
         PR = np.inf
+
+        I = -1
         IL = -1
         IR = -1
 
@@ -270,9 +288,7 @@ def _stump(
             )
 
         if ignore_trivial:
-            zone_start = max(0, i - excl_zone)
-            zone_stop = min(k, i + excl_zone)
-            D[zone_start : zone_stop + 1] = np.inf
+            core.apply_exclusion_zone(D, i, excl_zone)
 
         I = np.argmin(D)
         P = np.sqrt(D[I])
@@ -285,7 +301,7 @@ def _stump(
         if ignore_trivial and i > 0:
             IL = np.argmin(D[:i])
             PL = D[IL]
-        if PL == np.inf or zone_start <= IL < zone_stop:
+        if PL == np.inf:
             IL = -1
 
         IR = -1
@@ -293,7 +309,7 @@ def _stump(
         if ignore_trivial and i + 1 < D.shape[0]:
             IR = i + 1 + np.argmin(D[i + 1 :])
             PR = D[IR]
-        if PR == np.inf or zone_start <= IR < zone_stop:
+        if PR == np.inf:
             IR = -1
 
         # Only a part of the profile/indices array are passed
@@ -364,29 +380,26 @@ def stump(T_A, m, T_B=None, ignore_trivial=True):
     Note that left and right matrix profiles are only available for self-joins.
     """
 
-    T_A = np.asarray(T_A)
+    if T_B is None:
+        T_B = T_A
+        ignore_trivial = True
+
+    T_A, M_T, Σ_T = core.preprocess(T_A, m)
+    T_B, μ_Q, σ_Q = core.preprocess(T_B, m)
+
     if T_A.ndim != 1:  # pragma: no cover
         raise ValueError(
             f"T_A is {T_A.ndim}-dimensional and must be 1-dimensional. "
             "For multidimensional STUMP use `stumpy.mstump` or `stumpy.mstumped`"
         )
 
-    T_A = T_A.copy()
-    T_A[np.isinf(T_A)] = np.nan
-    core.check_dtype(T_A)
-
-    if T_B is None:
-        T_B = T_A
-        ignore_trivial = True
-
-    T_B = np.asarray(T_B)
-    T_B = T_B.copy()
     if T_B.ndim != 1:  # pragma: no cover
         raise ValueError(
             f"T_B is {T_B.ndim}-dimensional and must be 1-dimensional. "
             "For multidimensional STUMP use `stumpy.mstump` or `stumpy.mstumped`"
         )
-    T_B[np.isinf(T_B)] = np.nan
+
+    core.check_dtype(T_A)
     core.check_dtype(T_B)
 
     core.check_window_size(m)
@@ -404,11 +417,6 @@ def stump(T_A, m, T_B=None, ignore_trivial=True):
     l = n - m + 1
     excl_zone = int(np.ceil(m / 4))  # See Definition 3 and Figure 3
 
-    M_T, Σ_T = core.compute_mean_std(T_A, m)
-    μ_Q, σ_Q = core.compute_mean_std(T_B, m)
-
-    T_A[np.isnan(T_A)] = 0
-
     out = np.empty((l, 4), dtype=object)
     profile = np.empty((l,), dtype="float64")
     indices = np.empty((l, 3), dtype="int64")
@@ -417,13 +425,9 @@ def stump(T_A, m, T_B=None, ignore_trivial=True):
     stop = l
 
     all_start_profiles, indices[start, :] = _get_first_stump_profile(
-        start, T_A, T_B, m, excl_zone, M_T, Σ_T, ignore_trivial
+        start, T_A, T_B, m, excl_zone, M_T, Σ_T, μ_Q, σ_Q, ignore_trivial
     )
     profile[start] = all_start_profiles[0]
-
-    T_B[
-        np.isnan(T_B)
-    ] = 0  # Remove all nan values from T_B only after first profile is calculated
 
     QT, QT_first = _get_QT(start, T_A, T_B, m)
 

--- a/stumpy/stump.py
+++ b/stumpy/stump.py
@@ -72,7 +72,15 @@ def _get_first_stump_profile(
 
     # Handle first subsequence, add exclusionary zone
 
-    if not np.isinf(μ_Q[start]):
+    if np.isinf(μ_Q[start]):
+        P = np.inf
+        PL = np.inf
+        PR = np.inf
+
+        I = -1
+        IL = -1
+        IR = -1
+    else:
         if ignore_trivial:
             P, I = stamp.mass(T_B[start : start + m], T_A, M_T, Σ_T, start, excl_zone)
             PL, IL = stamp.mass(
@@ -88,14 +96,6 @@ def _get_first_stump_profile(
             PR = np.inf
             IL = -1
             IR = -1
-    else:
-        P = np.inf
-        PL = np.inf
-        PR = np.inf
-
-        I = -1
-        IL = -1
-        IR = -1
 
     return (P, PL, PR), (I, IL, IR)
 

--- a/stumpy/stumped.py
+++ b/stumpy/stumped.py
@@ -83,30 +83,26 @@ def stumped(dask_client, T_A, m, T_B=None, ignore_trivial=True):
     Note that left and right matrix profiles are only available for self-joins.
     """
 
-    T_A = np.asarray(T_A)
+    if T_B is None:
+        T_B = T_A
+        ignore_trivial = True
+
+    T_A, M_T, Σ_T = core.preprocess(T_A, m)
+    T_B, μ_Q, σ_Q = core.preprocess(T_B, m)
+
     if T_A.ndim != 1:  # pragma: no cover
         raise ValueError(
             f"T_A is {T_A.ndim}-dimensional and must be 1-dimensional. "
             "For multidimensional STUMP use `stumpy.mstump` or `stumpy.mstumped`"
         )
-    n = T_A.shape[0]
 
-    T_A = T_A.copy()
-    T_A[np.isinf(T_A)] = np.nan
-    core.check_dtype(T_A)
-
-    if T_B is None:
-        T_B = T_A
-        ignore_trivial = True
-
-    T_B = np.asarray(T_B)
     if T_B.ndim != 1:  # pragma: no cover
         raise ValueError(
             f"T_B is {T_B.ndim}-dimensional and must be 1-dimensional. "
             "For multidimensional STUMP use `stumpy.mstump` or `stumpy.mstumped`"
         )
-    T_B = T_B.copy()
-    T_B[np.isinf(T_B)] = np.nan
+
+    core.check_dtype(T_A)
     core.check_dtype(T_B)
 
     core.check_window_size(m)
@@ -124,11 +120,6 @@ def stumped(dask_client, T_A, m, T_B=None, ignore_trivial=True):
     l = n - m + 1
     excl_zone = int(np.ceil(m / 4))  # See Definition 3 and Figure 3
 
-    M_T, Σ_T = core.compute_mean_std(T_A, m)
-    μ_Q, σ_Q = core.compute_mean_std(T_B, m)
-
-    T_A[np.isnan(T_A)] = 0
-
     out = np.empty((l, 4), dtype=object)
     profile = np.empty((l,), dtype="float64")
     indices = np.empty((l, 3), dtype="int64")
@@ -141,11 +132,9 @@ def stumped(dask_client, T_A, m, T_B=None, ignore_trivial=True):
     QT_first_futures = []
     for i, start in enumerate(range(0, l, step)):
         all_start_profiles, indices[start, :] = _get_first_stump_profile(
-            start, T_A, T_B, m, excl_zone, M_T, Σ_T, ignore_trivial
+            start, T_A, T_B, m, excl_zone, M_T, Σ_T, μ_Q, σ_Q, ignore_trivial
         )
         profile[start] = all_start_profiles[0]
-
-    T_B[np.isnan(T_B)] = 0
 
     # Scatter data to Dask cluster
     T_A_future = dask_client.scatter(T_A, broadcast=True)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,6 @@
 import numpy as np
 import numpy.testing as npt
+import pandas as pd
 from stumpy import core
 import pytest
 import os
@@ -32,20 +33,18 @@ def test_check_window_size():
 def naive_compute_mean_std(T, m):
     n = T.shape[0]
 
-    cumsum_T = np.empty(len(T) + 1)
-    np.cumsum(T, out=cumsum_T[1:])  # store output in cumsum_T[1:]
-    cumsum_T[0] = 0
+    M_T = np.zeros(n - m + 1, dtype=float)
+    Σ_T = np.zeros(n - m + 1, dtype=float)
 
-    cumsum_T_squared = np.empty(len(T) + 1)
-    np.cumsum(np.square(T), out=cumsum_T_squared[1:])
-    cumsum_T_squared[0] = 0
+    for i in range(n - m + 1):
+        Q = T[i : i + m].copy()
+        Q[np.isinf(Q)] = np.nan
 
-    subseq_sum_T = cumsum_T[m:] - cumsum_T[: n - m + 1]
-    subseq_sum_T_squared = cumsum_T_squared[m:] - cumsum_T_squared[: n - m + 1]
-    M_T = subseq_sum_T / m
-    Σ_T = np.abs((subseq_sum_T_squared / m) - np.square(M_T))
-    Σ_T = np.sqrt(Σ_T)
+        M_T[i] = np.mean(Q)
+        Σ_T[i] = np.nanstd(Q)
 
+    M_T[np.isnan(M_T)] = np.inf
+    Σ_T[np.isnan(Σ_T)] = 0
     return M_T, Σ_T
 
 
@@ -169,6 +168,87 @@ def test_mass(Q, T):
     )
     right = core.mass(Q, T)
     npt.assert_almost_equal(left, right)
+
+
+@pytest.mark.parametrize("Q, T", test_data)
+def test_mass_nan(Q, T):
+    T[1] = np.nan
+    m = Q.shape[0]
+
+    left = np.linalg.norm(
+        core.z_norm(core.rolling_window(T, m), 1) - core.z_norm(Q), axis=1
+    )
+    left[np.isnan(left)] = np.inf
+
+    right = core.mass(Q, T)
+    npt.assert_almost_equal(left, right)
+
+
+@pytest.mark.parametrize("Q, T", test_data)
+def test_mass_inf(Q, T):
+    T[1] = np.inf
+    m = Q.shape[0]
+
+    left = np.linalg.norm(
+        core.z_norm(core.rolling_window(T, m), 1) - core.z_norm(Q), axis=1
+    )
+    left[np.isnan(left)] = np.inf
+
+    right = core.mass(Q, T)
+    npt.assert_almost_equal(left, right)
+
+
+def test_apply_exclusion_zone():
+    T = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=float)
+    exclusion_zone = 2
+
+    index = 1
+    left = np.array([np.inf, np.inf, np.inf, np.inf, 4, 5, 6, 7, 8, 9])
+    right = T.copy()
+    core.apply_exclusion_zone(right, index, exclusion_zone)
+
+    utils.replace_inf(left)
+    utils.replace_inf(right)
+    npt.assert_array_equal(left, right)
+
+    index = 8
+    left = np.array([0, 1, 2, 3, 4, 5, np.inf, np.inf, np.inf, np.inf])
+    right = T.copy()
+    core.apply_exclusion_zone(right, index, exclusion_zone)
+
+    utils.replace_inf(left)
+    utils.replace_inf(right)
+    npt.assert_array_equal(left, right)
+
+    index = 4
+    left = np.array([0, 1, np.inf, np.inf, np.inf, np.inf, np.inf, 7, 8, 9])
+    right = T.copy()
+    core.apply_exclusion_zone(right, index, exclusion_zone)
+
+    utils.replace_inf(left)
+    utils.replace_inf(right)
+    npt.assert_array_equal(left, right)
+
+
+def test_preprocess():
+    T = np.array([0, np.nan, 2, 3, 4, 5, 6, 7, np.inf, 9])
+    m = 3
+
+    left_T = np.array([0, 0, 2, 3, 4, 5, 6, 7, 0, 9], dtype=float)
+    left_M, left_Σ = naive_compute_mean_std(T, m)
+
+    right_T, right_M, right_Σ = core.preprocess(T, m)
+
+    npt.assert_almost_equal(left_T, right_T)
+    npt.assert_almost_equal(left_M, right_M)
+    npt.assert_almost_equal(left_Σ, right_Σ)
+
+    T = pd.Series(T)
+    right_T, right_M, right_Σ = core.preprocess(T, m)
+
+    npt.assert_almost_equal(left_T, right_T)
+    npt.assert_almost_equal(left_M, right_M)
+    npt.assert_almost_equal(left_Σ, right_Σ)
 
 
 def test_array_to_temp_file():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -230,6 +230,55 @@ def test_apply_exclusion_zone():
     npt.assert_array_equal(left, right)
 
 
+def test_apply_exclusion_zone_multidimensional():
+    T = np.array(
+        [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]], dtype=float
+    )
+    exclusion_zone = 2
+
+    index = 1
+    left = np.array(
+        [
+            [np.inf, np.inf, np.inf, np.inf, 4, 5, 6, 7, 8, 9],
+            [np.inf, np.inf, np.inf, np.inf, 4, 5, 6, 7, 8, 9],
+        ]
+    )
+    right = T.copy()
+    core.apply_exclusion_zone(right, index, exclusion_zone)
+
+    utils.replace_inf(left)
+    utils.replace_inf(right)
+    npt.assert_array_equal(left, right)
+
+    index = 8
+    left = np.array(
+        [
+            [0, 1, 2, 3, 4, 5, np.inf, np.inf, np.inf, np.inf],
+            [0, 1, 2, 3, 4, 5, np.inf, np.inf, np.inf, np.inf],
+        ]
+    )
+    right = T.copy()
+    core.apply_exclusion_zone(right, index, exclusion_zone)
+
+    utils.replace_inf(left)
+    utils.replace_inf(right)
+    npt.assert_array_equal(left, right)
+
+    index = 4
+    left = np.array(
+        [
+            [0, 1, np.inf, np.inf, np.inf, np.inf, np.inf, 7, 8, 9],
+            [0, 1, np.inf, np.inf, np.inf, np.inf, np.inf, 7, 8, 9],
+        ]
+    )
+    right = T.copy()
+    core.apply_exclusion_zone(right, index, exclusion_zone)
+
+    utils.replace_inf(left)
+    utils.replace_inf(right)
+    npt.assert_array_equal(left, right)
+
+
 def test_preprocess():
     T = np.array([0, np.nan, 2, 3, 4, 5, 6, 7, np.inf, 9])
     m = 3

--- a/tests/test_mstump.py
+++ b/tests/test_mstump.py
@@ -40,7 +40,7 @@ def test_multi_mass(T, m):
     left = utils.naive_multi_mass(Q, T, m)
 
     M_T, Σ_T = core.compute_mean_std(T, m)
-    right = _multi_mass(Q, T, m, M_T, Σ_T)
+    right = _multi_mass(Q, T, m, M_T, Σ_T, M_T[:, trivial_idx], Σ_T[:, trivial_idx])
 
     npt.assert_almost_equal(left, right)
 
@@ -55,7 +55,9 @@ def test_get_first_mstump_profile(T, m):
     left_I = left_I[start, :]
 
     M_T, Σ_T = core.compute_mean_std(T, m)
-    right_P, right_I = _get_first_mstump_profile(start, T, T, m, excl_zone, M_T, Σ_T)
+    right_P, right_I = _get_first_mstump_profile(
+        start, T, T, m, excl_zone, M_T, Σ_T, M_T, Σ_T
+    )
 
     npt.assert_almost_equal(left_P, right_P)
     npt.assert_equal(left_I, right_I)


### PR DESCRIPTION
Following some discussions in issue #166 I created a preprocessing function (and an `apply_exclusion_zone` function) that is used by all (currently only 1D) algorithms. Furthermore, `core.mass` now supports time series with NaN/Inf.
