### PR TITLE
Change variable names in tests

### DIFF
--- a/tests/test_aamp.py
+++ b/tests/test_aamp.py
@@ -28,65 +28,65 @@ def test_aamp_int_input():
 @pytest.mark.parametrize("T_A, T_B", test_data)
 def test_aamp_self_join(T_A, T_B):
     m = 3
-    left = naive.aamp(T_B, m)
-    right = aamp(T_B, m)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left, right)
+    ref_mp = naive.aamp(T_B, m)
+    comp_mp = aamp(T_B, m)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp, comp_mp)
 
-    right = aamp(pd.Series(T_B), m)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left, right)
+    comp_mp = aamp(pd.Series(T_B), m)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
 def test_aamp_A_B_join(T_A, T_B):
     m = 3
-    left = naive.aamp(T_A, m, T_B=T_B)
-    right = aamp(T_A, m, T_B, ignore_trivial=False)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left, right)
+    ref_mp = naive.aamp(T_A, m, T_B=T_B)
+    comp_mp = aamp(T_A, m, T_B, ignore_trivial=False)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp, comp_mp)
 
-    right = aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left, right)
+    comp_mp = aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 def test_aamp_constant_subsequence_self_join():
     T_A = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64)))
     m = 3
-    left = naive.aamp(T_A, m)
-    right = aamp(T_A, m, ignore_trivial=True)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    ref_mp = naive.aamp(T_A, m)
+    comp_mp = aamp(T_A, m, ignore_trivial=True)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
-    right = aamp(pd.Series(T_A), m, ignore_trivial=True)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    comp_mp = aamp(pd.Series(T_A), m, ignore_trivial=True)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
 
 def test_aamp_one_constant_subsequence_A_B_join():
     T_A = np.random.rand(20)
     T_B = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64)))
     m = 3
-    left = naive.aamp(T_A, m, T_B=T_B)
-    right = aamp(T_A, m, T_B, ignore_trivial=False)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    ref_mp = naive.aamp(T_A, m, T_B=T_B)
+    comp_mp = aamp(T_A, m, T_B, ignore_trivial=False)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
-    right = aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    comp_mp = aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
     # Swap inputs
-    left = naive.aamp(T_B, m, T_B=T_A)
-    right = aamp(T_B, m, T_A, ignore_trivial=False)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    ref_mp = naive.aamp(T_B, m, T_B=T_A)
+    comp_mp = aamp(T_B, m, T_A, ignore_trivial=False)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
 
 def test_aamp_two_constant_subsequences_A_B_join():
@@ -95,26 +95,26 @@ def test_aamp_two_constant_subsequences_A_B_join():
     )
     T_B = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64)))
     m = 3
-    left = naive.aamp(T_A, m, T_B=T_B)
-    right = aamp(T_A, m, T_B, ignore_trivial=False)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    ref_mp = naive.aamp(T_A, m, T_B=T_B)
+    comp_mp = aamp(T_A, m, T_B, ignore_trivial=False)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
-    right = aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    comp_mp = aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
     # Swap inputs
-    left = naive.aamp(T_B, m, T_B=T_A)
-    right = aamp(T_B, m, T_A, ignore_trivial=False)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    ref_mp = naive.aamp(T_B, m, T_B=T_A)
+    comp_mp = aamp(T_B, m, T_A, ignore_trivial=False)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
-    right = aamp(pd.Series(T_B), m, pd.Series(T_A), ignore_trivial=False)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    comp_mp = aamp(pd.Series(T_B), m, pd.Series(T_A), ignore_trivial=False)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
 
 def test_aamp_identical_subsequence_self_join():
@@ -123,18 +123,18 @@ def test_aamp_identical_subsequence_self_join():
     T_A[1 : 1 + identical.shape[0]] = identical
     T_A[11 : 11 + identical.shape[0]] = identical
     m = 3
-    left = naive.aamp(T_A, m)
-    right = aamp(T_A, m, ignore_trivial=True)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
+    ref_mp = naive.aamp(T_A, m)
+    comp_mp = aamp(T_A, m, ignore_trivial=True)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
     npt.assert_almost_equal(
-        left[:, 0], right[:, 0], decimal=config.STUMPY_TEST_PRECISION
+        ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
     )  # ignore indices
 
-    right = aamp(pd.Series(T_A), m, ignore_trivial=True)
-    naive.replace_inf(right)
+    comp_mp = aamp(pd.Series(T_A), m, ignore_trivial=True)
+    naive.replace_inf(comp_mp)
     npt.assert_almost_equal(
-        left[:, 0], right[:, 0], decimal=config.STUMPY_TEST_PRECISION
+        ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
     )  # ignore indices
 
 
@@ -145,27 +145,27 @@ def test_aamp_identical_subsequence_A_B_join():
     T_A[1 : 1 + identical.shape[0]] = identical
     T_B[11 : 11 + identical.shape[0]] = identical
     m = 3
-    left = naive.aamp(T_A, m, T_B=T_B)
-    right = aamp(T_A, m, T_B, ignore_trivial=False)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
+    ref_mp = naive.aamp(T_A, m, T_B=T_B)
+    comp_mp = aamp(T_A, m, T_B, ignore_trivial=False)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
     npt.assert_almost_equal(
-        left[:, 0], right[:, 0], config.STUMPY_TEST_PRECISION
+        ref_mp[:, 0], comp_mp[:, 0], config.STUMPY_TEST_PRECISION
     )  # ignore indices
 
-    right = aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
-    naive.replace_inf(right)
+    comp_mp = aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
+    naive.replace_inf(comp_mp)
     npt.assert_almost_equal(
-        left[:, 0], right[:, 0], config.STUMPY_TEST_PRECISION
+        ref_mp[:, 0], comp_mp[:, 0], config.STUMPY_TEST_PRECISION
     )  # ignore indices
 
     # Swap inputs
-    left = naive.aamp(T_B, m, T_B=T_A)
-    right = aamp(T_B, m, T_A, ignore_trivial=False)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
+    ref_mp = naive.aamp(T_B, m, T_B=T_A)
+    comp_mp = aamp(T_B, m, T_A, ignore_trivial=False)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
     npt.assert_almost_equal(
-        left[:, 0], right[:, 0], config.STUMPY_TEST_PRECISION
+        ref_mp[:, 0], comp_mp[:, 0], config.STUMPY_TEST_PRECISION
     )  # ignore indices
 
 
@@ -182,15 +182,15 @@ def test_aamp_nan_inf_self_join(T_A, T_B, substitute_B, substitution_locations):
         T_B_sub[substitution_location_B] = substitute_B
 
         zone = int(np.ceil(m / 4))
-        left = naive.aamp(T_B_sub, m)
-        right = aamp(T_B_sub, m, ignore_trivial=True)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        ref_mp = naive.aamp(T_B_sub, m)
+        comp_mp = aamp(T_B_sub, m, ignore_trivial=True)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)
 
-        right = aamp(pd.Series(T_B_sub), m, ignore_trivial=True)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        comp_mp = aamp(pd.Series(T_B_sub), m, ignore_trivial=True)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -212,17 +212,17 @@ def test_aamp_nan_inf_A_B_join(
             T_A_sub[substitution_location_A] = substitute_A
             T_B_sub[substitution_location_B] = substitute_B
 
-            left = naive.aamp(T_A_sub, m, T_B=T_B_sub)
-            right = aamp(T_A_sub, m, T_B_sub, ignore_trivial=False)
-            naive.replace_inf(left)
-            naive.replace_inf(right)
-            npt.assert_almost_equal(left, right)
+            ref_mp = naive.aamp(T_A_sub, m, T_B=T_B_sub)
+            comp_mp = aamp(T_A_sub, m, T_B_sub, ignore_trivial=False)
+            naive.replace_inf(ref_mp)
+            naive.replace_inf(comp_mp)
+            npt.assert_almost_equal(ref_mp, comp_mp)
 
-            right = aamp(
+            comp_mp = aamp(
                 pd.Series(T_A_sub), m, pd.Series(T_B_sub), ignore_trivial=False
             )
-            naive.replace_inf(right)
-            npt.assert_almost_equal(left, right)
+            naive.replace_inf(comp_mp)
+            npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 def test_aamp_nan_zero_mean_self_join():
@@ -230,9 +230,9 @@ def test_aamp_nan_zero_mean_self_join():
     m = 3
 
     zone = int(np.ceil(m / 4))
-    left = naive.aamp(T, m)
-    right = aamp(T, m, ignore_trivial=True)
+    ref_mp = naive.aamp(T, m)
+    comp_mp = aamp(T, m, ignore_trivial=True)
 
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left, right)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp, comp_mp)

--- a/tests/test_aamped.py
+++ b/tests/test_aamped.py
@@ -43,11 +43,11 @@ def test_aamp_int_input(dask_cluster):
 def test_aamped_self_join(T_A, T_B, dask_cluster):
     with Client(dask_cluster) as dask_client:
         m = 3
-        left = naive.aamp(T_B, m)
-        right = aamped(dask_client, T_B, m)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        ref_mp = naive.aamp(T_B, m)
+        comp_mp = aamped(dask_client, T_B, m)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 @pytest.mark.filterwarnings("ignore:numpy.dtype size changed")
@@ -58,11 +58,11 @@ def test_aamped_self_join(T_A, T_B, dask_cluster):
 def test_aamped_self_join_df(T_A, T_B, dask_cluster):
     with Client(dask_cluster) as dask_client:
         m = 3
-        left = naive.aamp(T_B, m)
-        right = aamped(dask_client, pd.Series(T_B), m)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        ref_mp = naive.aamp(T_B, m)
+        comp_mp = aamped(dask_client, pd.Series(T_B), m)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 @pytest.mark.filterwarnings("ignore:numpy.dtype size changed")
@@ -74,12 +74,12 @@ def test_aamped_self_join_df(T_A, T_B, dask_cluster):
 def test_aamped_self_join_larger_window(T_A, T_B, m, dask_cluster):
     with Client(dask_cluster) as dask_client:
         if len(T_B) > m:
-            left = naive.aamp(T_B, m)
-            right = aamped(dask_client, T_B, m)
-            naive.replace_inf(left)
-            naive.replace_inf(right)
+            ref_mp = naive.aamp(T_B, m)
+            comp_mp = aamped(dask_client, T_B, m)
+            naive.replace_inf(ref_mp)
+            naive.replace_inf(comp_mp)
 
-            npt.assert_almost_equal(left, right)
+            npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 @pytest.mark.filterwarnings("ignore:numpy.dtype size changed")
@@ -91,12 +91,12 @@ def test_aamped_self_join_larger_window(T_A, T_B, m, dask_cluster):
 def test_aamped_self_join_larger_window_df(T_A, T_B, m, dask_cluster):
     with Client(dask_cluster) as dask_client:
         if len(T_B) > m:
-            left = naive.aamp(T_B, m)
-            right = aamped(dask_client, pd.Series(T_B), m)
-            naive.replace_inf(left)
-            naive.replace_inf(right)
+            ref_mp = naive.aamp(T_B, m)
+            comp_mp = aamped(dask_client, pd.Series(T_B), m)
+            naive.replace_inf(ref_mp)
+            naive.replace_inf(comp_mp)
 
-            npt.assert_almost_equal(left, right)
+            npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 @pytest.mark.filterwarnings("ignore:numpy.dtype size changed")
@@ -107,11 +107,11 @@ def test_aamped_self_join_larger_window_df(T_A, T_B, m, dask_cluster):
 def test_aamped_A_B_join(T_A, T_B, dask_cluster):
     with Client(dask_cluster) as dask_client:
         m = 3
-        left = naive.aamp(T_A, m, T_B=T_B)
-        right = aamped(dask_client, T_A, m, T_B, ignore_trivial=False)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        ref_mp = naive.aamp(T_A, m, T_B=T_B)
+        comp_mp = aamped(dask_client, T_A, m, T_B, ignore_trivial=False)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 @pytest.mark.filterwarnings("ignore:numpy.dtype size changed")
@@ -122,10 +122,10 @@ def test_aamped_A_B_join(T_A, T_B, dask_cluster):
 def test_aamped_A_B_join_df(T_A, T_B, dask_cluster):
     with Client(dask_cluster) as dask_client:
         m = 3
-        left = naive.aamp(T_A, m, T_B=T_B)
-        right = aamped(
+        ref_mp = naive.aamp(T_A, m, T_B=T_B)
+        comp_mp = aamped(
             dask_client, pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False
         )
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)

--- a/tests/test_aamped_one_constant_subsequence.py
+++ b/tests/test_aamped_one_constant_subsequence.py
@@ -28,11 +28,11 @@ def test_aamped_one_constant_subsequence_self_join(dask_cluster):
         )
         m = 3
         zone = int(np.ceil(m / 4))
-        left = naive.aamp(T_A, m)
-        right = aamped(dask_client, T_A, m, ignore_trivial=True)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+        ref_mp = naive.aamp(T_A, m)
+        comp_mp = aamped(dask_client, T_A, m, ignore_trivial=True)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
 
 @pytest.mark.filterwarnings("ignore:A large number of values are smaller")
@@ -48,11 +48,11 @@ def test_aamped_one_constant_subsequence_self_join_df(dask_cluster):
         )
         m = 3
         zone = int(np.ceil(m / 4))
-        left = naive.aamp(T_A, m)
-        right = aamped(dask_client, pd.Series(T_A), m, ignore_trivial=True)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+        ref_mp = naive.aamp(T_A, m)
+        comp_mp = aamped(dask_client, pd.Series(T_A), m, ignore_trivial=True)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
 
 @pytest.mark.filterwarnings("ignore:\\s+A large number of values are smaller")
@@ -68,11 +68,11 @@ def test_aamped_one_constant_subsequence_A_B_join(dask_cluster):
             (np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64))
         )
         m = 3
-        left = naive.aamp(T_A, m, T_B=T_B)
-        right = aamped(dask_client, T_A, m, T_B, ignore_trivial=False)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+        ref_mp = naive.aamp(T_A, m, T_B=T_B)
+        comp_mp = aamped(dask_client, T_A, m, T_B, ignore_trivial=False)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
 
 @pytest.mark.filterwarnings("ignore:\\s+A large number of values are smaller")
@@ -88,13 +88,13 @@ def test_aamped_one_constant_subsequence_A_B_join_df(dask_cluster):
             (np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64))
         )
         m = 3
-        left = naive.aamp(T_A, m, T_B=T_B)
-        right = aamped(
+        ref_mp = naive.aamp(T_A, m, T_B=T_B)
+        comp_mp = aamped(
             dask_client, pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False
         )
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
 
 @pytest.mark.filterwarnings("ignore:\\s+A large number of values are smaller")
@@ -110,11 +110,11 @@ def test_aamped_one_constant_subsequence_A_B_join_swap(dask_cluster):
             (np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64))
         )
         m = 3
-        left = naive.aamp(T_A, m, T_B=T_B)
-        right = aamped(dask_client, T_A, m, T_B, ignore_trivial=False)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+        ref_mp = naive.aamp(T_A, m, T_B=T_B)
+        comp_mp = aamped(dask_client, T_A, m, T_B, ignore_trivial=False)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
 
 @pytest.mark.filterwarnings("ignore:\\s+A large number of values are smaller")
@@ -130,13 +130,13 @@ def test_aamped_one_constant_subsequence_A_B_join_df_swap(dask_cluster):
             (np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64))
         )
         m = 3
-        left = naive.aamp(T_A, m, T_B=T_B)
-        right = aamped(
+        ref_mp = naive.aamp(T_A, m, T_B=T_B)
+        comp_mp = aamped(
             dask_client, pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False
         )
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
 
 @pytest.mark.filterwarnings("ignore:A large number of values are smaller")
@@ -153,12 +153,12 @@ def test_aamped_identical_subsequence_self_join(dask_cluster):
         T_A[11 : 11 + identical.shape[0]] = identical
         m = 3
         zone = int(np.ceil(m / 4))
-        left = naive.aamp(T_A, m)
-        right = aamped(dask_client, T_A, m, ignore_trivial=True)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
+        ref_mp = naive.aamp(T_A, m)
+        comp_mp = aamped(dask_client, T_A, m, ignore_trivial=True)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
         npt.assert_almost_equal(
-            left[:, 0], right[:, 0], decimal=config.STUMPY_TEST_PRECISION
+            ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
         )  # ignore indices
 
 
@@ -176,10 +176,10 @@ def test_aamped_one_constant_subsequence_A_B_join(dask_cluster):
         T_A[1 : 1 + identical.shape[0]] = identical
         T_B[11 : 11 + identical.shape[0]] = identical
         m = 3
-        left = naive.aamp(T_A, m, T_B=T_B)
-        right = aamped(dask_client, T_A, m, T_B, ignore_trivial=False)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
+        ref_mp = naive.aamp(T_A, m, T_B=T_B)
+        comp_mp = aamped(dask_client, T_A, m, T_B, ignore_trivial=False)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
         npt.assert_almost_equal(
-            left[:, 0], right[:, 0], decimal=config.STUMPY_TEST_PRECISION
+            ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
         )  # ignore indices

--- a/tests/test_aamped_one_subsequence_inf_A_B_join.py
+++ b/tests/test_aamped_one_subsequence_inf_A_B_join.py
@@ -44,8 +44,8 @@ def test_aamped_one_subsequence_inf_A_B_join(
         T_B_sub = T_B.copy()
         T_B_sub[substitution_location_B] = np.inf
 
-        left = naive.aamp(T_A, m, T_B=T_B_sub)
-        right = aamped(dask_client, T_A, m, T_B_sub, ignore_trivial=False)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        ref_mp = naive.aamp(T_A, m, T_B=T_B_sub)
+        comp_mp = aamped(dask_client, T_A, m, T_B_sub, ignore_trivial=False)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)

--- a/tests/test_aamped_one_subsequence_inf_self_join.py
+++ b/tests/test_aamped_one_subsequence_inf_self_join.py
@@ -45,11 +45,11 @@ def test_aamped_one_subsequence_inf_self_join(
         T_B_sub[substitution_location_B] = np.inf
 
         zone = int(np.ceil(m / 4))
-        left = naive.aamp(T_B_sub, m)
-        right = aamped(dask_client, T_B_sub, m, ignore_trivial=True)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        ref_mp = naive.aamp(T_B_sub, m)
+        comp_mp = aamped(dask_client, T_B_sub, m, ignore_trivial=True)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 @pytest.mark.filterwarnings("ignore:numpy.dtype size changed")
@@ -62,9 +62,9 @@ def test_aamped_nan_zero_mean_self_join(dask_cluster):
         m = 3
 
         zone = int(np.ceil(m / 4))
-        left = naive.aamp(T, m)
-        right = aamped(dask_client, T, m, ignore_trivial=True)
+        ref_mp = naive.aamp(T, m)
+        comp_mp = aamped(dask_client, T, m, ignore_trivial=True)
 
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)

--- a/tests/test_aamped_one_subsequence_nan_A_B_join.py
+++ b/tests/test_aamped_one_subsequence_nan_A_B_join.py
@@ -44,8 +44,8 @@ def test_aamped_one_subsequence_nan_A_B_join(
         T_B_sub = T_B.copy()
         T_B_sub[substitution_location_B] = np.nan
 
-        left = naive.aamp(T_A, m, T_B=T_B_sub)
-        right = aamped(dask_client, T_A, m, T_B_sub, ignore_trivial=False)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        ref_mp = naive.aamp(T_A, m, T_B=T_B_sub)
+        comp_mp = aamped(dask_client, T_A, m, T_B_sub, ignore_trivial=False)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)

--- a/tests/test_aamped_one_subsequence_nan_self_join.py
+++ b/tests/test_aamped_one_subsequence_nan_self_join.py
@@ -45,8 +45,8 @@ def test_aamped_one_subsequence_nan_self_join(
         T_B_sub[substitution_location_B] = np.nan
 
         zone = int(np.ceil(m / 4))
-        left = naive.aamp(T_B_sub, m)
-        right = aamped(dask_client, T_B_sub, m, ignore_trivial=True)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        ref_mp = naive.aamp(T_B_sub, m)
+        comp_mp = aamped(dask_client, T_B_sub, m, ignore_trivial=True)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)

--- a/tests/test_aamped_two_constant_subsequences.py
+++ b/tests/test_aamped_two_constant_subsequences.py
@@ -30,11 +30,11 @@ def test_two_constant_subsequences_A_B_join(dask_cluster):
             (np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64))
         )
         m = 3
-        left = naive.aamp(T_A, m, T_B=T_B)
-        right = aamped(dask_client, T_A, m, T_B, ignore_trivial=False)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+        ref_mp = naive.aamp(T_A, m, T_B=T_B)
+        comp_mp = aamped(dask_client, T_A, m, T_B, ignore_trivial=False)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
 
 @pytest.mark.filterwarnings("ignore:\\s+A large number of values are smaller")
@@ -52,10 +52,10 @@ def test_two_constant_subsequences_A_B_join_df(dask_cluster):
             (np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64))
         )
         m = 3
-        left = naive.aamp(T_A, m, T_B=T_B)
-        right = aamped(
+        ref_mp = naive.aamp(T_A, m, T_B=T_B)
+        comp_mp = aamped(
             dask_client, pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False
         )
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices

--- a/tests/test_aamped_two_constant_subsequences_swap.py
+++ b/tests/test_aamped_two_constant_subsequences_swap.py
@@ -31,11 +31,11 @@ def test_two_constant_subsequences_A_B_join_swap(dask_cluster):
             (np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64))
         )
         m = 3
-        left = naive.aamp(T_B, m, T_B=T_A)
-        right = aamped(dask_client, T_B, m, T_A, ignore_trivial=False)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+        ref_mp = naive.aamp(T_B, m, T_B=T_A)
+        comp_mp = aamped(dask_client, T_B, m, T_A, ignore_trivial=False)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
 
 @pytest.mark.filterwarnings("ignore:\\s+A large number of values are smaller")
@@ -54,10 +54,10 @@ def test_constant_subsequence_A_B_join_df_swap(dask_cluster):
             (np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64))
         )
         m = 3
-        left = naive.aamp(T_B, m, T_B=T_A)
-        right = aamped(
+        ref_mp = naive.aamp(T_B, m, T_B=T_A)
+        comp_mp = aamped(
             dask_client, pd.Series(T_B), m, pd.Series(T_A), ignore_trivial=False
         )
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices

--- a/tests/test_aamped_two_subsequences_inf_A_B_join.py
+++ b/tests/test_aamped_two_subsequences_inf_A_B_join.py
@@ -48,8 +48,8 @@ def test_aamped_two_subsequences_inf_A_B_join(
         T_A_sub[substitution_location_A] = np.inf
         T_B_sub[substitution_location_B] = np.inf
 
-        left = naive.aamp(T_A_sub, m, T_B=T_B_sub)
-        right = aamped(dask_client, T_A_sub, m, T_B_sub, ignore_trivial=False)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        ref_mp = naive.aamp(T_A_sub, m, T_B=T_B_sub)
+        comp_mp = aamped(dask_client, T_A_sub, m, T_B_sub, ignore_trivial=False)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)

--- a/tests/test_aamped_two_subsequences_nan_A_B_join.py
+++ b/tests/test_aamped_two_subsequences_nan_A_B_join.py
@@ -48,8 +48,8 @@ def test_aamped_two_subsequences_nan_A_B_join(
         T_A_sub[substitution_location_A] = np.nan
         T_B_sub[substitution_location_B] = np.nan
 
-        left = naive.aamp(T_A_sub, m, T_B=T_B_sub)
-        right = aamped(dask_client, T_A_sub, m, T_B_sub, ignore_trivial=False)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        ref_mp = naive.aamp(T_A_sub, m, T_B=T_B_sub)
+        comp_mp = aamped(dask_client, T_A_sub, m, T_B_sub, ignore_trivial=False)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)

--- a/tests/test_aamped_two_subsequences_nan_inf_A_B_join.py
+++ b/tests/test_aamped_two_subsequences_nan_inf_A_B_join.py
@@ -48,8 +48,8 @@ def test_aamped_two_subsequences_nan_inf_A_B_join(
         T_A_sub[substitution_location_A] = np.inf
         T_B_sub[substitution_location_B] = np.nan
 
-        left = naive.aamp(T_A_sub, m, T_B=T_B_sub)
-        right = aamped(dask_client, T_A_sub, m, T_B_sub, ignore_trivial=False)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        ref_mp = naive.aamp(T_A_sub, m, T_B=T_B_sub)
+        comp_mp = aamped(dask_client, T_A_sub, m, T_B_sub, ignore_trivial=False)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)

--- a/tests/test_aamped_two_subsequences_nan_inf_A_B_join_swap.py
+++ b/tests/test_aamped_two_subsequences_nan_inf_A_B_join_swap.py
@@ -48,8 +48,8 @@ def test_aamped_two_subsequences_nan_inf_A_B_join(
         T_A_sub[substitution_location_A] = np.nan
         T_B_sub[substitution_location_B] = np.inf
 
-        left = naive.aamp(T_A_sub, m, T_B=T_B_sub)
-        right = aamped(dask_client, T_A_sub, m, T_B_sub, ignore_trivial=False)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        ref_mp = naive.aamp(T_A_sub, m, T_B=T_B_sub)
+        comp_mp = aamped(dask_client, T_A_sub, m, T_B_sub, ignore_trivial=False)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -81,9 +81,9 @@ test_data = [
 
 @pytest.mark.parametrize("Q, T", test_data)
 def test_sliding_dot_product(Q, T):
-    left = naive_rolling_window_dot_product(Q, T)
-    right = core.sliding_dot_product(Q, T)
-    npt.assert_almost_equal(left, right)
+    ref_mp = naive_rolling_window_dot_product(Q, T)
+    comp_mp = core.sliding_dot_product(Q, T)
+    npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 @pytest.mark.parametrize("Q, T", test_data)

--- a/tests/test_gpu_aamp.py
+++ b/tests/test_gpu_aamp.py
@@ -39,15 +39,15 @@ def test_gpu_aamp_int_input():
 def test_gpu_aamp_self_join(T_A, T_B):
     m = 3
     zone = int(np.ceil(m / 4))
-    left = naive.aamp(T_B, m, exclusion_zone=zone)
-    right = gpu_aamp(T_B, m, ignore_trivial=True)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left, right)
+    ref_mp = naive.aamp(T_B, m, exclusion_zone=zone)
+    comp_mp = gpu_aamp(T_B, m, ignore_trivial=True)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp, comp_mp)
 
-    right = gpu_aamp(pd.Series(T_B), m, ignore_trivial=True)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left, right)
+    comp_mp = gpu_aamp(pd.Series(T_B), m, ignore_trivial=True)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -55,34 +55,34 @@ def test_gpu_aamp_self_join(T_A, T_B):
 def test_gpu_aamp_self_join_larger_window(T_A, T_B, m):
     if len(T_B) > m:
         zone = int(np.ceil(m / 4))
-        left = naive.aamp(T_B, m, exclusion_zone=zone)
-        right = gpu_aamp(T_B, m, ignore_trivial=True)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
+        ref_mp = naive.aamp(T_B, m, exclusion_zone=zone)
+        comp_mp = gpu_aamp(T_B, m, ignore_trivial=True)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
 
-        npt.assert_almost_equal(left, right)
+        npt.assert_almost_equal(ref_mp, comp_mp)
 
-        # right = gpu_aamp(
+        # comp_mp = gpu_aamp(
         #     pd.Series(T_B),
         #     m,
         #     ignore_trivial=True,
         # )
-        # naive.replace_inf(right)
-        # npt.assert_almost_equal(left, right)
+        # naive.replace_inf(comp_mp)
+        # npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
 def test_gpu_aamp_A_B_join(T_A, T_B):
     m = 3
-    left = naive.aamp(T_B, m, T_B=T_A)
-    right = gpu_aamp(T_B, m, T_A, ignore_trivial=False)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left, right)
+    ref_mp = naive.aamp(T_B, m, T_B=T_A)
+    comp_mp = gpu_aamp(T_B, m, T_A, ignore_trivial=False)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp, comp_mp)
 
-    # right = gpu_aamp(pd.Series(T_B), m, pd.Series(T_A), ignore_trivial=False)
-    # naive.replace_inf(right)
-    # npt.assert_almost_equal(left, right)
+    # comp_mp = gpu_aamp(pd.Series(T_B), m, pd.Series(T_A), ignore_trivial=False)
+    # naive.replace_inf(comp_mp)
+    # npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -91,25 +91,25 @@ def test_parallel_gpu_aamp_self_join(T_A, T_B):
     if len(T_B) > 10:
         m = 3
         zone = int(np.ceil(m / 4))
-        left = naive.aamp(T_B, m, exclusion_zone=zone)
-        right = gpu_aamp(
+        ref_mp = naive.aamp(T_B, m, exclusion_zone=zone)
+        comp_mp = gpu_aamp(
             T_B,
             m,
             ignore_trivial=True,
             device_id=device_ids,
         )
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)
 
-        # right = gpu_aamp(
+        # comp_mp = gpu_aamp(
         #     pd.Series(T_B),
         #     m,
         #     ignore_trivial=True,
         #     device_id=device_ids,
         # )
-        # naive.replace_inf(right)
-        # npt.assert_almost_equal(left, right)
+        # naive.replace_inf(comp_mp)
+        # npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -117,94 +117,94 @@ def test_parallel_gpu_aamp_A_B_join(T_A, T_B):
     device_ids = [device.id for device in cuda.list_devices()]
     if len(T_B) > 10:
         m = 3
-        left = naive.aamp(T_B, m, T_B=T_A)
-        right = gpu_aamp(
+        ref_mp = naive.aamp(T_B, m, T_B=T_A)
+        comp_mp = gpu_aamp(
             T_B,
             m,
             T_A,
             ignore_trivial=False,
             device_id=device_ids,
         )
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)
 
-        # right = gpu_aamp(
+        # comp_mp = gpu_aamp(
         #     pd.Series(T_B),
         #     m,
         #     pd.Series(T_A),
         #     ignore_trivial=False,
         #     device_id=device_ids,
         # )
-        # naive.replace_inf(right)
-        # npt.assert_almost_equal(left, right)
+        # naive.replace_inf(comp_mp)
+        # npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 def test_gpu_aamp_constant_subsequence_self_join():
     T_A = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64)))
     m = 3
     zone = int(np.ceil(m / 4))
-    left = naive.aamp(T_A, m, exclusion_zone=zone)
-    right = gpu_aamp(T_A, m, ignore_trivial=True)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    ref_mp = naive.aamp(T_A, m, exclusion_zone=zone)
+    comp_mp = gpu_aamp(T_A, m, ignore_trivial=True)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
-    # right = gpu_aamp(pd.Series(T_A), m, ignore_trivial=True)
-    # naive.replace_inf(right)
-    # npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    # comp_mp = gpu_aamp(pd.Series(T_A), m, ignore_trivial=True)
+    # naive.replace_inf(comp_mp)
+    # npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
 
 def test_gpu_aamp_one_constant_subsequence_A_B_join():
     T_A = np.random.rand(20)
     T_B = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64)))
     m = 3
-    left = naive.aamp(T_B, m, T_B=T_A)
-    right = gpu_aamp(T_B, m, T_A, ignore_trivial=False)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    ref_mp = naive.aamp(T_B, m, T_B=T_A)
+    comp_mp = gpu_aamp(T_B, m, T_A, ignore_trivial=False)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
-    # right = gpu_aamp(pd.Series(T_B), m, pd.Series(T_A), ignore_trivial=False)
-    # naive.replace_inf(right)
-    # npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    # comp_mp = gpu_aamp(pd.Series(T_B), m, pd.Series(T_A), ignore_trivial=False)
+    # naive.replace_inf(comp_mp)
+    # npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
     # Swap inputs
-    left = naive.aamp(T_A, m, T_B=T_B)
-    right = gpu_aamp(T_A, m, T_B, ignore_trivial=False)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    ref_mp = naive.aamp(T_A, m, T_B=T_B)
+    comp_mp = gpu_aamp(T_A, m, T_B, ignore_trivial=False)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
-    # right = gpu_aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
-    # naive.replace_inf(right)
-    # npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    # comp_mp = gpu_aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
+    # naive.replace_inf(comp_mp)
+    # npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
 
 def test_gpu_aamp_two_constant_subsequences_A_B_join():
     T_A = np.array([0, 0, 0, 0, 0, 1], dtype=np.float64)
     T_B = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64)))
     m = 3
-    left = naive.aamp(T_B, m, T_B=T_A)
-    right = gpu_aamp(T_B, m, T_A, ignore_trivial=False)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    ref_mp = naive.aamp(T_B, m, T_B=T_A)
+    comp_mp = gpu_aamp(T_B, m, T_A, ignore_trivial=False)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
-    # right = gpu_aamp(pd.Series(T_B), m, pd.Series(T_A), ignore_trivial=False)
-    # naive.replace_inf(right)
-    # npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    # comp_mp = gpu_aamp(pd.Series(T_B), m, pd.Series(T_A), ignore_trivial=False)
+    # naive.replace_inf(comp_mp)
+    # npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
     # Swap inputs
-    left = naive.aamp(T_A, m, T_B=T_B)
-    right = gpu_aamp(T_A, m, T_B, ignore_trivial=False)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    ref_mp = naive.aamp(T_A, m, T_B=T_B)
+    comp_mp = gpu_aamp(T_A, m, T_B, ignore_trivial=False)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
-    # right = gpu_aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
-    # naive.replace_inf(right)
-    # npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    # comp_mp = gpu_aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
+    # naive.replace_inf(comp_mp)
+    # npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
 
 def test_gpu_aamp_identical_subsequence_self_join():
@@ -214,18 +214,18 @@ def test_gpu_aamp_identical_subsequence_self_join():
     T_A[11 : 11 + identical.shape[0]] = identical
     m = 3
     zone = int(np.ceil(m / 4))
-    left = naive.aamp(T_A, m, exclusion_zone=zone)
-    right = gpu_aamp(T_A, m, ignore_trivial=True)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
+    ref_mp = naive.aamp(T_A, m, exclusion_zone=zone)
+    comp_mp = gpu_aamp(T_A, m, ignore_trivial=True)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
     npt.assert_almost_equal(
-        left[:, 0], right[:, 0], decimal=config.STUMPY_TEST_PRECISION
+        ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
     )  # ignore indices
 
-    # right = gpu_aamp(pd.Series(T_A), m, ignore_trivial=True)
-    # naive.replace_inf(right)
+    # comp_mp = gpu_aamp(pd.Series(T_A), m, ignore_trivial=True)
+    # naive.replace_inf(comp_mp)
     # npt.assert_almost_equal(
-    #     left[:, 0], right[:, 0], decimal=config.STUMPY_TEST_PRECISION
+    #     ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
     # )  # ignore indices
 
 
@@ -236,33 +236,33 @@ def test_gpu_aamp_identical_subsequence_A_B_join():
     T_A[1 : 1 + identical.shape[0]] = identical
     T_B[11 : 11 + identical.shape[0]] = identical
     m = 3
-    left = naive.aamp(T_A, m, T_B=T_B)
-    right = gpu_aamp(T_A, m, T_B, ignore_trivial=False)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
+    ref_mp = naive.aamp(T_A, m, T_B=T_B)
+    comp_mp = gpu_aamp(T_A, m, T_B, ignore_trivial=False)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
     npt.assert_almost_equal(
-        left[:, 0], right[:, 0], decimal=config.STUMPY_TEST_PRECISION
+        ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
     )  # ignore indices
 
-    # right = gpu_aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
-    # naive.replace_inf(right)
+    # comp_mp = gpu_aamp(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
+    # naive.replace_inf(comp_mp)
     # npt.assert_almost_equal(
-    #     left[:, 0], right[:, 0], decimal=config.STUMPY_TEST_PRECISION
+    #     ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
     # )  # ignore indices
 
     # Swap inputs
-    left = naive.aamp(T_B, m, T_B=T_A)
-    right = gpu_aamp(T_B, m, T_A, ignore_trivial=False)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
+    ref_mp = naive.aamp(T_B, m, T_B=T_A)
+    comp_mp = gpu_aamp(T_B, m, T_A, ignore_trivial=False)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
     npt.assert_almost_equal(
-        left[:, 0], right[:, 0], decimal=config.STUMPY_TEST_PRECISION
+        ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
     )  # ignore indices
 
-    # right = gpu_aamp(pd.Series(T_B), m, pd.Series(T_A), ignore_trivial=False)
-    # naive.replace_inf(right)
+    # comp_mp = gpu_aamp(pd.Series(T_B), m, pd.Series(T_A), ignore_trivial=False)
+    # naive.replace_inf(comp_mp)
     # npt.assert_almost_equal(
-    #     left[:, 0], right[:, 0], decimal=config.STUMPY_TEST_PRECISION
+    #     ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
     # )  # ignore indices
 
 
@@ -279,15 +279,15 @@ def test_gpu_aamp_nan_inf_self_join(T_A, T_B, substitute_B, substitution_locatio
         T_B_sub[substitution_location_B] = substitute_B
 
         zone = int(np.ceil(m / 4))
-        left = naive.aamp(T_B_sub, m, exclusion_zone=zone)
-        right = gpu_aamp(T_B_sub, m, ignore_trivial=True)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        ref_mp = naive.aamp(T_B_sub, m, exclusion_zone=zone)
+        comp_mp = gpu_aamp(T_B_sub, m, ignore_trivial=True)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)
 
-        # right = gpu_aamp(pd.Series(T_B_sub), m, ignore_trivial=True)
-        # naive.replace_inf(right)
-        # npt.assert_almost_equal(left, right)
+        # comp_mp = gpu_aamp(pd.Series(T_B_sub), m, ignore_trivial=True)
+        # naive.replace_inf(comp_mp)
+        # npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -309,17 +309,17 @@ def test_gpu_aamp_nan_inf_A_B_join(
             T_A_sub[substitution_location_A] = substitute_A
             T_B_sub[substitution_location_B] = substitute_B
 
-            left = naive.aamp(T_B_sub, m, T_B=T_A_sub)
-            right = gpu_aamp(T_B_sub, m, T_A_sub, ignore_trivial=False)
-            naive.replace_inf(left)
-            naive.replace_inf(right)
-            npt.assert_almost_equal(left, right)
+            ref_mp = naive.aamp(T_B_sub, m, T_B=T_A_sub)
+            comp_mp = gpu_aamp(T_B_sub, m, T_A_sub, ignore_trivial=False)
+            naive.replace_inf(ref_mp)
+            naive.replace_inf(comp_mp)
+            npt.assert_almost_equal(ref_mp, comp_mp)
 
-            # right = gpu_aamp(
+            # comp_mp = gpu_aamp(
             #     pd.Series(T_B_sub), m, pd.Series(T_A_sub), ignore_trivial=False
             # )
-            # naive.replace_inf(right)
-            # npt.assert_almost_equal(left, right)
+            # naive.replace_inf(comp_mp)
+            # npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 def test_gpu_aamp_nan_zero_mean_self_join():
@@ -327,9 +327,9 @@ def test_gpu_aamp_nan_zero_mean_self_join():
     m = 3
 
     zone = int(np.ceil(m / 4))
-    left = naive.aamp(T, m, exclusion_zone=zone)
-    right = gpu_aamp(T, m, ignore_trivial=True)
+    ref_mp = naive.aamp(T, m, exclusion_zone=zone)
+    comp_mp = gpu_aamp(T, m, ignore_trivial=True)
 
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left, right)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp, comp_mp)

--- a/tests/test_gpu_stump.py
+++ b/tests/test_gpu_stump.py
@@ -39,15 +39,15 @@ def test_gpu_aamp_int_input():
 def test_gpu_stump_self_join(T_A, T_B):
     m = 3
     zone = int(np.ceil(m / 4))
-    left = naive.stamp(T_B, m, exclusion_zone=zone)
-    right = gpu_stump(T_B, m, ignore_trivial=True)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left, right)
+    ref_mp = naive.stamp(T_B, m, exclusion_zone=zone)
+    comp_mp = gpu_stump(T_B, m, ignore_trivial=True)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp, comp_mp)
 
-    right = gpu_stump(pd.Series(T_B), m, ignore_trivial=True)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left, right)
+    comp_mp = gpu_stump(pd.Series(T_B), m, ignore_trivial=True)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -55,34 +55,34 @@ def test_gpu_stump_self_join(T_A, T_B):
 def test_gpu_stump_self_join_larger_window(T_A, T_B, m):
     if len(T_B) > m:
         zone = int(np.ceil(m / 4))
-        left = naive.stamp(T_B, m, exclusion_zone=zone)
-        right = gpu_stump(T_B, m, ignore_trivial=True)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
+        ref_mp = naive.stamp(T_B, m, exclusion_zone=zone)
+        comp_mp = gpu_stump(T_B, m, ignore_trivial=True)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
 
-        npt.assert_almost_equal(left, right)
+        npt.assert_almost_equal(ref_mp, comp_mp)
 
-        # right = gpu_stump(
+        # comp_mp = gpu_stump(
         #     pd.Series(T_B),
         #     m,
         #     ignore_trivial=True,
         # )
-        # naive.replace_inf(right)
-        # npt.assert_almost_equal(left, right)
+        # naive.replace_inf(comp_mp)
+        # npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
 def test_gpu_stump_A_B_join(T_A, T_B):
     m = 3
-    left = naive.stamp(T_B, m, T_B=T_A)
-    right = gpu_stump(T_B, m, T_A, ignore_trivial=False)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left, right)
+    ref_mp = naive.stamp(T_B, m, T_B=T_A)
+    comp_mp = gpu_stump(T_B, m, T_A, ignore_trivial=False)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp, comp_mp)
 
-    # right = gpu_stump(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
-    # naive.replace_inf(right)
-    # npt.assert_almost_equal(left, right)
+    # comp_mp = gpu_stump(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
+    # naive.replace_inf(comp_mp)
+    # npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -91,25 +91,25 @@ def test_parallel_gpu_stump_self_join(T_A, T_B):
     if len(T_B) > 10:
         m = 3
         zone = int(np.ceil(m / 4))
-        left = naive.stamp(T_B, m, exclusion_zone=zone)
-        right = gpu_stump(
+        ref_mp = naive.stamp(T_B, m, exclusion_zone=zone)
+        comp_mp = gpu_stump(
             T_B,
             m,
             ignore_trivial=True,
             device_id=device_ids,
         )
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)
 
-        # right = gpu_stump(
+        # comp_mp = gpu_stump(
         #     pd.Series(T_B),
         #     m,
         #     ignore_trivial=True,
         #     device_id=device_ids,
         # )
-        # naive.replace_inf(right)
-        # npt.assert_almost_equal(left, right)
+        # naive.replace_inf(comp_mp)
+        # npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -117,94 +117,94 @@ def test_parallel_gpu_stump_A_B_join(T_A, T_B):
     device_ids = [device.id for device in cuda.list_devices()]
     if len(T_B) > 10:
         m = 3
-        left = naive.stamp(T_B, m, T_B=T_A)
-        right = gpu_stump(
+        ref_mp = naive.stamp(T_B, m, T_B=T_A)
+        comp_mp = gpu_stump(
             T_B,
             m,
             T_A,
             ignore_trivial=False,
             device_id=device_ids,
         )
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)
 
-        # right = gpu_stump(
+        # comp_mp = gpu_stump(
         #     pd.Series(T_B),
         #     m,
         #     pd.Series(T_A),
         #     ignore_trivial=False,
         #     device_id=device_ids,
         # )
-        # naive.replace_inf(right)
-        # npt.assert_almost_equal(left, right)
+        # naive.replace_inf(comp_mp)
+        # npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 def test_gpu_stump_constant_subsequence_self_join():
     T_A = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64)))
     m = 3
     zone = int(np.ceil(m / 4))
-    left = naive.stamp(T_A, m, exclusion_zone=zone)
-    right = gpu_stump(T_A, m, ignore_trivial=True)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    ref_mp = naive.stamp(T_A, m, exclusion_zone=zone)
+    comp_mp = gpu_stump(T_A, m, ignore_trivial=True)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
-    # right = gpu_stump(pd.Series(T_A), m, ignore_trivial=True)
-    # naive.replace_inf(right)
-    # npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    # comp_mp = gpu_stump(pd.Series(T_A), m, ignore_trivial=True)
+    # naive.replace_inf(comp_mp)
+    # npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
 
 def test_gpu_stump_one_constant_subsequence_A_B_join():
     T_A = np.random.rand(20)
     T_B = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64)))
     m = 3
-    left = naive.stamp(T_B, m, T_B=T_A)
-    right = gpu_stump(T_B, m, T_A, ignore_trivial=False)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    ref_mp = naive.stamp(T_B, m, T_B=T_A)
+    comp_mp = gpu_stump(T_B, m, T_A, ignore_trivial=False)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
-    # right = gpu_stump(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
-    # naive.replace_inf(right)
-    # npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    # comp_mp = gpu_stump(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
+    # naive.replace_inf(comp_mp)
+    # npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
     # Swap inputs
-    left = naive.stamp(T_A, m, T_B=T_B)
-    right = gpu_stump(T_A, m, T_B, ignore_trivial=False)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    ref_mp = naive.stamp(T_A, m, T_B=T_B)
+    comp_mp = gpu_stump(T_A, m, T_B, ignore_trivial=False)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
-    # right = gpu_stump(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
-    # naive.replace_inf(right)
-    # npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    # comp_mp = gpu_stump(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
+    # naive.replace_inf(comp_mp)
+    # npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
 
 def test_gpu_stump_two_constant_subsequences_A_B_join():
     T_A = np.array([0, 0, 0, 0, 0, 1], dtype=np.float64)
     T_B = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64)))
     m = 3
-    left = naive.stamp(T_B, m, T_B=T_A)
-    right = gpu_stump(T_B, m, T_A, ignore_trivial=False)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    ref_mp = naive.stamp(T_B, m, T_B=T_A)
+    comp_mp = gpu_stump(T_B, m, T_A, ignore_trivial=False)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
-    # right = gpu_stump(pd.Series(T_B), m, pd.Series(T_A), ignore_trivial=False)
-    # naive.replace_inf(right)
-    # npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    # comp_mp = gpu_stump(pd.Series(T_B), m, pd.Series(T_A), ignore_trivial=False)
+    # naive.replace_inf(comp_mp)
+    # npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
     # Swap inputs
-    left = naive.stamp(T_A, m, T_B=T_B)
-    right = gpu_stump(T_A, m, T_B, ignore_trivial=False)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    ref_mp = naive.stamp(T_A, m, T_B=T_B)
+    comp_mp = gpu_stump(T_A, m, T_B, ignore_trivial=False)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
-    # right = gpu_stump(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
-    # naive.replace_inf(right)
-    # npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    # comp_mp = gpu_stump(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
+    # naive.replace_inf(comp_mp)
+    # npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
 
 def test_gpu_stump_identical_subsequence_self_join():
@@ -214,18 +214,18 @@ def test_gpu_stump_identical_subsequence_self_join():
     T_A[11 : 11 + identical.shape[0]] = identical
     m = 3
     zone = int(np.ceil(m / 4))
-    left = naive.stamp(T_A, m, exclusion_zone=zone)
-    right = gpu_stump(T_A, m, ignore_trivial=True)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
+    ref_mp = naive.stamp(T_A, m, exclusion_zone=zone)
+    comp_mp = gpu_stump(T_A, m, ignore_trivial=True)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
     npt.assert_almost_equal(
-        left[:, 0], right[:, 0], decimal=config.STUMPY_TEST_PRECISION
+        ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
     )  # ignore indices
 
-    # right = gpu_stump(pd.Series(T_A), m, ignore_trivial=True)
-    # naive.replace_inf(right)
+    # comp_mp = gpu_stump(pd.Series(T_A), m, ignore_trivial=True)
+    # naive.replace_inf(comp_mp)
     # npt.assert_almost_equal(
-    #     left[:, 0], right[:, 0], decimal=config.STUMPY_TEST_PRECISION
+    #     ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
     # )  # ignore indices
 
 
@@ -236,33 +236,33 @@ def test_gpu_stump_identical_subsequence_A_B_join():
     T_A[1 : 1 + identical.shape[0]] = identical
     T_B[11 : 11 + identical.shape[0]] = identical
     m = 3
-    left = naive.stamp(T_B, m, T_B=T_A)
-    right = gpu_stump(T_B, m, T_A, ignore_trivial=False)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
+    ref_mp = naive.stamp(T_B, m, T_B=T_A)
+    comp_mp = gpu_stump(T_B, m, T_A, ignore_trivial=False)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
     npt.assert_almost_equal(
-        left[:, 0], right[:, 0], decimal=config.STUMPY_TEST_PRECISION
+        ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
     )  # ignore indices
 
-    # right = gpu_stump(pd.Series(T_B), m, pd.Series(T_A), ignore_trivial=False)
-    # naive.replace_inf(right)
+    # comp_mp = gpu_stump(pd.Series(T_B), m, pd.Series(T_A), ignore_trivial=False)
+    # naive.replace_inf(comp_mp)
     # npt.assert_almost_equal(
-    #     left[:, 0], right[:, 0], decimal=config.STUMPY_TEST_PRECISION
+    #     ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
     # )  # ignore indices
 
     # Swap inputs
-    left = naive.stamp(T_A, m, T_B=T_B)
-    right = gpu_stump(T_A, m, T_B, ignore_trivial=False)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
+    ref_mp = naive.stamp(T_A, m, T_B=T_B)
+    comp_mp = gpu_stump(T_A, m, T_B, ignore_trivial=False)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
     npt.assert_almost_equal(
-        left[:, 0], right[:, 0], decimal=config.STUMPY_TEST_PRECISION
+        ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
     )  # ignore indices
 
-    # right = gpu_stump(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
-    # naive.replace_inf(right)
+    # comp_mp = gpu_stump(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
+    # naive.replace_inf(comp_mp)
     # npt.assert_almost_equal(
-    #     left[:, 0], right[:, 0], decimal=config.STUMPY_TEST_PRECISION
+    #     ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
     # )  # ignore indices
 
 
@@ -279,15 +279,15 @@ def test_gpu_stump_nan_inf_self_join(T_A, T_B, substitute_B, substitution_locati
         T_B_sub[substitution_location_B] = substitute_B
 
         zone = int(np.ceil(m / 4))
-        left = naive.stamp(T_B_sub, m, exclusion_zone=zone)
-        right = gpu_stump(T_B_sub, m, ignore_trivial=True)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        ref_mp = naive.stamp(T_B_sub, m, exclusion_zone=zone)
+        comp_mp = gpu_stump(T_B_sub, m, ignore_trivial=True)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)
 
-        # right = gpu_stump(pd.Series(T_B_sub), m, ignore_trivial=True)
-        # naive.replace_inf(right)
-        # npt.assert_almost_equal(left, right)
+        # comp_mp = gpu_stump(pd.Series(T_B_sub), m, ignore_trivial=True)
+        # naive.replace_inf(comp_mp)
+        # npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -309,17 +309,17 @@ def test_gpu_stump_nan_inf_A_B_join(
             T_A_sub[substitution_location_A] = substitute_A
             T_B_sub[substitution_location_B] = substitute_B
 
-            left = naive.stamp(T_B_sub, m, T_B=T_A_sub)
-            right = gpu_stump(T_B_sub, m, T_A_sub, ignore_trivial=False)
-            naive.replace_inf(left)
-            naive.replace_inf(right)
-            npt.assert_almost_equal(left, right)
+            ref_mp = naive.stamp(T_B_sub, m, T_B=T_A_sub)
+            comp_mp = gpu_stump(T_B_sub, m, T_A_sub, ignore_trivial=False)
+            naive.replace_inf(ref_mp)
+            naive.replace_inf(comp_mp)
+            npt.assert_almost_equal(ref_mp, comp_mp)
 
-            # right = gpu_stump(
+            # comp_mp = gpu_stump(
             #     pd.Series(T_B_sub), m, pd.Series(T_A_sub), ignore_trivial=False
             # )
-            # naive.replace_inf(right)
-            # npt.assert_almost_equal(left, right)
+            # naive.replace_inf(comp_mp)
+            # npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 def test_gpu_stump_nan_zero_mean_self_join():
@@ -327,9 +327,9 @@ def test_gpu_stump_nan_zero_mean_self_join():
     m = 3
 
     zone = int(np.ceil(m / 4))
-    left = naive.stamp(T, m, exclusion_zone=zone)
-    right = gpu_stump(T, m, ignore_trivial=True)
+    ref_mp = naive.stamp(T, m, exclusion_zone=zone)
+    comp_mp = gpu_stump(T, m, ignore_trivial=True)
 
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left, right)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp, comp_mp)

--- a/tests/test_stamp.py
+++ b/tests/test_stamp.py
@@ -59,21 +59,21 @@ def test_stamp_int_input():
 def test_stamp_self_join(T_A, T_B):
     m = 3
     zone = int(np.ceil(m / 2))
-    left = naive.stamp(T_B, m, exclusion_zone=zone)
-    right = stamp.stamp(T_B, T_B, m, ignore_trivial=True)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left[:, :2], right)
+    ref_mp = naive.stamp(T_B, m, exclusion_zone=zone)
+    comp_mp = stamp.stamp(T_B, T_B, m, ignore_trivial=True)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp[:, :2], comp_mp)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
 def test_stamp_A_B_join(T_A, T_B):
     m = 3
-    left = naive.stamp(T_A, m, T_B=T_B)
-    right = stamp.stamp(T_A, T_B, m)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left[:, :2], right)
+    ref_mp = naive.stamp(T_A, m, T_B=T_B)
+    comp_mp = stamp.stamp(T_A, T_B, m)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp[:, :2], comp_mp)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -89,11 +89,11 @@ def test_stamp_nan_inf_self_join(T_A, T_B, substitute_B, substitution_locations)
         T_B_sub[substitution_location_B] = substitute_B
 
         zone = int(np.ceil(m / 2))
-        left = naive.stamp(T_B_sub, m, exclusion_zone=zone)
-        right = stamp.stamp(T_B_sub, T_B_sub, m, ignore_trivial=True)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left[:, :2], right)
+        ref_mp = naive.stamp(T_B_sub, m, exclusion_zone=zone)
+        comp_mp = stamp.stamp(T_B_sub, T_B_sub, m, ignore_trivial=True)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp[:, :2], comp_mp)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -115,11 +115,11 @@ def test_stamp_nan_inf_A_B_join(
             T_A_sub[substitution_location_A] = substitute_A
             T_B_sub[substitution_location_B] = substitute_B
 
-            left = naive.stamp(T_A_sub, m, T_B=T_B_sub)
-            right = stamp.stamp(T_A_sub, T_B_sub, m)
-            naive.replace_inf(left)
-            naive.replace_inf(right)
-            npt.assert_almost_equal(left[:, :2], right)
+            ref_mp = naive.stamp(T_A_sub, m, T_B=T_B_sub)
+            comp_mp = stamp.stamp(T_A_sub, T_B_sub, m)
+            naive.replace_inf(ref_mp)
+            naive.replace_inf(comp_mp)
+            npt.assert_almost_equal(ref_mp[:, :2], comp_mp)
 
 
 def test_stamp_nan_zero_mean_self_join():
@@ -127,9 +127,9 @@ def test_stamp_nan_zero_mean_self_join():
     m = 3
 
     zone = int(np.ceil(m / 2))
-    left = naive.stamp(T, m, exclusion_zone=zone)
-    right = stamp.stamp(T, T, m, ignore_trivial=True)
+    ref_mp = naive.stamp(T, m, exclusion_zone=zone)
+    comp_mp = stamp.stamp(T, T, m, ignore_trivial=True)
 
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left[:, :2], right)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp[:, :2], comp_mp)

--- a/tests/test_stomp.py
+++ b/tests/test_stomp.py
@@ -30,11 +30,11 @@ def test_stomp_int_input():
 def test_stomp_self_join(T_A, T_B):
     m = 3
     zone = int(np.ceil(m / 4))
-    left = naive.stamp(T_B, m, exclusion_zone=zone)
-    right = stomp._stomp(T_B, m, ignore_trivial=True)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left, right)
+    ref_mp = naive.stamp(T_B, m, exclusion_zone=zone)
+    comp_mp = stomp._stomp(T_B, m, ignore_trivial=True)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -42,22 +42,22 @@ def test_stomp_self_join(T_A, T_B):
 def test_stump_self_join_larger_window(T_A, T_B, m):
     if len(T_B) > m:
         zone = int(np.ceil(m / 4))
-        left = naive.stamp(T_B, m, exclusion_zone=zone)
-        right = stomp._stomp(T_B, m, ignore_trivial=True)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
+        ref_mp = naive.stamp(T_B, m, exclusion_zone=zone)
+        comp_mp = stomp._stomp(T_B, m, ignore_trivial=True)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
 
-        npt.assert_almost_equal(left, right)
+        npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
 def test_stomp_A_B_join(T_A, T_B):
     m = 3
-    left = naive.stamp(T_A, m, T_B=T_B)
-    right = stomp._stomp(T_A, m, T_B, ignore_trivial=False)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left, right)
+    ref_mp = naive.stamp(T_A, m, T_B=T_B)
+    comp_mp = stomp._stomp(T_A, m, T_B, ignore_trivial=False)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -73,11 +73,11 @@ def test_stomp_nan_inf_self_join(T_A, T_B, substitute_B, substitution_locations)
         T_B_sub[substitution_location_B] = substitute_B
 
         zone = int(np.ceil(m / 4))
-        left = naive.stamp(T_B_sub, m, exclusion_zone=zone)
-        right = stomp._stomp(T_B_sub, m, ignore_trivial=True)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        ref_mp = naive.stamp(T_B_sub, m, exclusion_zone=zone)
+        comp_mp = stomp._stomp(T_B_sub, m, ignore_trivial=True)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -99,11 +99,11 @@ def test_stomp_nan_inf_A_B_join(
             T_A_sub[substitution_location_A] = substitute_A
             T_B_sub[substitution_location_B] = substitute_B
 
-            left = naive.stamp(T_A_sub, m, T_B=T_B_sub)
-            right = stomp._stomp(T_A_sub, m, T_B_sub, ignore_trivial=False)
-            naive.replace_inf(left)
-            naive.replace_inf(right)
-            npt.assert_almost_equal(left, right)
+            ref_mp = naive.stamp(T_A_sub, m, T_B=T_B_sub)
+            comp_mp = stomp._stomp(T_A_sub, m, T_B_sub, ignore_trivial=False)
+            naive.replace_inf(ref_mp)
+            naive.replace_inf(comp_mp)
+            npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 def test_stomp_nan_zero_mean_self_join():
@@ -111,9 +111,9 @@ def test_stomp_nan_zero_mean_self_join():
     m = 3
 
     zone = int(np.ceil(m / 4))
-    left = naive.stamp(T, m, exclusion_zone=zone)
-    right = stomp._stomp(T, m, ignore_trivial=True)
+    ref_mp = naive.stamp(T, m, exclusion_zone=zone)
+    comp_mp = stomp._stomp(T, m, ignore_trivial=True)
 
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left, right)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp, comp_mp)

--- a/tests/test_stump.py
+++ b/tests/test_stump.py
@@ -30,66 +30,66 @@ def test_stump_int_input():
 def test_stump_self_join(T_A, T_B):
     m = 3
     zone = int(np.ceil(m / 4))
-    left = naive.stump(T_B, m, exclusion_zone=zone)
-    right = stump(T_B, m, ignore_trivial=True)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left, right)
+    ref_mp = naive.stump(T_B, m, exclusion_zone=zone)
+    comp_mp = stump(T_B, m, ignore_trivial=True)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp, comp_mp)
 
-    right = stump(pd.Series(T_B), m, ignore_trivial=True)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left, right)
+    comp_mp = stump(pd.Series(T_B), m, ignore_trivial=True)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
 def test_stump_A_B_join(T_A, T_B):
     m = 3
-    left = naive.stump(T_A, m, T_B=T_B)
-    right = stump(T_A, m, T_B, ignore_trivial=False)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left, right)
+    ref_mp = naive.stump(T_A, m, T_B=T_B)
+    comp_mp = stump(T_A, m, T_B, ignore_trivial=False)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp, comp_mp)
 
-    right = stump(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left, right)
+    comp_mp = stump(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 def test_stump_constant_subsequence_self_join():
     T_A = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64)))
     m = 3
     zone = int(np.ceil(m / 4))
-    left = naive.stump(T_A, m, exclusion_zone=zone)
-    right = stump(T_A, m, ignore_trivial=True)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    ref_mp = naive.stump(T_A, m, exclusion_zone=zone)
+    comp_mp = stump(T_A, m, ignore_trivial=True)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
-    right = stump(pd.Series(T_A), m, ignore_trivial=True)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    comp_mp = stump(pd.Series(T_A), m, ignore_trivial=True)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
 
 def test_stump_one_constant_subsequence_A_B_join():
     T_A = np.random.rand(20)
     T_B = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64)))
     m = 3
-    left = naive.stamp(T_A, m, T_B=T_B)
-    right = stump(T_A, m, T_B, ignore_trivial=False)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    ref_mp = naive.stamp(T_A, m, T_B=T_B)
+    comp_mp = stump(T_A, m, T_B, ignore_trivial=False)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
-    right = stump(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    comp_mp = stump(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
     # Swap inputs
-    left = naive.stamp(T_B, m, T_B=T_A)
-    right = stump(T_B, m, T_A, ignore_trivial=False)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    ref_mp = naive.stamp(T_B, m, T_B=T_A)
+    comp_mp = stump(T_B, m, T_A, ignore_trivial=False)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
 
 def test_stump_two_constant_subsequences_A_B_join():
@@ -98,26 +98,26 @@ def test_stump_two_constant_subsequences_A_B_join():
     )
     T_B = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64)))
     m = 3
-    left = naive.stamp(T_A, m, T_B=T_B)
-    right = stump(T_A, m, T_B, ignore_trivial=False)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    ref_mp = naive.stamp(T_A, m, T_B=T_B)
+    comp_mp = stump(T_A, m, T_B, ignore_trivial=False)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
-    right = stump(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    comp_mp = stump(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
     # Swap inputs
-    left = naive.stamp(T_B, m, T_B=T_A)
-    right = stump(T_B, m, T_A, ignore_trivial=False)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    ref_mp = naive.stamp(T_B, m, T_B=T_A)
+    comp_mp = stump(T_B, m, T_A, ignore_trivial=False)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
-    right = stump(pd.Series(T_B), m, pd.Series(T_A), ignore_trivial=False)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+    comp_mp = stump(pd.Series(T_B), m, pd.Series(T_A), ignore_trivial=False)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
 
 def test_stump_identical_subsequence_self_join():
@@ -127,18 +127,18 @@ def test_stump_identical_subsequence_self_join():
     T_A[11 : 11 + identical.shape[0]] = identical
     m = 3
     zone = int(np.ceil(m / 4))
-    left = naive.stamp(T_A, m, exclusion_zone=zone)
-    right = stump(T_A, m, ignore_trivial=True)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
+    ref_mp = naive.stamp(T_A, m, exclusion_zone=zone)
+    comp_mp = stump(T_A, m, ignore_trivial=True)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
     npt.assert_almost_equal(
-        left[:, 0], right[:, 0], decimal=config.STUMPY_TEST_PRECISION
+        ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
     )  # ignore indices
 
-    right = stump(pd.Series(T_A), m, ignore_trivial=True)
-    naive.replace_inf(right)
+    comp_mp = stump(pd.Series(T_A), m, ignore_trivial=True)
+    naive.replace_inf(comp_mp)
     npt.assert_almost_equal(
-        left[:, 0], right[:, 0], decimal=config.STUMPY_TEST_PRECISION
+        ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
     )  # ignore indices
 
 
@@ -149,27 +149,27 @@ def test_stump_identical_subsequence_A_B_join():
     T_A[1 : 1 + identical.shape[0]] = identical
     T_B[11 : 11 + identical.shape[0]] = identical
     m = 3
-    left = naive.stamp(T_A, m, T_B=T_B)
-    right = stump(T_A, m, T_B, ignore_trivial=False)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
+    ref_mp = naive.stamp(T_A, m, T_B=T_B)
+    comp_mp = stump(T_A, m, T_B, ignore_trivial=False)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
     npt.assert_almost_equal(
-        left[:, 0], right[:, 0], decimal=config.STUMPY_TEST_PRECISION
+        ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
     )  # ignore indices
 
-    right = stump(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
-    naive.replace_inf(right)
+    comp_mp = stump(pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False)
+    naive.replace_inf(comp_mp)
     npt.assert_almost_equal(
-        left[:, 0], right[:, 0], decimal=config.STUMPY_TEST_PRECISION
+        ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
     )  # ignore indices
 
     # Swap inputs
-    left = naive.stamp(T_B, m, T_B=T_A)
-    right = stump(T_B, m, T_A, ignore_trivial=False)
-    naive.replace_inf(left)
-    naive.replace_inf(right)
+    ref_mp = naive.stamp(T_B, m, T_B=T_A)
+    comp_mp = stump(T_B, m, T_A, ignore_trivial=False)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
     npt.assert_almost_equal(
-        left[:, 0], right[:, 0], decimal=config.STUMPY_TEST_PRECISION
+        ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
     )  # ignore indices
 
 
@@ -186,15 +186,15 @@ def test_stump_nan_inf_self_join(T_A, T_B, substitute_B, substitution_locations)
         T_B_sub[substitution_location_B] = substitute_B
 
         zone = int(np.ceil(m / 4))
-        left = naive.stamp(T_B_sub, m, exclusion_zone=zone)
-        right = stump(T_B_sub, m, ignore_trivial=True)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        ref_mp = naive.stamp(T_B_sub, m, exclusion_zone=zone)
+        comp_mp = stump(T_B_sub, m, ignore_trivial=True)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)
 
-        right = stump(pd.Series(T_B_sub), m, ignore_trivial=True)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        comp_mp = stump(pd.Series(T_B_sub), m, ignore_trivial=True)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -216,17 +216,17 @@ def test_stump_nan_inf_A_B_join(
             T_A_sub[substitution_location_A] = substitute_A
             T_B_sub[substitution_location_B] = substitute_B
 
-            left = naive.stamp(T_A_sub, m, T_B=T_B_sub)
-            right = stump(T_A_sub, m, T_B_sub, ignore_trivial=False)
-            naive.replace_inf(left)
-            naive.replace_inf(right)
-            npt.assert_almost_equal(left, right)
+            ref_mp = naive.stamp(T_A_sub, m, T_B=T_B_sub)
+            comp_mp = stump(T_A_sub, m, T_B_sub, ignore_trivial=False)
+            naive.replace_inf(ref_mp)
+            naive.replace_inf(comp_mp)
+            npt.assert_almost_equal(ref_mp, comp_mp)
 
-            right = stump(
+            comp_mp = stump(
                 pd.Series(T_A_sub), m, pd.Series(T_B_sub), ignore_trivial=False
             )
-            naive.replace_inf(right)
-            npt.assert_almost_equal(left, right)
+            naive.replace_inf(comp_mp)
+            npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 def test_stump_nan_zero_mean_self_join():
@@ -234,9 +234,9 @@ def test_stump_nan_zero_mean_self_join():
     m = 3
 
     zone = int(np.ceil(m / 4))
-    left = naive.stamp(T, m, exclusion_zone=zone)
-    right = stump(T, m, ignore_trivial=True)
+    ref_mp = naive.stamp(T, m, exclusion_zone=zone)
+    comp_mp = stump(T, m, ignore_trivial=True)
 
-    naive.replace_inf(left)
-    naive.replace_inf(right)
-    npt.assert_almost_equal(left, right)
+    naive.replace_inf(ref_mp)
+    naive.replace_inf(comp_mp)
+    npt.assert_almost_equal(ref_mp, comp_mp)

--- a/tests/test_stumped.py
+++ b/tests/test_stumped.py
@@ -44,11 +44,11 @@ def test_stumped_self_join(T_A, T_B, dask_cluster):
     with Client(dask_cluster) as dask_client:
         m = 3
         zone = int(np.ceil(m / 4))
-        left = naive.stump(T_B, m, exclusion_zone=zone)
-        right = stumped(dask_client, T_B, m, ignore_trivial=True)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        ref_mp = naive.stump(T_B, m, exclusion_zone=zone)
+        comp_mp = stumped(dask_client, T_B, m, ignore_trivial=True)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 @pytest.mark.filterwarnings("ignore:numpy.dtype size changed")
@@ -60,11 +60,11 @@ def test_stumped_self_join_df(T_A, T_B, dask_cluster):
     with Client(dask_cluster) as dask_client:
         m = 3
         zone = int(np.ceil(m / 4))
-        left = naive.stump(T_B, m, exclusion_zone=zone)
-        right = stumped(dask_client, pd.Series(T_B), m, ignore_trivial=True)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        ref_mp = naive.stump(T_B, m, exclusion_zone=zone)
+        comp_mp = stumped(dask_client, pd.Series(T_B), m, ignore_trivial=True)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 @pytest.mark.filterwarnings("ignore:numpy.dtype size changed")
@@ -78,12 +78,12 @@ def test_stump_self_join_larger_window(T_A, T_B, m, dask_cluster):
         for m in [8, 16, 32]:
             if len(T_B) > m:
                 zone = int(np.ceil(m / 4))
-                left = naive.stump(T_B, m, exclusion_zone=zone)
-                right = stumped(dask_client, T_B, m, ignore_trivial=True)
-                naive.replace_inf(left)
-                naive.replace_inf(right)
+                ref_mp = naive.stump(T_B, m, exclusion_zone=zone)
+                comp_mp = stumped(dask_client, T_B, m, ignore_trivial=True)
+                naive.replace_inf(ref_mp)
+                naive.replace_inf(comp_mp)
 
-                npt.assert_almost_equal(left, right)
+                npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 @pytest.mark.filterwarnings("ignore:numpy.dtype size changed")
@@ -97,12 +97,12 @@ def test_stump_self_join_larger_window_df(T_A, T_B, m, dask_cluster):
         for m in [8, 16, 32]:
             if len(T_B) > m:
                 zone = int(np.ceil(m / 4))
-                left = naive.stump(T_B, m, exclusion_zone=zone)
-                right = stumped(dask_client, pd.Series(T_B), m, ignore_trivial=True)
-                naive.replace_inf(left)
-                naive.replace_inf(right)
+                ref_mp = naive.stump(T_B, m, exclusion_zone=zone)
+                comp_mp = stumped(dask_client, pd.Series(T_B), m, ignore_trivial=True)
+                naive.replace_inf(ref_mp)
+                naive.replace_inf(comp_mp)
 
-                npt.assert_almost_equal(left, right)
+                npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 @pytest.mark.filterwarnings("ignore:numpy.dtype size changed")
@@ -113,11 +113,11 @@ def test_stump_self_join_larger_window_df(T_A, T_B, m, dask_cluster):
 def test_stumped_A_B_join(T_A, T_B, dask_cluster):
     with Client(dask_cluster) as dask_client:
         m = 3
-        left = naive.stump(T_A, m, T_B=T_B)
-        right = stumped(dask_client, T_A, m, T_B, ignore_trivial=False)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        ref_mp = naive.stump(T_A, m, T_B=T_B)
+        comp_mp = stumped(dask_client, T_A, m, T_B, ignore_trivial=False)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 @pytest.mark.filterwarnings("ignore:numpy.dtype size changed")
@@ -128,10 +128,10 @@ def test_stumped_A_B_join(T_A, T_B, dask_cluster):
 def test_stumped_A_B_join_df(T_A, T_B, dask_cluster):
     with Client(dask_cluster) as dask_client:
         m = 3
-        left = naive.stump(T_A, m, T_B=T_B)
-        right = stumped(
+        ref_mp = naive.stump(T_A, m, T_B=T_B)
+        comp_mp = stumped(
             dask_client, pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False
         )
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)

--- a/tests/test_stumped_one_constant_subsequence.py
+++ b/tests/test_stumped_one_constant_subsequence.py
@@ -28,11 +28,11 @@ def test_stumped_one_constant_subsequence_self_join(dask_cluster):
         )
         m = 3
         zone = int(np.ceil(m / 4))
-        left = naive.stump(T_A, m, exclusion_zone=zone)
-        right = stumped(dask_client, T_A, m, ignore_trivial=True)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+        ref_mp = naive.stump(T_A, m, exclusion_zone=zone)
+        comp_mp = stumped(dask_client, T_A, m, ignore_trivial=True)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
 
 @pytest.mark.filterwarnings("ignore:A large number of values are smaller")
@@ -48,11 +48,11 @@ def test_stumped_one_constant_subsequence_self_join_df(dask_cluster):
         )
         m = 3
         zone = int(np.ceil(m / 4))
-        left = naive.stump(T_A, m, exclusion_zone=zone)
-        right = stumped(dask_client, pd.Series(T_A), m, ignore_trivial=True)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+        ref_mp = naive.stump(T_A, m, exclusion_zone=zone)
+        comp_mp = stumped(dask_client, pd.Series(T_A), m, ignore_trivial=True)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
 
 @pytest.mark.filterwarnings("ignore:\\s+A large number of values are smaller")
@@ -68,11 +68,11 @@ def test_stumped_one_constant_subsequence_A_B_join(dask_cluster):
             (np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64))
         )
         m = 3
-        left = naive.stump(T_A, m, T_B=T_B)
-        right = stumped(dask_client, T_A, m, T_B, ignore_trivial=False)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+        ref_mp = naive.stump(T_A, m, T_B=T_B)
+        comp_mp = stumped(dask_client, T_A, m, T_B, ignore_trivial=False)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
 
 @pytest.mark.filterwarnings("ignore:\\s+A large number of values are smaller")
@@ -88,13 +88,13 @@ def test_stumped_one_constant_subsequence_A_B_join_df(dask_cluster):
             (np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64))
         )
         m = 3
-        left = naive.stump(T_A, m, T_B=T_B)
-        right = stumped(
+        ref_mp = naive.stump(T_A, m, T_B=T_B)
+        comp_mp = stumped(
             dask_client, pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False
         )
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
 
 @pytest.mark.filterwarnings("ignore:\\s+A large number of values are smaller")
@@ -110,11 +110,11 @@ def test_stumped_one_constant_subsequence_A_B_join_swap(dask_cluster):
             (np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64))
         )
         m = 3
-        left = naive.stump(T_A, m, T_B=T_B)
-        right = stumped(dask_client, T_A, m, T_B, ignore_trivial=False)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+        ref_mp = naive.stump(T_A, m, T_B=T_B)
+        comp_mp = stumped(dask_client, T_A, m, T_B, ignore_trivial=False)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
 
 @pytest.mark.filterwarnings("ignore:\\s+A large number of values are smaller")
@@ -130,13 +130,13 @@ def test_stumped_one_constant_subsequence_A_B_join_df_swap(dask_cluster):
             (np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64))
         )
         m = 3
-        left = naive.stump(T_A, m, T_B=T_B)
-        right = stumped(
+        ref_mp = naive.stump(T_A, m, T_B=T_B)
+        comp_mp = stumped(
             dask_client, pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False
         )
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
 
 @pytest.mark.filterwarnings("ignore:A large number of values are smaller")
@@ -153,12 +153,12 @@ def test_stumped_identical_subsequence_self_join(dask_cluster):
         T_A[11 : 11 + identical.shape[0]] = identical
         m = 3
         zone = int(np.ceil(m / 4))
-        left = naive.stump(T_A, m, exclusion_zone=zone)
-        right = stumped(dask_client, T_A, m, ignore_trivial=True)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
+        ref_mp = naive.stump(T_A, m, exclusion_zone=zone)
+        comp_mp = stumped(dask_client, T_A, m, ignore_trivial=True)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
         npt.assert_almost_equal(
-            left[:, 0], right[:, 0], decimal=config.STUMPY_TEST_PRECISION
+            ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
         )  # ignore indices
 
 
@@ -176,10 +176,10 @@ def test_stumped_one_constant_subsequence_A_B_join(dask_cluster):
         T_A[1 : 1 + identical.shape[0]] = identical
         T_B[11 : 11 + identical.shape[0]] = identical
         m = 3
-        left = naive.stump(T_A, m, T_B=T_B)
-        right = stumped(dask_client, T_A, m, T_B, ignore_trivial=False)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
+        ref_mp = naive.stump(T_A, m, T_B=T_B)
+        comp_mp = stumped(dask_client, T_A, m, T_B, ignore_trivial=False)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
         npt.assert_almost_equal(
-            left[:, 0], right[:, 0], decimal=config.STUMPY_TEST_PRECISION
+            ref_mp[:, 0], comp_mp[:, 0], decimal=config.STUMPY_TEST_PRECISION
         )  # ignore indices

--- a/tests/test_stumped_one_subsequence_inf_A_B_join.py
+++ b/tests/test_stumped_one_subsequence_inf_A_B_join.py
@@ -44,8 +44,8 @@ def test_stumped_one_subsequence_inf_A_B_join(
         T_B_sub = T_B.copy()
         T_B_sub[substitution_location_B] = np.inf
 
-        left = naive.stump(T_A, m, T_B=T_B_sub)
-        right = stumped(dask_client, T_A, m, T_B_sub, ignore_trivial=False)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        ref_mp = naive.stump(T_A, m, T_B=T_B_sub)
+        comp_mp = stumped(dask_client, T_A, m, T_B_sub, ignore_trivial=False)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)

--- a/tests/test_stumped_one_subsequence_inf_self_join.py
+++ b/tests/test_stumped_one_subsequence_inf_self_join.py
@@ -45,11 +45,11 @@ def test_stumped_one_subsequence_inf_self_join(
         T_B_sub[substitution_location_B] = np.inf
 
         zone = int(np.ceil(m / 4))
-        left = naive.stump(T_B_sub, m, exclusion_zone=zone)
-        right = stumped(dask_client, T_B_sub, m, ignore_trivial=True)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        ref_mp = naive.stump(T_B_sub, m, exclusion_zone=zone)
+        comp_mp = stumped(dask_client, T_B_sub, m, ignore_trivial=True)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)
 
 
 @pytest.mark.filterwarnings("ignore:numpy.dtype size changed")
@@ -62,9 +62,9 @@ def test_stumped_nan_zero_mean_self_join(dask_cluster):
         m = 3
 
         zone = int(np.ceil(m / 4))
-        left = naive.stump(T, m, exclusion_zone=zone)
-        right = stumped(dask_client, T, m, ignore_trivial=True)
+        ref_mp = naive.stump(T, m, exclusion_zone=zone)
+        comp_mp = stumped(dask_client, T, m, ignore_trivial=True)
 
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)

--- a/tests/test_stumped_one_subsequence_nan_A_B_join.py
+++ b/tests/test_stumped_one_subsequence_nan_A_B_join.py
@@ -44,8 +44,8 @@ def test_stumped_one_subsequence_nan_A_B_join(
         T_B_sub = T_B.copy()
         T_B_sub[substitution_location_B] = np.nan
 
-        left = naive.stump(T_A, m, T_B=T_B_sub)
-        right = stumped(dask_client, T_A, m, T_B_sub, ignore_trivial=False)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        ref_mp = naive.stump(T_A, m, T_B=T_B_sub)
+        comp_mp = stumped(dask_client, T_A, m, T_B_sub, ignore_trivial=False)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)

--- a/tests/test_stumped_one_subsequence_nan_self_join.py
+++ b/tests/test_stumped_one_subsequence_nan_self_join.py
@@ -45,8 +45,8 @@ def test_stumped_one_subsequence_nan_self_join(
         T_B_sub[substitution_location_B] = np.nan
 
         zone = int(np.ceil(m / 4))
-        left = naive.stump(T_B_sub, m, exclusion_zone=zone)
-        right = stumped(dask_client, T_B_sub, m, ignore_trivial=True)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        ref_mp = naive.stump(T_B_sub, m, exclusion_zone=zone)
+        comp_mp = stumped(dask_client, T_B_sub, m, ignore_trivial=True)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)

--- a/tests/test_stumped_two_constant_subsequences.py
+++ b/tests/test_stumped_two_constant_subsequences.py
@@ -30,11 +30,11 @@ def test_two_constant_subsequences_A_B_join(dask_cluster):
             (np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64))
         )
         m = 3
-        left = naive.stump(T_A, m, T_B=T_B)
-        right = stumped(dask_client, T_A, m, T_B, ignore_trivial=False)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+        ref_mp = naive.stump(T_A, m, T_B=T_B)
+        comp_mp = stumped(dask_client, T_A, m, T_B, ignore_trivial=False)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
 
 @pytest.mark.filterwarnings("ignore:\\s+A large number of values are smaller")
@@ -52,10 +52,10 @@ def test_two_constant_subsequences_A_B_join_df(dask_cluster):
             (np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64))
         )
         m = 3
-        left = naive.stump(T_A, m, T_B=T_B)
-        right = stumped(
+        ref_mp = naive.stump(T_A, m, T_B=T_B)
+        comp_mp = stumped(
             dask_client, pd.Series(T_A), m, pd.Series(T_B), ignore_trivial=False
         )
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices

--- a/tests/test_stumped_two_constant_subsequences_swap.py
+++ b/tests/test_stumped_two_constant_subsequences_swap.py
@@ -31,11 +31,11 @@ def test_two_constant_subsequences_A_B_join_swap(dask_cluster):
             (np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64))
         )
         m = 3
-        left = naive.stump(T_B, m, T_B=T_A)
-        right = stumped(dask_client, T_B, m, T_A, ignore_trivial=False)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+        ref_mp = naive.stump(T_B, m, T_B=T_A)
+        comp_mp = stumped(dask_client, T_B, m, T_A, ignore_trivial=False)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
 
 @pytest.mark.filterwarnings("ignore:\\s+A large number of values are smaller")
@@ -54,10 +54,10 @@ def test_constant_subsequence_A_B_join_df_swap(dask_cluster):
             (np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64))
         )
         m = 3
-        left = naive.stump(T_B, m, T_B=T_A)
-        right = stumped(
+        ref_mp = naive.stump(T_B, m, T_B=T_A)
+        comp_mp = stumped(
             dask_client, pd.Series(T_B), m, pd.Series(T_A), ignore_trivial=False
         )
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left[:, 0], right[:, 0])  # ignore indices
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices

--- a/tests/test_stumped_two_subsequences_inf_A_B_join.py
+++ b/tests/test_stumped_two_subsequences_inf_A_B_join.py
@@ -48,8 +48,8 @@ def test_stumped_two_subsequences_inf_A_B_join(
         T_A_sub[substitution_location_A] = np.inf
         T_B_sub[substitution_location_B] = np.inf
 
-        left = naive.stump(T_A_sub, m, T_B=T_B_sub)
-        right = stumped(dask_client, T_A_sub, m, T_B_sub, ignore_trivial=False)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        ref_mp = naive.stump(T_A_sub, m, T_B=T_B_sub)
+        comp_mp = stumped(dask_client, T_A_sub, m, T_B_sub, ignore_trivial=False)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)

--- a/tests/test_stumped_two_subsequences_nan_A_B_join.py
+++ b/tests/test_stumped_two_subsequences_nan_A_B_join.py
@@ -48,8 +48,8 @@ def test_stumped_two_subsequences_nan_A_B_join(
         T_A_sub[substitution_location_A] = np.nan
         T_B_sub[substitution_location_B] = np.nan
 
-        left = naive.stump(T_A_sub, m, T_B=T_B_sub)
-        right = stumped(dask_client, T_A_sub, m, T_B_sub, ignore_trivial=False)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        ref_mp = naive.stump(T_A_sub, m, T_B=T_B_sub)
+        comp_mp = stumped(dask_client, T_A_sub, m, T_B_sub, ignore_trivial=False)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)

--- a/tests/test_stumped_two_subsequences_nan_inf_A_B_join.py
+++ b/tests/test_stumped_two_subsequences_nan_inf_A_B_join.py
@@ -48,8 +48,8 @@ def test_stumped_two_subsequences_nan_inf_A_B_join(
         T_A_sub[substitution_location_A] = np.inf
         T_B_sub[substitution_location_B] = np.nan
 
-        left = naive.stump(T_A_sub, m, T_B=T_B_sub)
-        right = stumped(dask_client, T_A_sub, m, T_B_sub, ignore_trivial=False)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        ref_mp = naive.stump(T_A_sub, m, T_B=T_B_sub)
+        comp_mp = stumped(dask_client, T_A_sub, m, T_B_sub, ignore_trivial=False)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)

--- a/tests/test_stumped_two_subsequences_nan_inf_A_B_join_swap.py
+++ b/tests/test_stumped_two_subsequences_nan_inf_A_B_join_swap.py
@@ -48,8 +48,8 @@ def test_stumped_two_subsequences_nan_inf_A_B_join(
         T_A_sub[substitution_location_A] = np.nan
         T_B_sub[substitution_location_B] = np.inf
 
-        left = naive.stump(T_A_sub, m, T_B=T_B_sub)
-        right = stumped(dask_client, T_A_sub, m, T_B_sub, ignore_trivial=False)
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_almost_equal(left, right)
+        ref_mp = naive.stump(T_A_sub, m, T_B=T_B_sub)
+        comp_mp = stumped(dask_client, T_A_sub, m, T_B_sub, ignore_trivial=False)
+        naive.replace_inf(ref_mp)
+        naive.replace_inf(comp_mp)
+        npt.assert_almost_equal(ref_mp, comp_mp)


### PR DESCRIPTION
This patch changes the references of left/right, as discussed in TDAmeritrade/stumpy#235.

This PR (the first) includes the most straightforward changes.

---

Checklist:
- I was able to get`./setup.sh && ./test.sh ` to run without issues.