### PR TITLE
Change more references to left/right in tests

### DIFF
--- a/tests/test_aampi.py
+++ b/tests/test_aampi.py
@@ -28,30 +28,30 @@ def test_aampi_self_join():
         t = np.random.rand()
         stream.update(t)
 
-    right_P = stream.P_
-    right_I = stream.I_
-    right_left_P = stream.left_P_
-    right_left_I = stream.left_I_
+    comp_P = stream.P_
+    comp_I = stream.I_
+    comp_left_P = stream.left_P_
+    comp_left_I = stream.left_I_
 
-    left = naive.aamp(stream.T_, m)
-    left_P = left[:, 0]
-    left_I = left[:, 1]
-    left_left_P = np.full(left_P.shape, np.inf)
-    left_left_I = left[:, 2]
-    for i, j in enumerate(left_left_I):
+    ref_mp = naive.aamp(stream.T_, m)
+    ref_P = ref_mp[:, 0]
+    ref_I = ref_mp[:, 1]
+    ref_left_P = np.full(ref_P.shape, np.inf)
+    ref_left_I = ref_mp[:, 2]
+    for i, j in enumerate(ref_left_I):
         if j >= 0:
             D = core.mass_absolute(stream.T_[i : i + m], stream.T_[j : j + m])
-            left_left_P[i] = D[0]
+            ref_left_P[i] = D[0]
 
-    naive.replace_inf(left_P)
-    naive.replace_inf(left_left_P)
-    naive.replace_inf(right_P)
-    naive.replace_inf(right_left_P)
+    naive.replace_inf(ref_P)
+    naive.replace_inf(ref_left_P)
+    naive.replace_inf(comp_P)
+    naive.replace_inf(comp_left_P)
 
-    npt.assert_almost_equal(left_P, right_P)
-    npt.assert_almost_equal(left_I, right_I)
-    npt.assert_almost_equal(left_left_P, right_left_P)
-    npt.assert_almost_equal(left_left_I, right_left_I)
+    npt.assert_almost_equal(ref_P, comp_P)
+    npt.assert_almost_equal(ref_I, comp_I)
+    npt.assert_almost_equal(ref_left_P, comp_left_P)
+    npt.assert_almost_equal(ref_left_I, comp_left_I)
 
     np.random.seed(seed)
     n = 30
@@ -62,18 +62,18 @@ def test_aampi_self_join():
         t = np.random.rand()
         stream.update(t)
 
-    right_P = stream.P_
-    right_I = stream.I_
-    right_left_P = stream.left_P_
-    right_left_I = stream.left_I_
+    comp_P = stream.P_
+    comp_I = stream.I_
+    comp_left_P = stream.left_P_
+    comp_left_I = stream.left_I_
 
-    naive.replace_inf(right_P)
-    naive.replace_inf(right_left_P)
+    naive.replace_inf(comp_P)
+    naive.replace_inf(comp_left_P)
 
-    npt.assert_almost_equal(left_P, right_P)
-    npt.assert_almost_equal(left_I, right_I)
-    npt.assert_almost_equal(left_left_P, right_left_P)
-    npt.assert_almost_equal(left_left_I, right_left_I)
+    npt.assert_almost_equal(ref_P, comp_P)
+    npt.assert_almost_equal(ref_I, comp_I)
+    npt.assert_almost_equal(ref_left_P, comp_left_P)
+    npt.assert_almost_equal(ref_left_I, comp_left_I)
 
 
 def test_aampi_self_join_egress():
@@ -86,99 +86,99 @@ def test_aampi_self_join_egress():
     n = 30
     T = np.random.rand(n)
 
-    left = naive.aampi_egress(T, m)
-    left_P = left.P_.copy()
-    left_I = left.I_
-    left_left_P = left.left_P_.copy()
-    left_left_I = left.left_I_
+    ref_mp = naive.aampi_egress(T, m)
+    ref_P = ref_mp.P_.copy()
+    ref_I = ref_mp.I_
+    ref_left_P = ref_mp.left_P_.copy()
+    ref_left_I = ref_mp.left_I_
 
     stream = aampi(T, m, egress=True)
 
-    right_P = stream.P_.copy()
-    right_I = stream.I_
-    right_left_P = stream.left_P_.copy()
-    right_left_I = stream.left_I_
+    comp_P = stream.P_.copy()
+    comp_I = stream.I_
+    comp_left_P = stream.left_P_.copy()
+    comp_left_I = stream.left_I_
 
-    naive.replace_inf(left_P)
-    naive.replace_inf(left_left_P)
-    naive.replace_inf(right_P)
-    naive.replace_inf(right_left_P)
+    naive.replace_inf(ref_P)
+    naive.replace_inf(ref_left_P)
+    naive.replace_inf(comp_P)
+    naive.replace_inf(comp_left_P)
 
-    npt.assert_almost_equal(left_P, right_P)
-    npt.assert_almost_equal(left_I, right_I)
-    npt.assert_almost_equal(left_left_P, right_left_P)
-    npt.assert_almost_equal(left_left_I, right_left_I)
+    npt.assert_almost_equal(ref_P, comp_P)
+    npt.assert_almost_equal(ref_I, comp_I)
+    npt.assert_almost_equal(ref_left_P, comp_left_P)
+    npt.assert_almost_equal(ref_left_I, comp_left_I)
 
     for i in range(34):
         t = np.random.rand()
 
-        left.update(t)
+        ref_mp.update(t)
         stream.update(t)
 
-        right_P = stream.P_.copy()
-        right_I = stream.I_
-        right_left_P = stream.left_P_.copy()
-        right_left_I = stream.left_I_
+        comp_P = stream.P_.copy()
+        comp_I = stream.I_
+        comp_left_P = stream.left_P_.copy()
+        comp_left_I = stream.left_I_
 
-        left_P = left.P_.copy()
-        left_I = left.I_
-        left_left_P = left.left_P_.copy()
-        left_left_I = left.left_I_
+        ref_P = ref_mp.P_.copy()
+        ref_I = ref_mp.I_
+        ref_left_P = ref_mp.left_P_.copy()
+        ref_left_I = ref_mp.left_I_
 
-        naive.replace_inf(left_P)
-        naive.replace_inf(left_left_P)
-        naive.replace_inf(right_P)
-        naive.replace_inf(right_left_P)
+        naive.replace_inf(ref_P)
+        naive.replace_inf(ref_left_P)
+        naive.replace_inf(comp_P)
+        naive.replace_inf(comp_left_P)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
-        npt.assert_almost_equal(left_left_P, right_left_P)
-        npt.assert_almost_equal(left_left_I, right_left_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
+        npt.assert_almost_equal(ref_left_P, comp_left_P)
+        npt.assert_almost_equal(ref_left_I, comp_left_I)
 
     np.random.seed(seed)
     T = np.random.rand(n)
     T = pd.Series(T)
 
-    left = naive.aampi_egress(T, m)
-    left_P = left.P_.copy()
-    left_I = left.I_
+    ref_mp = naive.aampi_egress(T, m)
+    ref_P = ref_mp.P_.copy()
+    ref_I = ref_mp.I_
 
     stream = aampi(T, m, egress=True)
 
-    right_P = stream.P_.copy()
-    right_I = stream.I_
+    comp_P = stream.P_.copy()
+    comp_I = stream.I_
 
-    naive.replace_inf(left_P)
-    naive.replace_inf(right_P)
+    naive.replace_inf(ref_P)
+    naive.replace_inf(comp_P)
 
-    npt.assert_almost_equal(left_P, right_P)
-    npt.assert_almost_equal(left_I, right_I)
+    npt.assert_almost_equal(ref_P, comp_P)
+    npt.assert_almost_equal(ref_I, comp_I)
 
     for i in range(34):
         t = np.random.rand()
 
-        left.update(t)
+        ref_mp.update(t)
         stream.update(t)
 
-        right_P = stream.P_.copy()
-        right_I = stream.I_
-        right_left_P = stream.left_P_.copy()
-        right_left_I = stream.left_I_
+        comp_P = stream.P_.copy()
+        comp_I = stream.I_
+        comp_left_P = stream.left_P_.copy()
+        comp_left_I = stream.left_I_
 
-        left_P = left.P_.copy()
-        left_I = left.I_
-        left_left_P = left.left_P_.copy()
-        left_left_I = left.left_I_
+        ref_P = ref_mp.P_.copy()
+        ref_I = ref_mp.I_
+        ref_left_P = ref_mp.left_P_.copy()
+        ref_left_I = ref_mp.left_I_
 
-        naive.replace_inf(left_P)
-        naive.replace_inf(left_left_P)
-        naive.replace_inf(right_P)
-        naive.replace_inf(right_left_P)
+        naive.replace_inf(ref_P)
+        naive.replace_inf(ref_left_P)
+        naive.replace_inf(comp_P)
+        naive.replace_inf(comp_left_P)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
-        npt.assert_almost_equal(left_left_P, right_left_P)
-        npt.assert_almost_equal(left_left_I, right_left_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
+        npt.assert_almost_equal(ref_left_P, comp_left_P)
+        npt.assert_almost_equal(ref_left_I, comp_left_I)
 
 
 @pytest.mark.parametrize("substitute", substitution_values)
@@ -203,18 +203,18 @@ def test_aampi_init_nan_inf_self_join(substitute, substitution_locations):
             t = np.random.rand()
             stream.update(t)
 
-        right_P = stream.P_
-        right_I = stream.I_
+        comp_P = stream.P_
+        comp_I = stream.I_
 
         stream.T_[substitution_location] = substitute
-        left = naive.aamp(stream.T_, m)
-        left_P = left[:, 0]
-        left_I = left[:, 1]
+        ref_mp = naive.aamp(stream.T_, m)
+        ref_P = ref_mp[:, 0]
+        ref_I = ref_mp[:, 1]
 
-        naive.replace_inf(left_P)
-        naive.replace_inf(right_P)
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
+        naive.replace_inf(ref_P)
+        naive.replace_inf(comp_P)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
 
         np.random.seed(seed)
         n = 30
@@ -229,13 +229,13 @@ def test_aampi_init_nan_inf_self_join(substitute, substitution_locations):
             t = np.random.rand()
             stream.update(t)
 
-        right_P = stream.P_
-        right_I = stream.I_
+        comp_P = stream.P_
+        comp_I = stream.I_
 
-        naive.replace_inf(right_P)
+        naive.replace_inf(comp_P)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
 
 
 @pytest.mark.parametrize("substitute", substitution_values)
@@ -256,103 +256,103 @@ def test_aampi_init_nan_inf_self_join_egress(substitute, substitution_locations)
             substitution_location = T.shape[0] - 1
         T[substitution_location] = substitute
 
-        left = naive.aampi_egress(T, m)
-        left_P = left.P_.copy()
-        left_I = left.I_
-        left_left_P = left.left_P_.copy()
-        left_left_I = left.left_I_
+        ref_mp = naive.aampi_egress(T, m)
+        ref_P = ref_mp.P_.copy()
+        ref_I = ref_mp.I_
+        ref_left_P = ref_mp.left_P_.copy()
+        ref_left_I = ref_mp.left_I_
 
         stream = aampi(T, m, egress=True)
 
-        right_P = stream.P_.copy()
-        right_I = stream.I_
-        right_left_P = stream.left_P_.copy()
-        right_left_I = stream.left_I_
+        comp_P = stream.P_.copy()
+        comp_I = stream.I_
+        comp_left_P = stream.left_P_.copy()
+        comp_left_I = stream.left_I_
 
-        naive.replace_inf(left_P)
-        naive.replace_inf(right_P)
-        naive.replace_inf(left_left_P)
-        naive.replace_inf(right_left_P)
+        naive.replace_inf(ref_P)
+        naive.replace_inf(comp_P)
+        naive.replace_inf(ref_left_P)
+        naive.replace_inf(comp_left_P)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
-        npt.assert_almost_equal(left_left_P, right_left_P)
-        npt.assert_almost_equal(left_left_I, right_left_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
+        npt.assert_almost_equal(ref_left_P, comp_left_P)
+        npt.assert_almost_equal(ref_left_I, comp_left_I)
 
         for i in range(34):
             t = np.random.rand()
 
-            left.update(t)
+            ref_mp.update(t)
             stream.update(t)
 
-            right_P = stream.P_.copy()
-            right_I = stream.I_
-            right_left_P = stream.left_P_.copy()
-            right_left_I = stream.left_I_
+            comp_P = stream.P_.copy()
+            comp_I = stream.I_
+            comp_left_P = stream.left_P_.copy()
+            comp_left_I = stream.left_I_
 
-            left_P = left.P_.copy()
-            left_I = left.I_
-            left_left_P = left.left_P_.copy()
-            left_left_I = left.left_I_
+            ref_P = ref_mp.P_.copy()
+            ref_I = ref_mp.I_
+            ref_left_P = ref_mp.left_P_.copy()
+            ref_left_I = ref_mp.left_I_
 
-            naive.replace_inf(left_P)
-            naive.replace_inf(left_left_P)
-            naive.replace_inf(right_P)
-            naive.replace_inf(right_left_P)
+            naive.replace_inf(ref_P)
+            naive.replace_inf(ref_left_P)
+            naive.replace_inf(comp_P)
+            naive.replace_inf(comp_left_P)
 
-            npt.assert_almost_equal(left_P, right_P)
-            npt.assert_almost_equal(left_I, right_I)
-            npt.assert_almost_equal(left_left_P, right_left_P)
-            npt.assert_almost_equal(left_left_I, right_left_I)
+            npt.assert_almost_equal(ref_P, comp_P)
+            npt.assert_almost_equal(ref_I, comp_I)
+            npt.assert_almost_equal(ref_left_P, comp_left_P)
+            npt.assert_almost_equal(ref_left_I, comp_left_I)
 
         np.random.seed(seed)
         n = 30
         T = np.random.rand(n)
         T = pd.Series(T)
 
-        left = naive.aampi_egress(T, m)
-        left_P = left.P_.copy()
-        left_I = left.I_
-        left_left_P = left.left_P_.copy()
-        left_left_I = left.left_I_
+        ref_mp = naive.aampi_egress(T, m)
+        ref_P = ref_mp.P_.copy()
+        ref_I = ref_mp.I_
+        ref_left_P = ref_mp.left_P_.copy()
+        ref_left_I = ref_mp.left_I_
 
         stream = aampi(T, m, egress=True)
 
-        right_P = stream.P_.copy()
-        right_I = stream.I_
-        right_left_P = stream.left_P_.copy()
-        right_left_I = stream.left_I_
+        comp_P = stream.P_.copy()
+        comp_I = stream.I_
+        comp_left_P = stream.left_P_.copy()
+        comp_left_I = stream.left_I_
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
-        naive.replace_inf(left_left_P)
-        naive.replace_inf(right_left_P)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
+        naive.replace_inf(ref_left_P)
+        naive.replace_inf(comp_left_P)
 
         for i in range(34):
             t = np.random.rand()
 
-            left.update(t)
+            ref_mp.update(t)
             stream.update(t)
 
-            right_P = stream.P_.copy()
-            right_I = stream.I_
-            right_left_P = stream.left_P_.copy()
-            right_left_I = stream.left_I_
+            comp_P = stream.P_.copy()
+            comp_I = stream.I_
+            comp_left_P = stream.left_P_.copy()
+            comp_left_I = stream.left_I_
 
-            left_P = left.P_.copy()
-            left_I = left.I_
-            left_left_P = left.left_P_.copy()
-            left_left_I = left.left_I_
+            ref_P = ref_mp.P_.copy()
+            ref_I = ref_mp.I_
+            ref_left_P = ref_mp.left_P_.copy()
+            ref_left_I = ref_mp.left_I_
 
-            naive.replace_inf(left_P)
-            naive.replace_inf(left_left_P)
-            naive.replace_inf(right_P)
-            naive.replace_inf(right_left_P)
+            naive.replace_inf(ref_P)
+            naive.replace_inf(ref_left_P)
+            naive.replace_inf(comp_P)
+            naive.replace_inf(comp_left_P)
 
-            npt.assert_almost_equal(left_P, right_P)
-            npt.assert_almost_equal(left_I, right_I)
-            npt.assert_almost_equal(left_left_P, right_left_P)
-            npt.assert_almost_equal(left_left_I, right_left_I)
+            npt.assert_almost_equal(ref_P, comp_P)
+            npt.assert_almost_equal(ref_I, comp_I)
+            npt.assert_almost_equal(ref_left_P, comp_left_P)
+            npt.assert_almost_equal(ref_left_I, comp_left_I)
 
 
 @pytest.mark.parametrize("substitute", substitution_values)
@@ -375,19 +375,19 @@ def test_aampi_stream_nan_inf_self_join(substitute, substitution_locations):
         for t in T[n:]:
             stream.update(t)
 
-        right_P = stream.P_
-        right_I = stream.I_
+        comp_P = stream.P_
+        comp_I = stream.I_
 
         stream.T_[n:][substitution_location] = substitute
-        left = naive.aamp(stream.T_, m)
-        left_P = left[:, 0]
-        left_I = left[:, 1]
+        ref_mp = naive.aamp(stream.T_, m)
+        ref_P = ref_mp[:, 0]
+        ref_I = ref_mp[:, 1]
 
-        naive.replace_inf(left_P)
-        naive.replace_inf(right_P)
+        naive.replace_inf(ref_P)
+        naive.replace_inf(comp_P)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
 
         np.random.seed(seed)
         T = np.random.rand(64)
@@ -399,13 +399,13 @@ def test_aampi_stream_nan_inf_self_join(substitute, substitution_locations):
         for t in T[n:]:
             stream.update(t)
 
-        right_P = stream.P_
-        right_I = stream.I_
+        comp_P = stream.P_
+        comp_I = stream.I_
 
-        naive.replace_inf(right_P)
+        naive.replace_inf(comp_P)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
 
 
 @pytest.mark.parametrize("substitute", substitution_values)
@@ -421,107 +421,107 @@ def test_aampi_stream_nan_inf_self_join_egress(substitute, substitution_location
         n = 30
         T = np.random.rand(64)
 
-        left = naive.aampi_egress(T[:n], m)
-        left_P = left.P_.copy()
-        left_I = left.I_
-        left_left_P = left.left_P_.copy()
-        left_left_I = left.left_I_
+        ref_mp = naive.aampi_egress(T[:n], m)
+        ref_P = ref_mp.P_.copy()
+        ref_I = ref_mp.I_
+        ref_left_P = ref_mp.left_P_.copy()
+        ref_left_I = ref_mp.left_I_
 
         stream = aampi(T[:n], m, egress=True)
 
-        right_P = stream.P_.copy()
-        right_I = stream.I_
-        right_left_P = stream.left_P_.copy()
-        right_left_I = stream.left_I_
+        comp_P = stream.P_.copy()
+        comp_I = stream.I_
+        comp_left_P = stream.left_P_.copy()
+        comp_left_I = stream.left_I_
 
-        naive.replace_inf(left_P)
-        naive.replace_inf(right_P)
-        naive.replace_inf(left_left_P)
-        naive.replace_inf(right_left_P)
+        naive.replace_inf(ref_P)
+        naive.replace_inf(comp_P)
+        naive.replace_inf(ref_left_P)
+        naive.replace_inf(comp_left_P)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
-        npt.assert_almost_equal(left_left_P, right_left_P)
-        npt.assert_almost_equal(left_left_I, right_left_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
+        npt.assert_almost_equal(ref_left_P, comp_left_P)
+        npt.assert_almost_equal(ref_left_I, comp_left_I)
 
         if substitution_location == -1:
             substitution_location = T[n:].shape[0] - 1
         T[n:][substitution_location] = substitute
         for t in T[n:]:
-            left.update(t)
+            ref_mp.update(t)
             stream.update(t)
 
-            right_P = stream.P_.copy()
-            right_I = stream.I_
-            right_left_P = stream.left_P_.copy()
-            right_left_I = stream.left_I_
+            comp_P = stream.P_.copy()
+            comp_I = stream.I_
+            comp_left_P = stream.left_P_.copy()
+            comp_left_I = stream.left_I_
 
-            left_P = left.P_.copy()
-            left_I = left.I_
-            left_left_P = left.left_P_.copy()
-            left_left_I = left.left_I_
+            ref_P = ref_mp.P_.copy()
+            ref_I = ref_mp.I_
+            ref_left_P = ref_mp.left_P_.copy()
+            ref_left_I = ref_mp.left_I_
 
-            naive.replace_inf(left_P)
-            naive.replace_inf(left_left_P)
-            naive.replace_inf(right_P)
-            naive.replace_inf(right_left_P)
+            naive.replace_inf(ref_P)
+            naive.replace_inf(ref_left_P)
+            naive.replace_inf(comp_P)
+            naive.replace_inf(comp_left_P)
 
-            npt.assert_almost_equal(left_P, right_P)
-            npt.assert_almost_equal(left_I, right_I)
-            npt.assert_almost_equal(left_left_P, right_left_P)
-            npt.assert_almost_equal(left_left_I, right_left_I)
+            npt.assert_almost_equal(ref_P, comp_P)
+            npt.assert_almost_equal(ref_I, comp_I)
+            npt.assert_almost_equal(ref_left_P, comp_left_P)
+            npt.assert_almost_equal(ref_left_I, comp_left_I)
 
         np.random.seed(seed)
         T = np.random.rand(64)
 
-        left = naive.aampi_egress(T[:n], m)
-        left_P = left.P_.copy()
-        left_I = left.I_
-        left_left_P = left.left_P_.copy()
-        left_left_I = left.left_I_
+        ref_mp = naive.aampi_egress(T[:n], m)
+        ref_P = ref_mp.P_.copy()
+        ref_I = ref_mp.I_
+        ref_left_P = ref_mp.left_P_.copy()
+        ref_left_I = ref_mp.left_I_
 
         stream = aampi(pd.Series(T[:n]), m, egress=True)
 
-        right_P = stream.P_.copy()
-        right_I = stream.I_
-        right_left_P = stream.left_P_.copy()
-        right_left_I = stream.left_I_
+        comp_P = stream.P_.copy()
+        comp_I = stream.I_
+        comp_left_P = stream.left_P_.copy()
+        comp_left_I = stream.left_I_
 
-        naive.replace_inf(left_P)
-        naive.replace_inf(right_P)
-        naive.replace_inf(left_left_P)
-        naive.replace_inf(right_left_P)
+        naive.replace_inf(ref_P)
+        naive.replace_inf(comp_P)
+        naive.replace_inf(ref_left_P)
+        naive.replace_inf(comp_left_P)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
-        npt.assert_almost_equal(left_left_P, right_left_P)
-        npt.assert_almost_equal(left_left_I, right_left_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
+        npt.assert_almost_equal(ref_left_P, comp_left_P)
+        npt.assert_almost_equal(ref_left_I, comp_left_I)
         if substitution_location == -1:
             substitution_location = T[n:].shape[0] - 1
         T[n:][substitution_location] = substitute
         for t in T[n:]:
-            left.update(t)
+            ref_mp.update(t)
             stream.update(t)
 
-            right_P = stream.P_.copy()
-            right_I = stream.I_
-            right_left_P = stream.left_P_.copy()
-            right_left_I = stream.left_I_
+            comp_P = stream.P_.copy()
+            comp_I = stream.I_
+            comp_left_P = stream.left_P_.copy()
+            comp_left_I = stream.left_I_
 
-            left_P = left.P_.copy()
-            left_I = left.I_
-            left_left_P = left.left_P_.copy()
-            left_left_I = left.left_I_
+            ref_P = ref_mp.P_.copy()
+            ref_I = ref_mp.I_
+            ref_left_P = ref_mp.left_P_.copy()
+            ref_left_I = ref_mp.left_I_
 
-            naive.replace_inf(left_P)
-            naive.replace_inf(left_left_P)
-            naive.replace_inf(right_P)
-            naive.replace_inf(right_left_P)
+            naive.replace_inf(ref_P)
+            naive.replace_inf(ref_left_P)
+            naive.replace_inf(comp_P)
+            naive.replace_inf(comp_left_P)
 
-            npt.assert_almost_equal(left_P, right_P)
-            npt.assert_almost_equal(left_I, right_I)
-            npt.assert_almost_equal(left_left_P, right_left_P)
-            npt.assert_almost_equal(left_left_I, right_left_I)
+            npt.assert_almost_equal(ref_P, comp_P)
+            npt.assert_almost_equal(ref_I, comp_I)
+            npt.assert_almost_equal(ref_left_P, comp_left_P)
+            npt.assert_almost_equal(ref_left_I, comp_left_I)
 
 
 def test_aampi_constant_subsequence_self_join():
@@ -537,18 +537,18 @@ def test_aampi_constant_subsequence_self_join():
         t = np.random.rand()
         stream.update(t)
 
-    right_P = stream.P_
-    right_I = stream.I_
+    comp_P = stream.P_
+    comp_I = stream.I_
 
-    left = naive.aamp(stream.T_, m)
-    left_P = left[:, 0]
-    left_I = left[:, 1]
+    ref_mp = naive.aamp(stream.T_, m)
+    ref_P = ref_mp[:, 0]
+    ref_I = ref_mp[:, 1]
 
-    naive.replace_inf(left_P)
-    naive.replace_inf(right_P)
+    naive.replace_inf(ref_P)
+    naive.replace_inf(comp_P)
 
-    npt.assert_almost_equal(left_P, right_P)
-    # npt.assert_almost_equal(left_I, right_I)
+    npt.assert_almost_equal(ref_P, comp_P)
+    # npt.assert_almost_equal(ref_I, comp_I)
 
     np.random.seed(seed)
     T = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(10, dtype=np.float64)))
@@ -558,13 +558,13 @@ def test_aampi_constant_subsequence_self_join():
         t = np.random.rand()
         stream.update(t)
 
-    right_P = stream.P_
-    right_I = stream.I_
+    comp_P = stream.P_
+    comp_I = stream.I_
 
-    naive.replace_inf(right_P)
+    naive.replace_inf(comp_P)
 
-    npt.assert_almost_equal(left_P, right_P)
-    # npt.assert_almost_equal(left_I, right_I)
+    npt.assert_almost_equal(ref_P, comp_P)
+    # npt.assert_almost_equal(ref_I, comp_I)
 
 
 def test_aampi_constant_subsequence_self_join_egress():
@@ -576,105 +576,105 @@ def test_aampi_constant_subsequence_self_join_egress():
 
     T = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(10, dtype=np.float64)))
 
-    left = naive.aampi_egress(T, m)
-    left_P = left.P_.copy()
-    left_I = left.I_
-    left_left_P = left.left_P_.copy()
-    left_left_I = left.left_I_
+    ref_mp = naive.aampi_egress(T, m)
+    ref_P = ref_mp.P_.copy()
+    ref_I = ref_mp.I_
+    ref_left_P = ref_mp.left_P_.copy()
+    ref_left_I = ref_mp.left_I_
 
     stream = aampi(T, m, egress=True)
 
-    right_P = stream.P_.copy()
-    right_I = stream.I_
-    right_left_P = stream.left_P_.copy()
-    right_left_I = stream.left_I_
+    comp_P = stream.P_.copy()
+    comp_I = stream.I_
+    comp_left_P = stream.left_P_.copy()
+    comp_left_I = stream.left_I_
 
-    naive.replace_inf(left_P)
-    naive.replace_inf(right_P)
-    naive.replace_inf(left_left_P)
-    naive.replace_inf(right_left_P)
+    naive.replace_inf(ref_P)
+    naive.replace_inf(comp_P)
+    naive.replace_inf(ref_left_P)
+    naive.replace_inf(comp_left_P)
 
-    npt.assert_almost_equal(left_P, right_P)
-    # npt.assert_almost_equal(left_I, right_I)
-    npt.assert_almost_equal(left_left_P, right_left_P)
-    # npt.assert_almost_equal(left_left_I, right_left_I)
+    npt.assert_almost_equal(ref_P, comp_P)
+    # npt.assert_almost_equal(ref_I, comp_I)
+    npt.assert_almost_equal(ref_left_P, comp_left_P)
+    # npt.assert_almost_equal(ref_left_I, comp_left_I)
 
     for i in range(34):
         t = np.random.rand()
-        left.update(t)
+        ref_mp.update(t)
         stream.update(t)
 
-        right_P = stream.P_.copy()
-        right_I = stream.I_
-        right_left_P = stream.left_P_.copy()
-        right_left_I = stream.left_I_
+        comp_P = stream.P_.copy()
+        comp_I = stream.I_
+        comp_left_P = stream.left_P_.copy()
+        comp_left_I = stream.left_I_
 
-        left_P = left.P_.copy()
-        left_I = left.I_
-        left_left_P = left.left_P_.copy()
-        left_left_I = left.left_I_
+        ref_P = ref_mp.P_.copy()
+        ref_I = ref_mp.I_
+        ref_left_P = ref_mp.left_P_.copy()
+        ref_left_I = ref_mp.left_I_
 
-        naive.replace_inf(left_P)
-        naive.replace_inf(left_left_P)
-        naive.replace_inf(right_P)
-        naive.replace_inf(right_left_P)
+        naive.replace_inf(ref_P)
+        naive.replace_inf(ref_left_P)
+        naive.replace_inf(comp_P)
+        naive.replace_inf(comp_left_P)
 
-        npt.assert_almost_equal(left_P, right_P)
-        # npt.assert_almost_equal(left_I, right_I)
-        npt.assert_almost_equal(left_left_P, right_left_P)
-        # npt.assert_almost_equal(left_left_I, right_left_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        # npt.assert_almost_equal(ref_I, comp_I)
+        npt.assert_almost_equal(ref_left_P, comp_left_P)
+        # npt.assert_almost_equal(ref_left_I, comp_left_I)
 
     np.random.seed(seed)
     T = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(10, dtype=np.float64)))
     T = pd.Series(T)
 
-    left = naive.aampi_egress(T, m)
-    left_P = left.P_.copy()
-    left_I = left.I_
-    left_left_P = left.left_P_.copy()
-    left_left_I = left.left_I_
+    ref_mp = naive.aampi_egress(T, m)
+    ref_P = ref_mp.P_.copy()
+    ref_I = ref_mp.I_
+    ref_left_P = ref_mp.left_P_.copy()
+    ref_left_I = ref_mp.left_I_
 
     stream = aampi(T, m, egress=True)
 
-    right_P = stream.P_.copy()
-    right_I = stream.I_
-    right_left_P = stream.left_P_.copy()
-    right_left_I = stream.left_I_
+    comp_P = stream.P_.copy()
+    comp_I = stream.I_
+    comp_left_P = stream.left_P_.copy()
+    comp_left_I = stream.left_I_
 
-    naive.replace_inf(left_P)
-    naive.replace_inf(right_P)
-    naive.replace_inf(left_left_P)
-    naive.replace_inf(right_left_P)
+    naive.replace_inf(ref_P)
+    naive.replace_inf(comp_P)
+    naive.replace_inf(ref_left_P)
+    naive.replace_inf(comp_left_P)
 
-    npt.assert_almost_equal(left_P, right_P)
-    # npt.assert_almost_equal(left_I, right_I)
-    npt.assert_almost_equal(left_left_P, right_left_P)
-    # npt.assert_almost_equal(left_left_I, right_left_I)
+    npt.assert_almost_equal(ref_P, comp_P)
+    # npt.assert_almost_equal(ref_I, comp_I)
+    npt.assert_almost_equal(ref_left_P, comp_left_P)
+    # npt.assert_almost_equal(ref_left_I, comp_left_I)
 
     for i in range(34):
         t = np.random.rand()
-        left.update(t)
+        ref_mp.update(t)
         stream.update(t)
 
-        right_P = stream.P_.copy()
-        right_I = stream.I_
-        right_left_P = stream.left_P_.copy()
-        right_left_I = stream.left_I_
+        comp_P = stream.P_.copy()
+        comp_I = stream.I_
+        comp_left_P = stream.left_P_.copy()
+        comp_left_I = stream.left_I_
 
-        left_P = left.P_.copy()
-        left_I = left.I_
-        left_left_P = left.left_P_.copy()
-        left_left_I = left.left_I_
+        ref_P = ref_mp.P_.copy()
+        ref_I = ref_mp.I_
+        ref_left_P = ref_mp.left_P_.copy()
+        ref_left_I = ref_mp.left_I_
 
-        naive.replace_inf(left_P)
-        naive.replace_inf(left_left_P)
-        naive.replace_inf(right_P)
-        naive.replace_inf(right_left_P)
+        naive.replace_inf(ref_P)
+        naive.replace_inf(ref_left_P)
+        naive.replace_inf(comp_P)
+        naive.replace_inf(comp_left_P)
 
-        npt.assert_almost_equal(left_P, right_P)
-        # npt.assert_almost_equal(left_I, right_I)
-        npt.assert_almost_equal(left_left_P, right_left_P)
-        # npt.assert_almost_equal(left_left_I, right_left_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        # npt.assert_almost_equal(ref_I, comp_I)
+        npt.assert_almost_equal(ref_left_P, comp_left_P)
+        # npt.assert_almost_equal(ref_left_I, comp_left_I)
 
 
 def test_aampi_identical_subsequence_self_join():
@@ -693,18 +693,18 @@ def test_aampi_identical_subsequence_self_join():
         t = np.random.rand()
         stream.update(t)
 
-    right_P = stream.P_
-    right_I = stream.I_
+    comp_P = stream.P_
+    comp_I = stream.I_
 
-    left = naive.aamp(stream.T_, m)
-    left_P = left[:, 0]
-    left_I = left[:, 1]
+    ref_mp = naive.aamp(stream.T_, m)
+    ref_P = ref_mp[:, 0]
+    ref_I = ref_mp[:, 1]
 
-    naive.replace_inf(left_P)
-    naive.replace_inf(right_P)
+    naive.replace_inf(ref_P)
+    naive.replace_inf(comp_P)
 
-    npt.assert_almost_equal(left_P, right_P, decimal=config.STUMPY_TEST_PRECISION)
-    # npt.assert_almost_equal(left_I, right_I)
+    npt.assert_almost_equal(ref_P, comp_P, decimal=config.STUMPY_TEST_PRECISION)
+    # npt.assert_almost_equal(ref_I, comp_I)
 
     np.random.seed(seed)
     identical = np.random.rand(8)
@@ -717,13 +717,13 @@ def test_aampi_identical_subsequence_self_join():
         t = np.random.rand()
         stream.update(t)
 
-    right_P = stream.P_
-    right_I = stream.I_
+    comp_P = stream.P_
+    comp_I = stream.I_
 
-    naive.replace_inf(right_P)
+    naive.replace_inf(comp_P)
 
-    npt.assert_almost_equal(left_P, right_P, decimal=config.STUMPY_TEST_PRECISION)
-    # npt.assert_almost_equal(left_I, right_I)
+    npt.assert_almost_equal(ref_P, comp_P, decimal=config.STUMPY_TEST_PRECISION)
+    # npt.assert_almost_equal(ref_I, comp_I)
 
 
 def test_aampi_identical_subsequence_self_join_egress():
@@ -738,57 +738,57 @@ def test_aampi_identical_subsequence_self_join_egress():
     T[1 : 1 + identical.shape[0]] = identical
     T[11 : 11 + identical.shape[0]] = identical
 
-    left = naive.aampi_egress(T, m)
-    left_P = left.P_.copy()
-    left_I = left.I_
-    left_left_P = left.left_P_.copy()
-    left_left_I = left.left_I_
+    ref_mp = naive.aampi_egress(T, m)
+    ref_P = ref_mp.P_.copy()
+    ref_I = ref_mp.I_
+    ref_left_P = ref_mp.left_P_.copy()
+    ref_left_I = ref_mp.left_I_
 
     stream = aampi(T, m, egress=True)
 
-    right_P = stream.P_.copy()
-    right_I = stream.I_
-    right_left_P = stream.left_P_.copy()
-    right_left_I = stream.left_I_
+    comp_P = stream.P_.copy()
+    comp_I = stream.I_
+    comp_left_P = stream.left_P_.copy()
+    comp_left_I = stream.left_I_
 
-    naive.replace_inf(left_P)
-    naive.replace_inf(right_P)
-    naive.replace_inf(left_left_P)
-    naive.replace_inf(right_left_P)
+    naive.replace_inf(ref_P)
+    naive.replace_inf(comp_P)
+    naive.replace_inf(ref_left_P)
+    naive.replace_inf(comp_left_P)
 
-    npt.assert_almost_equal(left_P, right_P, decimal=config.STUMPY_TEST_PRECISION)
-    # npt.assert_almost_equal(left_I, right_I)
+    npt.assert_almost_equal(ref_P, comp_P, decimal=config.STUMPY_TEST_PRECISION)
+    # npt.assert_almost_equal(ref_I, comp_I)
     npt.assert_almost_equal(
-        left_left_P, right_left_P, decimal=config.STUMPY_TEST_PRECISION
+        ref_left_P, comp_left_P, decimal=config.STUMPY_TEST_PRECISION
     )
-    # npt.assert_almost_equal(left_left_I, right_left_I)
+    # npt.assert_almost_equal(ref_left_I, comp_left_I)
 
     for i in range(34):
         t = np.random.rand()
-        left.update(t)
+        ref_mp.update(t)
         stream.update(t)
 
-        right_P = stream.P_.copy()
-        right_I = stream.I_
-        right_left_P = stream.left_P_.copy()
-        right_left_I = stream.left_I_
+        comp_P = stream.P_.copy()
+        comp_I = stream.I_
+        comp_left_P = stream.left_P_.copy()
+        comp_left_I = stream.left_I_
 
-        left_P = left.P_.copy()
-        left_I = left.I_
-        left_left_P = left.left_P_.copy()
-        left_left_I = left.left_I_
+        ref_P = ref_mp.P_.copy()
+        ref_I = ref_mp.I_
+        ref_left_P = ref_mp.left_P_.copy()
+        ref_left_I = ref_mp.left_I_
 
-        naive.replace_inf(left_P)
-        naive.replace_inf(left_left_P)
-        naive.replace_inf(right_P)
-        naive.replace_inf(right_left_P)
+        naive.replace_inf(ref_P)
+        naive.replace_inf(ref_left_P)
+        naive.replace_inf(comp_P)
+        naive.replace_inf(comp_left_P)
 
-        npt.assert_almost_equal(left_P, right_P, decimal=config.STUMPY_TEST_PRECISION)
-        # npt.assert_almost_equal(left_I, right_I)
+        npt.assert_almost_equal(ref_P, comp_P, decimal=config.STUMPY_TEST_PRECISION)
+        # npt.assert_almost_equal(ref_I, comp_I)
         npt.assert_almost_equal(
-            left_left_P, right_left_P, decimal=config.STUMPY_TEST_PRECISION
+            ref_left_P, comp_left_P, decimal=config.STUMPY_TEST_PRECISION
         )
-        # npt.assert_almost_equal(left_left_I, right_left_I)
+        # npt.assert_almost_equal(ref_left_I, comp_left_I)
 
     np.random.seed(seed)
     identical = np.random.rand(8)
@@ -797,57 +797,57 @@ def test_aampi_identical_subsequence_self_join_egress():
     T[11 : 11 + identical.shape[0]] = identical
     T = pd.Series(T)
 
-    left = naive.aampi_egress(T, m)
-    left_P = left.P_.copy()
-    left_I = left.I_
-    left_left_P = left.left_P_.copy()
-    left_left_I = left.left_I_
+    ref_mp = naive.aampi_egress(T, m)
+    ref_P = ref_mp.P_.copy()
+    ref_I = ref_mp.I_
+    ref_left_P = ref_mp.left_P_.copy()
+    ref_left_I = ref_mp.left_I_
 
     stream = aampi(T, m, egress=True)
 
-    right_P = stream.P_.copy()
-    right_I = stream.I_
-    right_left_P = stream.left_P_.copy()
-    right_left_I = stream.left_I_
+    comp_P = stream.P_.copy()
+    comp_I = stream.I_
+    comp_left_P = stream.left_P_.copy()
+    comp_left_I = stream.left_I_
 
-    naive.replace_inf(left_P)
-    naive.replace_inf(right_P)
-    naive.replace_inf(left_left_P)
-    naive.replace_inf(right_left_P)
+    naive.replace_inf(ref_P)
+    naive.replace_inf(comp_P)
+    naive.replace_inf(ref_left_P)
+    naive.replace_inf(comp_left_P)
 
-    npt.assert_almost_equal(left_P, right_P, decimal=config.STUMPY_TEST_PRECISION)
-    # npt.assert_almost_equal(left_I, right_I)
+    npt.assert_almost_equal(ref_P, comp_P, decimal=config.STUMPY_TEST_PRECISION)
+    # npt.assert_almost_equal(ref_I, comp_I)
     npt.assert_almost_equal(
-        left_left_P, right_left_P, decimal=config.STUMPY_TEST_PRECISION
+        ref_left_P, comp_left_P, decimal=config.STUMPY_TEST_PRECISION
     )
-    # npt.assert_almost_equal(left_left_I, right_left_I)
+    # npt.assert_almost_equal(ref_left_I, comp_left_I)
 
     for i in range(34):
         t = np.random.rand()
-        left.update(t)
+        ref_mp.update(t)
         stream.update(t)
 
-        right_P = stream.P_.copy()
-        right_I = stream.I_
-        right_left_P = stream.left_P_.copy()
-        right_left_I = stream.left_I_
+        comp_P = stream.P_.copy()
+        comp_I = stream.I_
+        comp_left_P = stream.left_P_.copy()
+        comp_left_I = stream.left_I_
 
-        left_P = left.P_.copy()
-        left_I = left.I_
-        left_left_P = left.left_P_.copy()
-        left_left_I = left.left_I_
+        ref_P = ref_mp.P_.copy()
+        ref_I = ref_mp.I_
+        ref_left_P = ref_mp.left_P_.copy()
+        ref_left_I = ref_mp.left_I_
 
-        naive.replace_inf(left_P)
-        naive.replace_inf(left_left_P)
-        naive.replace_inf(right_P)
-        naive.replace_inf(right_left_P)
+        naive.replace_inf(ref_P)
+        naive.replace_inf(ref_left_P)
+        naive.replace_inf(comp_P)
+        naive.replace_inf(comp_left_P)
 
-        npt.assert_almost_equal(left_P, right_P, decimal=config.STUMPY_TEST_PRECISION)
-        # npt.assert_almost_equal(left_I, right_I)
+        npt.assert_almost_equal(ref_P, comp_P, decimal=config.STUMPY_TEST_PRECISION)
+        # npt.assert_almost_equal(ref_I, comp_I)
         npt.assert_almost_equal(
-            left_left_P, right_left_P, decimal=config.STUMPY_TEST_PRECISION
+            ref_left_P, comp_left_P, decimal=config.STUMPY_TEST_PRECISION
         )
-        # npt.assert_almost_equal(left_left_I, right_left_I)
+        # npt.assert_almost_equal(ref_left_I, comp_left_I)
 
 
 def test_aampi_profile_index_match():

--- a/tests/test_chains.py
+++ b/tests/test_chains.py
@@ -15,15 +15,15 @@ test_data = [
 @pytest.mark.parametrize("Value, IR, IL", test_data)
 def test_atsc(Value, IR, IL):
     j = 2
-    left = np.array([2, 4, 6, 8, 10], np.int64)
-    right = atsc(IL, IR, j)
-    npt.assert_equal(left, right)
+    ref = np.array([2, 4, 6, 8, 10], np.int64)
+    comp = atsc(IL, IR, j)
+    npt.assert_equal(ref, comp)
 
 
 @pytest.mark.parametrize("Value, IR, IL", test_data)
 def test_allc(Value, IR, IL):
     j = 2
-    S_left = [
+    S_ref = [
         np.array([1, 7, 11], dtype=np.int64),
         np.array([0], dtype=np.int64),
         np.array([3], dtype=np.int64),
@@ -31,11 +31,11 @@ def test_allc(Value, IR, IL):
         np.array([2, 4, 6, 8, 10], dtype=np.int64),
         np.array([5], dtype=np.int64),
     ]
-    C_left = np.array([2, 4, 6, 8, 10], dtype=np.int64)
-    S_right, C_right = allc(IL, IR)
+    C_ref = np.array([2, 4, 6, 8, 10], dtype=np.int64)
+    S_comp, C_comp = allc(IL, IR)
 
-    S_left = sorted(S_left, key=lambda x: (len(x), list(x)))
-    S_right = sorted(S_right, key=lambda x: (len(x), list(x)))
+    S_ref = sorted(S_ref, key=lambda x: (len(x), list(x)))
+    S_comp = sorted(S_comp, key=lambda x: (len(x), list(x)))
 
-    npt.assert_equal(S_left, S_right)
-    npt.assert_equal(C_left, C_right)
+    npt.assert_equal(S_ref, S_comp)
+    npt.assert_equal(C_ref, C_comp)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -90,15 +90,15 @@ def test_sliding_dot_product(Q, T):
 def test_compute_mean_std(Q, T):
     m = Q.shape[0]
 
-    left_μ_Q, left_σ_Q = naive_compute_mean_std(Q, m)
-    left_M_T, left_Σ_T = naive_compute_mean_std(T, m)
-    right_μ_Q, right_σ_Q = core.compute_mean_std(Q, m)
-    right_M_T, right_Σ_T = core.compute_mean_std(T, m)
+    ref_μ_Q, ref_σ_Q = naive_compute_mean_std(Q, m)
+    ref_M_T, ref_Σ_T = naive_compute_mean_std(T, m)
+    comp_μ_Q, comp_σ_Q = core.compute_mean_std(Q, m)
+    comp_M_T, comp_Σ_T = core.compute_mean_std(T, m)
 
-    npt.assert_almost_equal(left_μ_Q, right_μ_Q)
-    npt.assert_almost_equal(left_σ_Q, right_σ_Q)
-    npt.assert_almost_equal(left_M_T, right_M_T)
-    npt.assert_almost_equal(left_Σ_T, right_Σ_T)
+    npt.assert_almost_equal(ref_μ_Q, comp_μ_Q)
+    npt.assert_almost_equal(ref_σ_Q, comp_σ_Q)
+    npt.assert_almost_equal(ref_M_T, comp_M_T)
+    npt.assert_almost_equal(ref_Σ_T, comp_Σ_T)
 
 
 @pytest.mark.parametrize("Q, T", test_data)
@@ -106,16 +106,16 @@ def test_compute_mean_std_chunked(Q, T):
     m = Q.shape[0]
 
     config.STUMPY_MEAN_STD_NUM_CHUNKS = 2
-    left_μ_Q, left_σ_Q = naive_compute_mean_std(Q, m)
-    left_M_T, left_Σ_T = naive_compute_mean_std(T, m)
-    right_μ_Q, right_σ_Q = core.compute_mean_std(Q, m)
-    right_M_T, right_Σ_T = core.compute_mean_std(T, m)
+    ref_μ_Q, ref_σ_Q = naive_compute_mean_std(Q, m)
+    ref_M_T, ref_Σ_T = naive_compute_mean_std(T, m)
+    comp_μ_Q, comp_σ_Q = core.compute_mean_std(Q, m)
+    comp_M_T, comp_Σ_T = core.compute_mean_std(T, m)
     config.STUMPY_MEAN_STD_NUM_CHUNKS = 1
 
-    npt.assert_almost_equal(left_μ_Q, right_μ_Q)
-    npt.assert_almost_equal(left_σ_Q, right_σ_Q)
-    npt.assert_almost_equal(left_M_T, right_M_T)
-    npt.assert_almost_equal(left_Σ_T, right_Σ_T)
+    npt.assert_almost_equal(ref_μ_Q, comp_μ_Q)
+    npt.assert_almost_equal(ref_σ_Q, comp_σ_Q)
+    npt.assert_almost_equal(ref_M_T, comp_M_T)
+    npt.assert_almost_equal(ref_Σ_T, comp_Σ_T)
 
 
 @pytest.mark.parametrize("Q, T", test_data)
@@ -123,16 +123,16 @@ def test_compute_mean_std_chunked_many(Q, T):
     m = Q.shape[0]
 
     config.STUMPY_MEAN_STD_NUM_CHUNKS = 128
-    left_μ_Q, left_σ_Q = naive_compute_mean_std(Q, m)
-    left_M_T, left_Σ_T = naive_compute_mean_std(T, m)
-    right_μ_Q, right_σ_Q = core.compute_mean_std(Q, m)
-    right_M_T, right_Σ_T = core.compute_mean_std(T, m)
+    ref_μ_Q, ref_σ_Q = naive_compute_mean_std(Q, m)
+    ref_M_T, ref_Σ_T = naive_compute_mean_std(T, m)
+    comp_μ_Q, comp_σ_Q = core.compute_mean_std(Q, m)
+    comp_M_T, comp_Σ_T = core.compute_mean_std(T, m)
     config.STUMPY_MEAN_STD_NUM_CHUNKS = 1
 
-    npt.assert_almost_equal(left_μ_Q, right_μ_Q)
-    npt.assert_almost_equal(left_σ_Q, right_σ_Q)
-    npt.assert_almost_equal(left_M_T, right_M_T)
-    npt.assert_almost_equal(left_Σ_T, right_Σ_T)
+    npt.assert_almost_equal(ref_μ_Q, comp_μ_Q)
+    npt.assert_almost_equal(ref_σ_Q, comp_σ_Q)
+    npt.assert_almost_equal(ref_M_T, comp_M_T)
+    npt.assert_almost_equal(ref_Σ_T, comp_Σ_T)
 
 
 @pytest.mark.parametrize("Q, T", test_data)
@@ -142,15 +142,15 @@ def test_compute_mean_std_multidimensional(Q, T):
     Q = np.array([Q, np.random.uniform(-1000, 1000, [Q.shape[0]])])
     T = np.array([T, T, np.random.uniform(-1000, 1000, [T.shape[0]])])
 
-    left_μ_Q, left_σ_Q = naive_compute_mean_std_multidimensional(Q, m)
-    left_M_T, left_Σ_T = naive_compute_mean_std_multidimensional(T, m)
-    right_μ_Q, right_σ_Q = core.compute_mean_std(Q, m)
-    right_M_T, right_Σ_T = core.compute_mean_std(T, m)
+    ref_μ_Q, ref_σ_Q = naive_compute_mean_std_multidimensional(Q, m)
+    ref_M_T, ref_Σ_T = naive_compute_mean_std_multidimensional(T, m)
+    comp_μ_Q, comp_σ_Q = core.compute_mean_std(Q, m)
+    comp_M_T, comp_Σ_T = core.compute_mean_std(T, m)
 
-    npt.assert_almost_equal(left_μ_Q, right_μ_Q)
-    npt.assert_almost_equal(left_σ_Q, right_σ_Q)
-    npt.assert_almost_equal(left_M_T, right_M_T)
-    npt.assert_almost_equal(left_Σ_T, right_Σ_T)
+    npt.assert_almost_equal(ref_μ_Q, comp_μ_Q)
+    npt.assert_almost_equal(ref_σ_Q, comp_σ_Q)
+    npt.assert_almost_equal(ref_M_T, comp_M_T)
+    npt.assert_almost_equal(ref_Σ_T, comp_Σ_T)
 
 
 @pytest.mark.parametrize("Q, T", test_data)
@@ -161,16 +161,16 @@ def test_compute_mean_std_multidimensional_chunked(Q, T):
     T = np.array([T, T, np.random.uniform(-1000, 1000, [T.shape[0]])])
 
     config.STUMPY_MEAN_STD_NUM_CHUNKS = 2
-    left_μ_Q, left_σ_Q = naive_compute_mean_std_multidimensional(Q, m)
-    left_M_T, left_Σ_T = naive_compute_mean_std_multidimensional(T, m)
-    right_μ_Q, right_σ_Q = core.compute_mean_std(Q, m)
-    right_M_T, right_Σ_T = core.compute_mean_std(T, m)
+    ref_μ_Q, ref_σ_Q = naive_compute_mean_std_multidimensional(Q, m)
+    ref_M_T, ref_Σ_T = naive_compute_mean_std_multidimensional(T, m)
+    comp_μ_Q, comp_σ_Q = core.compute_mean_std(Q, m)
+    comp_M_T, comp_Σ_T = core.compute_mean_std(T, m)
     config.STUMPY_MEAN_STD_NUM_CHUNKS = 1
 
-    npt.assert_almost_equal(left_μ_Q, right_μ_Q)
-    npt.assert_almost_equal(left_σ_Q, right_σ_Q)
-    npt.assert_almost_equal(left_M_T, right_M_T)
-    npt.assert_almost_equal(left_Σ_T, right_Σ_T)
+    npt.assert_almost_equal(ref_μ_Q, comp_μ_Q)
+    npt.assert_almost_equal(ref_σ_Q, comp_σ_Q)
+    npt.assert_almost_equal(ref_M_T, comp_M_T)
+    npt.assert_almost_equal(ref_Σ_T, comp_Σ_T)
 
 
 @pytest.mark.parametrize("Q, T", test_data)
@@ -181,22 +181,22 @@ def test_compute_mean_std_multidimensional_chunked_many(Q, T):
     T = np.array([T, T, np.random.uniform(-1000, 1000, [T.shape[0]])])
 
     config.STUMPY_MEAN_STD_NUM_CHUNKS = 128
-    left_μ_Q, left_σ_Q = naive_compute_mean_std_multidimensional(Q, m)
-    left_M_T, left_Σ_T = naive_compute_mean_std_multidimensional(T, m)
-    right_μ_Q, right_σ_Q = core.compute_mean_std(Q, m)
-    right_M_T, right_Σ_T = core.compute_mean_std(T, m)
+    ref_μ_Q, ref_σ_Q = naive_compute_mean_std_multidimensional(Q, m)
+    ref_M_T, ref_Σ_T = naive_compute_mean_std_multidimensional(T, m)
+    comp_μ_Q, comp_σ_Q = core.compute_mean_std(Q, m)
+    comp_M_T, comp_Σ_T = core.compute_mean_std(T, m)
     config.STUMPY_MEAN_STD_NUM_CHUNKS = 1
 
-    npt.assert_almost_equal(left_μ_Q, right_μ_Q)
-    npt.assert_almost_equal(left_σ_Q, right_σ_Q)
-    npt.assert_almost_equal(left_M_T, right_M_T)
-    npt.assert_almost_equal(left_Σ_T, right_Σ_T)
+    npt.assert_almost_equal(ref_μ_Q, comp_μ_Q)
+    npt.assert_almost_equal(ref_σ_Q, comp_σ_Q)
+    npt.assert_almost_equal(ref_M_T, comp_M_T)
+    npt.assert_almost_equal(ref_Σ_T, comp_Σ_T)
 
 
 @pytest.mark.parametrize("Q, T", test_data)
 def test_calculate_squared_distance_profile(Q, T):
     m = Q.shape[0]
-    left = (
+    ref = (
         np.linalg.norm(
             core.z_norm(core.rolling_window(T, m), 1) - core.z_norm(Q), axis=1
         )
@@ -205,33 +205,33 @@ def test_calculate_squared_distance_profile(Q, T):
     QT = core.sliding_dot_product(Q, T)
     μ_Q, σ_Q = core.compute_mean_std(Q, m)
     M_T, Σ_T = core.compute_mean_std(T, m)
-    right = core._calculate_squared_distance_profile(
+    comp = core._calculate_squared_distance_profile(
         m, QT, μ_Q.item(0), σ_Q.item(0), M_T, Σ_T
     )
-    npt.assert_almost_equal(left, right)
+    npt.assert_almost_equal(ref, comp)
 
 
 @pytest.mark.parametrize("Q, T", test_data)
 def test_calculate_distance_profile(Q, T):
     m = Q.shape[0]
-    left = np.linalg.norm(
+    ref = np.linalg.norm(
         core.z_norm(core.rolling_window(T, m), 1) - core.z_norm(Q), axis=1
     )
     QT = core.sliding_dot_product(Q, T)
     μ_Q, σ_Q = core.compute_mean_std(Q, m)
     M_T, Σ_T = core.compute_mean_std(T, m)
-    right = core.calculate_distance_profile(m, QT, μ_Q.item(0), σ_Q.item(0), M_T, Σ_T)
-    npt.assert_almost_equal(left, right)
+    comp = core.calculate_distance_profile(m, QT, μ_Q.item(0), σ_Q.item(0), M_T, Σ_T)
+    npt.assert_almost_equal(ref, comp)
 
 
 @pytest.mark.parametrize("Q, T", test_data)
 def test_mueen_calculate_distance_profile(Q, T):
     m = Q.shape[0]
-    left = np.linalg.norm(
+    ref = np.linalg.norm(
         core.z_norm(core.rolling_window(T, m), 1) - core.z_norm(Q), axis=1
     )
-    right = core.mueen_calculate_distance_profile(Q, T)
-    npt.assert_almost_equal(left, right)
+    comp = core.mueen_calculate_distance_profile(Q, T)
+    npt.assert_almost_equal(ref, comp)
 
 
 @pytest.mark.parametrize("Q, T", test_data)
@@ -239,11 +239,11 @@ def test_mass(Q, T):
     Q = Q.copy()
     T = T.copy()
     m = Q.shape[0]
-    left = np.linalg.norm(
+    ref = np.linalg.norm(
         core.z_norm(core.rolling_window(T, m), 1) - core.z_norm(Q), axis=1
     )
-    right = core.mass(Q, T)
-    npt.assert_almost_equal(left, right)
+    comp = core.mass(Q, T)
+    npt.assert_almost_equal(ref, comp)
 
 
 @pytest.mark.parametrize("Q, T", test_data)
@@ -253,13 +253,13 @@ def test_mass_Q_nan(Q, T):
     T = T.copy()
     m = Q.shape[0]
 
-    left = np.linalg.norm(
+    ref = np.linalg.norm(
         core.z_norm(core.rolling_window(T, m), 1) - core.z_norm(Q), axis=1
     )
-    left[np.isnan(left)] = np.inf
+    ref[np.isnan(ref)] = np.inf
 
-    right = core.mass(Q, T)
-    npt.assert_almost_equal(left, right)
+    comp = core.mass(Q, T)
+    npt.assert_almost_equal(ref, comp)
 
 
 @pytest.mark.parametrize("Q, T", test_data)
@@ -269,13 +269,13 @@ def test_mass_Q_inf(Q, T):
     T = T.copy()
     m = Q.shape[0]
 
-    left = np.linalg.norm(
+    ref = np.linalg.norm(
         core.z_norm(core.rolling_window(T, m), 1) - core.z_norm(Q), axis=1
     )
-    left[np.isnan(left)] = np.inf
+    ref[np.isnan(ref)] = np.inf
 
-    right = core.mass(Q, T)
-    npt.assert_almost_equal(left, right)
+    comp = core.mass(Q, T)
+    npt.assert_almost_equal(ref, comp)
     T[1] = 1e10
 
 
@@ -286,13 +286,13 @@ def test_mass_T_nan(Q, T):
     T[1] = np.nan
     m = Q.shape[0]
 
-    left = np.linalg.norm(
+    ref = np.linalg.norm(
         core.z_norm(core.rolling_window(T, m), 1) - core.z_norm(Q), axis=1
     )
-    left[np.isnan(left)] = np.inf
+    ref[np.isnan(ref)] = np.inf
 
-    right = core.mass(Q, T)
-    npt.assert_almost_equal(left, right)
+    comp = core.mass(Q, T)
+    npt.assert_almost_equal(ref, comp)
 
 
 @pytest.mark.parametrize("Q, T", test_data)
@@ -302,13 +302,13 @@ def test_mass_T_inf(Q, T):
     T[1] = np.inf
     m = Q.shape[0]
 
-    left = np.linalg.norm(
+    ref = np.linalg.norm(
         core.z_norm(core.rolling_window(T, m), 1) - core.z_norm(Q), axis=1
     )
-    left[np.isnan(left)] = np.inf
+    ref[np.isnan(ref)] = np.inf
 
-    right = core.mass(Q, T)
-    npt.assert_almost_equal(left, right)
+    comp = core.mass(Q, T)
+    npt.assert_almost_equal(ref, comp)
     T[1] = 1e10
 
 
@@ -317,9 +317,9 @@ def test_mass_asbolute(Q, T):
     Q = Q.copy()
     T = T.copy()
     m = Q.shape[0]
-    left = np.linalg.norm(core.rolling_window(T, m) - Q, axis=1)
-    right = core.mass_absolute(Q, T)
-    npt.assert_almost_equal(left, right)
+    ref = np.linalg.norm(core.rolling_window(T, m) - Q, axis=1)
+    comp = core.mass_absolute(Q, T)
+    npt.assert_almost_equal(ref, comp)
 
 
 @pytest.mark.parametrize("Q, T", test_data)
@@ -329,11 +329,11 @@ def test_mass_absolute_Q_nan(Q, T):
     T = T.copy()
     m = Q.shape[0]
 
-    left = np.linalg.norm(core.rolling_window(T, m) - Q, axis=1)
-    left[np.isnan(left)] = np.inf
+    ref = np.linalg.norm(core.rolling_window(T, m) - Q, axis=1)
+    ref[np.isnan(ref)] = np.inf
 
-    right = core.mass_absolute(Q, T)
-    npt.assert_almost_equal(left, right)
+    comp = core.mass_absolute(Q, T)
+    npt.assert_almost_equal(ref, comp)
 
 
 @pytest.mark.parametrize("Q, T", test_data)
@@ -343,11 +343,11 @@ def test_mass_absolute_Q_inf(Q, T):
     T = T.copy()
     m = Q.shape[0]
 
-    left = np.linalg.norm(core.rolling_window(T, m) - Q, axis=1)
-    left[np.isnan(left)] = np.inf
+    ref = np.linalg.norm(core.rolling_window(T, m) - Q, axis=1)
+    ref[np.isnan(ref)] = np.inf
 
-    right = core.mass_absolute(Q, T)
-    npt.assert_almost_equal(left, right)
+    comp = core.mass_absolute(Q, T)
+    npt.assert_almost_equal(ref, comp)
 
 
 @pytest.mark.parametrize("Q, T", test_data)
@@ -357,11 +357,11 @@ def test_mass_absolute_T_nan(Q, T):
     T[1] = np.nan
     m = Q.shape[0]
 
-    left = np.linalg.norm(core.rolling_window(T, m) - Q, axis=1)
-    left[np.isnan(left)] = np.inf
+    ref = np.linalg.norm(core.rolling_window(T, m) - Q, axis=1)
+    ref[np.isnan(ref)] = np.inf
 
-    right = core.mass_absolute(Q, T)
-    npt.assert_almost_equal(left, right)
+    comp = core.mass_absolute(Q, T)
+    npt.assert_almost_equal(ref, comp)
 
 
 @pytest.mark.parametrize("Q, T", test_data)
@@ -371,132 +371,132 @@ def test_mass_absolute_T_inf(Q, T):
     T[1] = np.inf
     m = Q.shape[0]
 
-    left = np.linalg.norm(core.rolling_window(T, m) - Q, axis=1)
-    left[np.isnan(left)] = np.inf
+    ref = np.linalg.norm(core.rolling_window(T, m) - Q, axis=1)
+    ref[np.isnan(ref)] = np.inf
 
-    right = core.mass_absolute(Q, T)
-    npt.assert_almost_equal(left, right)
+    comp = core.mass_absolute(Q, T)
+    npt.assert_almost_equal(ref, comp)
 
 
 def test_apply_exclusion_zone():
     T = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=float)
-    left = np.empty(T.shape)
-    right = np.empty(T.shape)
+    ref = np.empty(T.shape)
+    comp = np.empty(T.shape)
     exclusion_zone = 2
 
     for i in range(T.shape[0]):
-        left[:] = T[:]
-        naive.apply_exclusion_zone(left, i, exclusion_zone)
+        ref[:] = T[:]
+        naive.apply_exclusion_zone(ref, i, exclusion_zone)
 
-        right[:] = T[:]
-        core.apply_exclusion_zone(right, i, exclusion_zone)
+        comp[:] = T[:]
+        core.apply_exclusion_zone(comp, i, exclusion_zone)
 
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_array_equal(left, right)
+        naive.replace_inf(ref)
+        naive.replace_inf(comp)
+        npt.assert_array_equal(ref, comp)
 
 
 def test_apply_exclusion_zone_multidimensional():
     T = np.array(
         [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]], dtype=float
     )
-    left = np.empty(T.shape)
-    right = np.empty(T.shape)
+    ref = np.empty(T.shape)
+    comp = np.empty(T.shape)
     exclusion_zone = 2
 
     for i in range(T.shape[1]):
-        left[:, :] = T[:, :]
-        naive.apply_exclusion_zone(left, i, exclusion_zone)
+        ref[:, :] = T[:, :]
+        naive.apply_exclusion_zone(ref, i, exclusion_zone)
 
-        right[:, :] = T[:, :]
-        core.apply_exclusion_zone(right, i, exclusion_zone)
+        comp[:, :] = T[:, :]
+        core.apply_exclusion_zone(comp, i, exclusion_zone)
 
-        naive.replace_inf(left)
-        naive.replace_inf(right)
-        npt.assert_array_equal(left, right)
+        naive.replace_inf(ref)
+        naive.replace_inf(comp)
+        npt.assert_array_equal(ref, comp)
 
 
 def test_preprocess():
     T = np.array([0, np.nan, 2, 3, 4, 5, 6, 7, np.inf, 9])
     m = 3
 
-    left_T = np.array([0, 0, 2, 3, 4, 5, 6, 7, 0, 9], dtype=float)
-    left_M, left_Σ = naive_compute_mean_std(T, m)
+    ref_T = np.array([0, 0, 2, 3, 4, 5, 6, 7, 0, 9], dtype=float)
+    ref_M, ref_Σ = naive_compute_mean_std(T, m)
 
-    right_T, right_M, right_Σ = core.preprocess(T, m)
+    comp_T, comp_M, comp_Σ = core.preprocess(T, m)
 
-    npt.assert_almost_equal(left_T, right_T)
-    npt.assert_almost_equal(left_M, right_M)
-    npt.assert_almost_equal(left_Σ, right_Σ)
+    npt.assert_almost_equal(ref_T, comp_T)
+    npt.assert_almost_equal(ref_M, comp_M)
+    npt.assert_almost_equal(ref_Σ, comp_Σ)
 
     T = pd.Series(T)
-    right_T, right_M, right_Σ = core.preprocess(T, m)
+    comp_T, comp_M, comp_Σ = core.preprocess(T, m)
 
-    npt.assert_almost_equal(left_T, right_T)
-    npt.assert_almost_equal(left_M, right_M)
-    npt.assert_almost_equal(left_Σ, right_Σ)
+    npt.assert_almost_equal(ref_T, comp_T)
+    npt.assert_almost_equal(ref_M, comp_M)
+    npt.assert_almost_equal(ref_Σ, comp_Σ)
 
 
 def test_preprocess_non_normalized():
     T = np.array([0, np.nan, 2, 3, 4, 5, 6, 7, np.inf, 9])
     m = 3
 
-    left_T_subseq_isfinite = np.full(T.shape[0] - m + 1, False, dtype=bool)
+    ref_T_subseq_isfinite = np.full(T.shape[0] - m + 1, False, dtype=bool)
     for i in range(T.shape[0] - m + 1):
         if np.all(np.isfinite(T[i : i + m])):
-            left_T_subseq_isfinite[i] = True
+            ref_T_subseq_isfinite[i] = True
 
-    left_T = np.array([0, 0, 2, 3, 4, 5, 6, 7, 0, 9], dtype=float)
+    ref_T = np.array([0, 0, 2, 3, 4, 5, 6, 7, 0, 9], dtype=float)
 
-    right_T, right_T_subseq_isfinite = core.preprocess_non_normalized(T, m)
+    comp_T, comp_T_subseq_isfinite = core.preprocess_non_normalized(T, m)
 
-    npt.assert_almost_equal(left_T, right_T)
-    npt.assert_almost_equal(left_T_subseq_isfinite, right_T_subseq_isfinite)
+    npt.assert_almost_equal(ref_T, comp_T)
+    npt.assert_almost_equal(ref_T_subseq_isfinite, comp_T_subseq_isfinite)
 
     T = pd.Series(T)
-    right_T, right_T_subseq_isfinite = core.preprocess_non_normalized(T, m)
+    comp_T, comp_T_subseq_isfinite = core.preprocess_non_normalized(T, m)
 
-    npt.assert_almost_equal(left_T, right_T)
-    npt.assert_almost_equal(left_T_subseq_isfinite, right_T_subseq_isfinite)
+    npt.assert_almost_equal(ref_T, comp_T)
+    npt.assert_almost_equal(ref_T_subseq_isfinite, comp_T_subseq_isfinite)
 
 
 def test_preprocess_diagonal():
     T = np.array([0, np.nan, 2, 3, 4, 5, 6, 7, np.inf, 9])
     m = 3
 
-    left_T = np.array([0, 0, 2, 3, 4, 5, 6, 7, 0, 9], dtype=float)
-    left_M, left_Σ = naive_compute_mean_std(left_T, m)
-    left_Σ_inverse = 1.0 / left_Σ
-    left_M_m_1, _ = naive_compute_mean_std(left_T, m - 1)
+    ref_T = np.array([0, 0, 2, 3, 4, 5, 6, 7, 0, 9], dtype=float)
+    ref_M, ref_Σ = naive_compute_mean_std(ref_T, m)
+    ref_Σ_inverse = 1.0 / ref_Σ
+    ref_M_m_1, _ = naive_compute_mean_std(ref_T, m - 1)
 
     (
-        right_T,
-        right_M,
-        right_Σ_inverse,
-        right_M_m_1,
-        right_T_subseq_isfinite,
-        right_T_subseq_isconstant,
+        comp_T,
+        comp_M,
+        comp_Σ_inverse,
+        comp_M_m_1,
+        comp_T_subseq_isfinite,
+        comp_T_subseq_isconstant,
     ) = core.preprocess_diagonal(T, m)
 
-    npt.assert_almost_equal(left_T, right_T)
-    npt.assert_almost_equal(left_M, right_M)
-    npt.assert_almost_equal(left_Σ_inverse, right_Σ_inverse)
-    npt.assert_almost_equal(left_M_m_1, right_M_m_1)
+    npt.assert_almost_equal(ref_T, comp_T)
+    npt.assert_almost_equal(ref_M, comp_M)
+    npt.assert_almost_equal(ref_Σ_inverse, comp_Σ_inverse)
+    npt.assert_almost_equal(ref_M_m_1, comp_M_m_1)
 
     T = pd.Series(T)
     (
-        right_T,
-        right_M,
-        right_Σ_inverse,
-        right_M_m_1,
-        right_T_subseq_isfinite,
-        right_T_subseq_isconstant,
+        comp_T,
+        comp_M,
+        comp_Σ_inverse,
+        comp_M_m_1,
+        comp_T_subseq_isfinite,
+        comp_T_subseq_isconstant,
     ) = core.preprocess_diagonal(T, m)
 
-    npt.assert_almost_equal(left_T, right_T)
-    npt.assert_almost_equal(left_M, right_M)
-    npt.assert_almost_equal(left_Σ_inverse, right_Σ_inverse)
-    npt.assert_almost_equal(left_M_m_1, right_M_m_1)
+    npt.assert_almost_equal(ref_T, comp_T)
+    npt.assert_almost_equal(ref_M, comp_M)
+    npt.assert_almost_equal(ref_Σ_inverse, comp_Σ_inverse)
+    npt.assert_almost_equal(ref_M_m_1, comp_M_m_1)
 
 
 def test_replace_distance():
@@ -522,39 +522,39 @@ def test_count_diagonal_ndist():
             for m in range(3, 6):
                 diags = np.random.permutation(range(-(n_A - m + 1) + 1, n_B - m + 1))
                 ones_matrix = np.ones((n_A - m + 1, n_B - m + 1), dtype=np.int64)
-                left_ndist_counts = np.empty(len(diags))
+                ref_ndist_counts = np.empty(len(diags))
                 for i, diag in enumerate(diags):
-                    left_ndist_counts[i] = ones_matrix.diagonal(offset=diag).sum()
+                    ref_ndist_counts[i] = ones_matrix.diagonal(offset=diag).sum()
 
-            right_ndist_counts = core._count_diagonal_ndist(diags, m, n_A, n_B)
+            comp_ndist_counts = core._count_diagonal_ndist(diags, m, n_A, n_B)
 
-            npt.assert_almost_equal(left_ndist_counts, right_ndist_counts)
+            npt.assert_almost_equal(ref_ndist_counts, comp_ndist_counts)
 
 
 def test_get_array_ranges():
     x = np.array([3, 9, 2, 1, 5, 4, 7, 7, 8, 6])
     for n_chunks in range(2, 5):
-        left = naive.get_array_ranges(x, n_chunks)
+        ref = naive.get_array_ranges(x, n_chunks)
 
-        right = core._get_array_ranges(x, n_chunks)
-        npt.assert_almost_equal(left, right)
+        comp = core._get_array_ranges(x, n_chunks)
+        npt.assert_almost_equal(ref, comp)
 
 
 def test_get_array_ranges_exhausted():
     x = np.array([3, 3, 3, 11, 11, 11])
     n_chunks = 6
 
-    left = naive.get_array_ranges(x, n_chunks)
+    ref = naive.get_array_ranges(x, n_chunks)
 
-    right = core._get_array_ranges(x, n_chunks)
-    npt.assert_almost_equal(left, right)
+    comp = core._get_array_ranges(x, n_chunks)
+    npt.assert_almost_equal(ref, comp)
 
 
 def test_get_array_ranges_exhausted_truncated():
     x = np.array([3, 3, 3, 11, 11, 11])
     n_chunks = 6
 
-    left = naive.get_array_ranges(x, n_chunks, truncate=True)
+    ref = naive.get_array_ranges(x, n_chunks, truncate=True)
 
-    right = core._get_array_ranges(x, n_chunks, truncate=True)
-    npt.assert_almost_equal(left, right)
+    comp = core._get_array_ranges(x, n_chunks, truncate=True)
+    npt.assert_almost_equal(ref, comp)

--- a/tests/test_mstump.py
+++ b/tests/test_mstump.py
@@ -46,18 +46,18 @@ substitution_values = [np.nan, np.inf]
 
 def test_apply_include():
     D = np.random.uniform(-1000, 1000, [10, 20]).astype(np.float64)
-    left_D = np.empty(D.shape)
-    right_D = np.empty(D.shape)
+    ref_D = np.empty(D.shape)
+    comp_D = np.empty(D.shape)
     for width in range(D.shape[0]):
         for i in range(D.shape[0] - width):
-            left_D[:, :] = D[:, :]
-            right_D[:, :] = D[:, :]
+            ref_D[:, :] = D[:, :]
+            comp_D[:, :] = D[:, :]
             include = np.asarray(range(i, i + width + 1))
 
             naive_apply_include(D, include)
             _apply_include(D, include)
 
-            npt.assert_almost_equal(left_D, right_D)
+            npt.assert_almost_equal(ref_D, comp_D)
 
 
 def test_multi_mass_seeded():
@@ -69,12 +69,12 @@ def test_multi_mass_seeded():
 
     Q = T[:, trivial_idx : trivial_idx + m]
 
-    left = naive.multi_mass(Q, T, m)
+    ref = naive.multi_mass(Q, T, m)
 
     M_T, Σ_T = core.compute_mean_std(T, m)
-    right = _multi_mass(Q, T, m, M_T, Σ_T, M_T[:, trivial_idx], Σ_T[:, trivial_idx])
+    comp = _multi_mass(Q, T, m, M_T, Σ_T, M_T[:, trivial_idx], Σ_T[:, trivial_idx])
 
-    npt.assert_almost_equal(left, right, decimal=config.STUMPY_TEST_PRECISION)
+    npt.assert_almost_equal(ref, comp, decimal=config.STUMPY_TEST_PRECISION)
 
 
 @pytest.mark.parametrize("T, m", test_data)
@@ -83,12 +83,12 @@ def test_multi_mass(T, m):
 
     Q = T[:, trivial_idx : trivial_idx + m]
 
-    left = naive.multi_mass(Q, T, m)
+    ref = naive.multi_mass(Q, T, m)
 
     M_T, Σ_T = core.compute_mean_std(T, m)
-    right = _multi_mass(Q, T, m, M_T, Σ_T, M_T[:, trivial_idx], Σ_T[:, trivial_idx])
+    comp = _multi_mass(Q, T, m, M_T, Σ_T, M_T[:, trivial_idx], Σ_T[:, trivial_idx])
 
-    npt.assert_almost_equal(left, right, decimal=config.STUMPY_TEST_PRECISION)
+    npt.assert_almost_equal(ref, comp, decimal=config.STUMPY_TEST_PRECISION)
 
 
 @pytest.mark.parametrize("T, m", test_data)
@@ -96,36 +96,36 @@ def test_get_first_mstump_profile(T, m):
     excl_zone = int(np.ceil(m / 4))
     start = 0
 
-    left_P, left_I = naive.mstump(T, m, excl_zone)
-    left_P = left_P[start, :]
-    left_I = left_I[start, :]
+    ref_P, ref_I = naive.mstump(T, m, excl_zone)
+    ref_P = ref_P[start, :]
+    ref_I = ref_I[start, :]
 
     M_T, Σ_T = core.compute_mean_std(T, m)
-    right_P, right_I = _get_first_mstump_profile(
+    comp_P, comp_I = _get_first_mstump_profile(
         start, T, T, m, excl_zone, M_T, Σ_T, M_T, Σ_T
     )
 
-    npt.assert_almost_equal(left_P, right_P)
-    npt.assert_equal(left_I, right_I)
+    npt.assert_almost_equal(ref_P, comp_P)
+    npt.assert_equal(ref_I, comp_I)
 
 
 @pytest.mark.parametrize("T, m", test_data)
 def test_get_multi_QT(T, m):
     start = 0
     Q = core.rolling_window(T, m)
-    left_QT = np.empty((Q.shape[0], Q.shape[1]), dtype="float64")
-    left_QT_first = np.empty((Q.shape[0], Q.shape[1]), dtype="float64")
+    ref_QT = np.empty((Q.shape[0], Q.shape[1]), dtype="float64")
+    ref_QT_first = np.empty((Q.shape[0], Q.shape[1]), dtype="float64")
 
     for dim in range(T.shape[0]):
-        left_QT[dim] = naive_rolling_window_dot_product(
+        ref_QT[dim] = naive_rolling_window_dot_product(
             T[dim, start : start + m], T[dim]
         )
-        left_QT_first[dim] = naive_rolling_window_dot_product(T[dim, :m], T[dim])
+        ref_QT_first[dim] = naive_rolling_window_dot_product(T[dim, :m], T[dim])
 
-    right_QT, right_QT_first = _get_multi_QT(start, T, m)
+    comp_QT, comp_QT_first = _get_multi_QT(start, T, m)
 
-    npt.assert_almost_equal(left_QT, right_QT)
-    npt.assert_almost_equal(left_QT_first, right_QT_first)
+    npt.assert_almost_equal(ref_QT, comp_QT)
+    npt.assert_almost_equal(ref_QT_first, comp_QT_first)
 
 
 def test_naive_mstump():
@@ -134,14 +134,14 @@ def test_naive_mstump():
 
     zone = int(np.ceil(m / 4))
 
-    left = naive.stamp(T[0], m, exclusion_zone=zone)
-    left_P = left[np.newaxis, :, 0].T
-    left_I = left[np.newaxis, :, 1].T
+    ref_mp = naive.stamp(T[0], m, exclusion_zone=zone)
+    ref_P = ref_mp[np.newaxis, :, 0].T
+    ref_I = ref_mp[np.newaxis, :, 1].T
 
-    right_P, right_I = naive.mstump(T, m, zone)
+    comp_P, comp_I = naive.mstump(T, m, zone)
 
-    npt.assert_almost_equal(left_P, right_P)
-    npt.assert_almost_equal(left_I, right_I)
+    npt.assert_almost_equal(ref_P, comp_P)
+    npt.assert_almost_equal(ref_I, comp_I)
 
 
 def test_mstump_int_input():
@@ -153,11 +153,11 @@ def test_mstump_int_input():
 def test_mstump(T, m):
     excl_zone = int(np.ceil(m / 4))
 
-    left_P, left_I = naive.mstump(T, m, excl_zone)
-    right_P, right_I = mstump(T, m)
+    ref_P, ref_I = naive.mstump(T, m, excl_zone)
+    comp_P, comp_I = mstump(T, m)
 
-    npt.assert_almost_equal(left_P, right_P)
-    npt.assert_almost_equal(left_I, right_I)
+    npt.assert_almost_equal(ref_P, comp_P)
+    npt.assert_almost_equal(ref_I, comp_I)
 
 
 @pytest.mark.parametrize("T, m", test_data)
@@ -167,22 +167,22 @@ def test_mstump_include(T, m):
             include = np.asarray(range(i, i + width + 1))
             excl_zone = int(np.ceil(m / 4))
 
-            left_P, left_I = naive.mstump(T, m, excl_zone, include)
-            right_P, right_I = mstump(T, m, include)
+            ref_P, ref_I = naive.mstump(T, m, excl_zone, include)
+            comp_P, comp_I = mstump(T, m, include)
 
-            npt.assert_almost_equal(left_P, right_P)
-            npt.assert_almost_equal(left_I, right_I)
+            npt.assert_almost_equal(ref_P, comp_P)
+            npt.assert_almost_equal(ref_I, comp_I)
 
 
 @pytest.mark.parametrize("T, m", test_data)
 def test_mstump_discords(T, m):
     excl_zone = int(np.ceil(m / 4))
 
-    left_P, left_I = naive.mstump(T, m, excl_zone, discords=True)
-    right_P, right_I = mstump(T, m, discords=True)
+    ref_P, ref_I = naive.mstump(T, m, excl_zone, discords=True)
+    comp_P, comp_I = mstump(T, m, discords=True)
 
-    npt.assert_almost_equal(left_P, right_P)
-    npt.assert_almost_equal(left_I, right_I)
+    npt.assert_almost_equal(ref_P, comp_P)
+    npt.assert_almost_equal(ref_I, comp_I)
 
 
 @pytest.mark.parametrize("T, m", test_data)
@@ -193,28 +193,28 @@ def test_mstump_include_discords(T, m):
 
             excl_zone = int(np.ceil(m / 4))
 
-            left_P, left_I = naive.mstump(T, m, excl_zone, include, discords=True)
-            right_P, right_I = mstump(T, m, include, discords=True)
+            ref_P, ref_I = naive.mstump(T, m, excl_zone, include, discords=True)
+            comp_P, comp_I = mstump(T, m, include, discords=True)
 
-            npt.assert_almost_equal(left_P, right_P)
-            npt.assert_almost_equal(left_I, right_I)
+            npt.assert_almost_equal(ref_P, comp_P)
+            npt.assert_almost_equal(ref_I, comp_I)
 
 
 @pytest.mark.parametrize("T, m", test_data)
 def test_mstump_wrapper(T, m):
     excl_zone = int(np.ceil(m / 4))
 
-    left_P, left_I = naive.mstump(T, m, excl_zone)
-    right_P, right_I = mstump(T, m)
+    ref_P, ref_I = naive.mstump(T, m, excl_zone)
+    comp_P, comp_I = mstump(T, m)
 
-    npt.assert_almost_equal(left_P, right_P)
-    npt.assert_almost_equal(left_I, right_I)
+    npt.assert_almost_equal(ref_P, comp_P)
+    npt.assert_almost_equal(ref_I, comp_I)
 
     df = pd.DataFrame(T.T)
-    right_P, right_I = mstump(df, m)
+    comp_P, comp_I = mstump(df, m)
 
-    npt.assert_almost_equal(left_P, right_P)
-    npt.assert_almost_equal(left_I, right_I)
+    npt.assert_almost_equal(ref_P, comp_P)
+    npt.assert_almost_equal(ref_I, comp_I)
 
 
 @pytest.mark.parametrize("T, m", test_data)
@@ -225,17 +225,17 @@ def test_mstump_wrapper_include(T, m):
 
             excl_zone = int(np.ceil(m / 4))
 
-            left_P, left_I = naive.mstump(T, m, excl_zone, include)
-            right_P, right_I = mstump(T, m, include)
+            ref_P, ref_I = naive.mstump(T, m, excl_zone, include)
+            comp_P, comp_I = mstump(T, m, include)
 
-            npt.assert_almost_equal(left_P, right_P)
-            npt.assert_almost_equal(left_I, right_I)
+            npt.assert_almost_equal(ref_P, comp_P)
+            npt.assert_almost_equal(ref_I, comp_I)
 
             df = pd.DataFrame(T.T)
-            right_P, right_I = mstump(df, m, include)
+            comp_P, comp_I = mstump(df, m, include)
 
-            npt.assert_almost_equal(left_P, right_P)
-            npt.assert_almost_equal(left_I, right_I)
+            npt.assert_almost_equal(ref_P, comp_P)
+            npt.assert_almost_equal(ref_I, comp_I)
 
 
 def test_constant_subsequence_self_join():
@@ -245,10 +245,10 @@ def test_constant_subsequence_self_join():
 
     excl_zone = int(np.ceil(m / 4))
 
-    left_P, left_I = naive.mstump(T, m, excl_zone)
-    right_P, right_I = mstump(T, m)
+    ref_P, ref_I = naive.mstump(T, m, excl_zone)
+    comp_P, comp_I = mstump(T, m)
 
-    npt.assert_almost_equal(left_P, right_P)  # ignore indices
+    npt.assert_almost_equal(ref_P, comp_P)  # ignore indices
 
 
 def test_identical_subsequence_self_join():
@@ -261,11 +261,11 @@ def test_identical_subsequence_self_join():
 
     excl_zone = int(np.ceil(m / 4))
 
-    left_P, left_I = naive.mstump(T, m, excl_zone)
-    right_P, right_I = mstump(T, m)
+    ref_P, ref_I = naive.mstump(T, m, excl_zone)
+    comp_P, comp_I = mstump(T, m)
 
     npt.assert_almost_equal(
-        left_P, right_P, decimal=config.STUMPY_TEST_PRECISION
+        ref_P, comp_P, decimal=config.STUMPY_TEST_PRECISION
     )  # ignore indices
 
 
@@ -283,11 +283,11 @@ def test_mstump_nan_inf_self_join_first_dimension(
         T_sub[:] = T[:]
         T_sub[0, substitution_location] = substitute
 
-        left_P, left_I = naive.mstump(T_sub, m, excl_zone)
-        right_P, right_I = mstump(T_sub, m)
+        ref_P, ref_I = naive.mstump(T_sub, m, excl_zone)
+        comp_P, comp_I = mstump(T_sub, m)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
 
 
 @pytest.mark.parametrize("T, m", test_data)
@@ -302,8 +302,8 @@ def test_mstump_nan_self_join_all_dimensions(T, m, substitute, substitution_loca
         T_sub[:] = T[:]
         T_sub[:, substitution_location] = substitute
 
-        left_P, left_I = naive.mstump(T_sub, m, excl_zone)
-        right_P, right_I = mstump(T_sub, m)
+        ref_P, ref_I = naive.mstump(T_sub, m, excl_zone)
+        comp_P, comp_I = mstump(T_sub, m)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)

--- a/tests/test_mstumped.py
+++ b/tests/test_mstumped.py
@@ -33,11 +33,11 @@ def test_mstumped(T, m, dask_cluster):
     with Client(dask_cluster) as dask_client:
         excl_zone = int(np.ceil(m / 4))
 
-        left_P, left_I = naive.mstump(T, m, excl_zone)
-        right_P, right_I = mstumped(dask_client, T, m)
+        ref_P, ref_I = naive.mstump(T, m, excl_zone)
+        comp_P, comp_I = mstumped(dask_client, T, m)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
 
 
 @pytest.mark.filterwarnings("ignore:\\s+Port 8787 is already in use:UserWarning")
@@ -50,11 +50,11 @@ def test_mstumped_include(T, m, dask_cluster):
 
                 excl_zone = int(np.ceil(m / 4))
 
-                left_P, left_I = naive.mstump(T, m, excl_zone, include)
-                right_P, right_I = mstumped(dask_client, T, m, include)
+                ref_P, ref_I = naive.mstump(T, m, excl_zone, include)
+                comp_P, comp_I = mstumped(dask_client, T, m, include)
 
-                npt.assert_almost_equal(left_P, right_P)
-                npt.assert_almost_equal(left_I, right_I)
+                npt.assert_almost_equal(ref_P, comp_P)
+                npt.assert_almost_equal(ref_I, comp_I)
 
 
 @pytest.mark.filterwarnings("ignore:\\s+Port 8787 is already in use:UserWarning")
@@ -63,11 +63,11 @@ def test_mstumped_discords(T, m, dask_cluster):
     with Client(dask_cluster) as dask_client:
         excl_zone = int(np.ceil(m / 4))
 
-        left_P, left_I = naive.mstump(T, m, excl_zone, discords=True)
-        right_P, right_I = mstumped(dask_client, T, m, discords=True)
+        ref_P, ref_I = naive.mstump(T, m, excl_zone, discords=True)
+        comp_P, comp_I = mstumped(dask_client, T, m, discords=True)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
 
 
 @pytest.mark.filterwarnings("ignore:\\s+Port 8787 is already in use:UserWarning")
@@ -80,11 +80,11 @@ def test_mstumped_include_discords(T, m, dask_cluster):
 
                 excl_zone = int(np.ceil(m / 4))
 
-                left_P, left_I = naive.mstump(T, m, excl_zone, include, discords=True)
-                right_P, right_I = mstumped(dask_client, T, m, include, discords=True)
+                ref_P, ref_I = naive.mstump(T, m, excl_zone, include, discords=True)
+                comp_P, comp_I = mstumped(dask_client, T, m, include, discords=True)
 
-                npt.assert_almost_equal(left_P, right_P)
-                npt.assert_almost_equal(left_I, right_I)
+                npt.assert_almost_equal(ref_P, comp_P)
+                npt.assert_almost_equal(ref_I, comp_I)
 
 
 @pytest.mark.filterwarnings("ignore:\\s+Port 8787 is already in use:UserWarning")
@@ -93,12 +93,12 @@ def test_mstumped_df(T, m, dask_cluster):
     with Client(dask_cluster) as dask_client:
         excl_zone = int(np.ceil(m / 4))
 
-        left_P, left_I = naive.mstump(T, m, excl_zone)
+        ref_P, ref_I = naive.mstump(T, m, excl_zone)
         df = pd.DataFrame(T.T)
-        right_P, right_I = mstumped(dask_client, df, m)
+        comp_P, comp_I = mstumped(dask_client, df, m)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
 
 
 @pytest.mark.filterwarnings("ignore:\\s+Port 8787 is already in use:UserWarning")
@@ -112,10 +112,10 @@ def test_mstumped_constant_subsequence_self_join(dask_cluster):
 
         excl_zone = int(np.ceil(m / 4))
 
-        left_P, left_I = naive.mstump(T, m, excl_zone)
-        right_P, right_I = mstumped(dask_client, T, m)
+        ref_P, ref_I = naive.mstump(T, m, excl_zone)
+        comp_P, comp_I = mstumped(dask_client, T, m)
 
-        npt.assert_almost_equal(left_P, right_P)  # ignore indices
+        npt.assert_almost_equal(ref_P, comp_P)  # ignore indices
 
 
 @pytest.mark.filterwarnings("ignore:\\s+Port 8787 is already in use:UserWarning")
@@ -130,9 +130,9 @@ def test_mstumped_identical_subsequence_self_join(dask_cluster):
 
         excl_zone = int(np.ceil(m / 4))
 
-        left_P, left_I = naive.mstump(T, m, excl_zone)
-        right_P, right_I = mstumped(dask_client, T, m)
+        ref_P, ref_I = naive.mstump(T, m, excl_zone)
+        comp_P, comp_I = mstumped(dask_client, T, m)
 
         npt.assert_almost_equal(
-            left_P, right_P, decimal=config.STUMPY_TEST_PRECISION
+            ref_P, comp_P, decimal=config.STUMPY_TEST_PRECISION
         )  # ignore indices

--- a/tests/test_mstumped_one_subsequence_inf_self_join.py
+++ b/tests/test_mstumped_one_subsequence_inf_self_join.py
@@ -35,11 +35,11 @@ def test_mstumped_one_subsequence_inf_self_join_first_dimension(
         T_sub = T.copy()
         T_sub[0, substitution_location] = np.inf
 
-        left_P, left_I = naive.mstump(T_sub, m, excl_zone)
-        right_P, right_I = mstumped(dask_client, T_sub, m)
+        ref_P, ref_I = naive.mstump(T_sub, m, excl_zone)
+        comp_P, comp_I = mstumped(dask_client, T_sub, m)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
 
 
 @pytest.mark.filterwarnings("ignore:\\s+Port 8787 is already in use:UserWarning")
@@ -54,8 +54,8 @@ def test_mstumped_one_subsequence_inf_self_join_all_dimensions(
         T_sub = T.copy()
         T_sub[:, substitution_location] = np.inf
 
-        left_P, left_I = naive.mstump(T_sub, m, excl_zone)
-        right_P, right_I = mstumped(dask_client, T_sub, m)
+        ref_P, ref_I = naive.mstump(T_sub, m, excl_zone)
+        comp_P, comp_I = mstumped(dask_client, T_sub, m)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)

--- a/tests/test_mstumped_one_subsequence_nan_self_join.py
+++ b/tests/test_mstumped_one_subsequence_nan_self_join.py
@@ -35,11 +35,11 @@ def test_mstumped_one_subsequence_nan_self_join_first_dimension(
         T_sub = T.copy()
         T_sub[0, substitution_location] = np.nan
 
-        left_P, left_I = naive.mstump(T_sub, m, excl_zone)
-        right_P, right_I = mstumped(dask_client, T_sub, m)
+        ref_P, ref_I = naive.mstump(T_sub, m, excl_zone)
+        comp_P, comp_I = mstumped(dask_client, T_sub, m)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
 
 
 @pytest.mark.filterwarnings("ignore:\\s+Port 8787 is already in use:UserWarning")
@@ -54,8 +54,8 @@ def test_mstumped_one_subsequence_nan_self_join_all_dimensions(
         T_sub = T.copy()
         T_sub[:, substitution_location] = np.nan
 
-        left_P, left_I = naive.mstump(T_sub, m, excl_zone)
-        right_P, right_I = mstumped(dask_client, T_sub, m)
+        ref_P, ref_I = naive.mstump(T_sub, m, excl_zone)
+        comp_P, comp_I = mstumped(dask_client, T_sub, m)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)

--- a/tests/test_scrump.py
+++ b/tests/test_scrump.py
@@ -136,13 +136,13 @@ def test_prescrump_self_join(T_A, T_B):
         seed = np.random.randint(100000)
 
         np.random.seed(seed)
-        left_P, left_I = naive_prescrump(T_B, m, T_B, s=s, exclusion_zone=zone)
+        ref_P, ref_I = naive_prescrump(T_B, m, T_B, s=s, exclusion_zone=zone)
 
         np.random.seed(seed)
-        right_P, right_I = prescrump(T_B, m, s=s)
+        comp_P, comp_I = prescrump(T_B, m, s=s)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -153,13 +153,13 @@ def test_prescrump_A_B_join(T_A, T_B):
         seed = np.random.randint(100000)
 
         np.random.seed(seed)
-        left_P, left_I = naive_prescrump(T_A, m, T_B, s=s)
+        ref_P, ref_I = naive_prescrump(T_A, m, T_B, s=s)
 
         np.random.seed(seed)
-        right_P, right_I = prescrump(T_A, m, T_B=T_B, s=s)
+        comp_P, comp_I = prescrump(T_A, m, T_B=T_B, s=s)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -170,13 +170,13 @@ def test_prescrump_A_B_join_swap(T_A, T_B):
         seed = np.random.randint(100000)
 
         np.random.seed(seed)
-        left_P, left_I = naive_prescrump(T_B, m, T_A, s=s)
+        ref_P, ref_I = naive_prescrump(T_B, m, T_A, s=s)
 
         np.random.seed(seed)
-        right_P, right_I = prescrump(T_B, m, T_B=T_A, s=s)
+        comp_P, comp_I = prescrump(T_B, m, T_B=T_A, s=s)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -188,13 +188,13 @@ def test_prescrump_self_join_larger_window(T_A, T_B, m):
             seed = np.random.randint(100000)
 
             np.random.seed(seed)
-            left_P, left_I = naive_prescrump(T_B, m, T_B, s=s, exclusion_zone=zone)
+            ref_P, ref_I = naive_prescrump(T_B, m, T_B, s=s, exclusion_zone=zone)
 
             np.random.seed(seed)
-            right_P, right_I = prescrump(T_B, m, s=s)
+            comp_P, comp_I = prescrump(T_B, m, s=s)
 
-            npt.assert_almost_equal(left_P, right_P)
-            npt.assert_almost_equal(left_I, right_I)
+            npt.assert_almost_equal(ref_P, comp_P)
+            npt.assert_almost_equal(ref_I, comp_I)
 
 
 def test_scrump_int_input():
@@ -212,28 +212,28 @@ def test_scrump_self_join(T_A, T_B, percentages):
         seed = np.random.randint(100000)
 
         np.random.seed(seed)
-        left = naive_scrump(T_B, m, T_B, percentage, zone, False, None)
-        left_P = left[:, 0]
-        left_I = left[:, 1]
-        left_left_I = left[:, 2]
-        left_right_I = left[:, 3]
+        ref_mp = naive_scrump(T_B, m, T_B, percentage, zone, False, None)
+        ref_P = ref_mp[:, 0]
+        ref_I = ref_mp[:, 1]
+        ref_left_I = ref_mp[:, 2]
+        ref_right_I = ref_mp[:, 3]
 
         np.random.seed(seed)
         approx = scrump(
             T_B, m, ignore_trivial=True, percentage=percentage, pre_scrump=False
         )
         approx.update()
-        right_P = approx.P_
-        right_I = approx.I_
-        right_left_I = approx.left_I_
-        right_right_I = approx.right_I_
+        comp_P = approx.P_
+        comp_I = approx.I_
+        comp_left_I = approx.left_I_
+        comp_right_I = approx.right_I_
 
-        naive.replace_inf(left_P)
-        naive.replace_inf(right_P)
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
-        npt.assert_almost_equal(left_left_I, right_left_I)
-        npt.assert_almost_equal(left_right_I, right_right_I)
+        naive.replace_inf(ref_P)
+        naive.replace_inf(comp_P)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
+        npt.assert_almost_equal(ref_left_I, comp_left_I)
+        npt.assert_almost_equal(ref_right_I, comp_right_I)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -245,29 +245,29 @@ def test_scrump_A_B_join(T_A, T_B, percentages):
         seed = np.random.randint(100000)
 
         np.random.seed(seed)
-        left = naive_scrump(T_A, m, T_B, percentage, None, False, None)
-        left_P = left[:, 0]
-        left_I = left[:, 1]
-        left_left_I = left[:, 2]
-        left_right_I = left[:, 3]
+        ref_mp = naive_scrump(T_A, m, T_B, percentage, None, False, None)
+        ref_P = ref_mp[:, 0]
+        ref_I = ref_mp[:, 1]
+        ref_left_I = ref_mp[:, 2]
+        ref_right_I = ref_mp[:, 3]
 
         np.random.seed(seed)
         approx = scrump(
             T_A, m, T_B, ignore_trivial=False, percentage=percentage, pre_scrump=False
         )
         approx.update()
-        right_P = approx.P_
-        right_I = approx.I_
-        right_left_I = approx.left_I_
-        right_right_I = approx.right_I_
+        comp_P = approx.P_
+        comp_I = approx.I_
+        comp_left_I = approx.left_I_
+        comp_right_I = approx.right_I_
 
-        naive.replace_inf(left_P)
-        naive.replace_inf(right_P)
+        naive.replace_inf(ref_P)
+        naive.replace_inf(comp_P)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
-        npt.assert_almost_equal(left_left_I, right_left_I)
-        npt.assert_almost_equal(left_right_I, right_right_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
+        npt.assert_almost_equal(ref_left_I, comp_left_I)
+        npt.assert_almost_equal(ref_right_I, comp_right_I)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -279,29 +279,29 @@ def test_scrump_A_B_join_swap(T_A, T_B, percentages):
         seed = np.random.randint(100000)
 
         np.random.seed(seed)
-        left = naive_scrump(T_B, m, T_A, percentage, None, False, None)
-        left_P = left[:, 0]
-        left_I = left[:, 1]
-        left_left_I = left[:, 2]
-        left_right_I = left[:, 3]
+        ref_mp = naive_scrump(T_B, m, T_A, percentage, None, False, None)
+        ref_P = ref_mp[:, 0]
+        ref_I = ref_mp[:, 1]
+        ref_left_I = ref_mp[:, 2]
+        ref_right_I = ref_mp[:, 3]
 
         np.random.seed(seed)
         approx = scrump(
             T_B, m, T_A, ignore_trivial=False, percentage=percentage, pre_scrump=False
         )
         approx.update()
-        right_P = approx.P_
-        right_I = approx.I_
-        right_left_I = approx.left_I_
-        right_right_I = approx.right_I_
+        comp_P = approx.P_
+        comp_I = approx.I_
+        comp_left_I = approx.left_I_
+        comp_right_I = approx.right_I_
 
-        naive.replace_inf(left_P)
-        naive.replace_inf(right_P)
+        naive.replace_inf(ref_P)
+        naive.replace_inf(comp_P)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_left_I, right_left_I)
-        npt.assert_almost_equal(left_right_I, right_right_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_left_I, comp_left_I)
+        npt.assert_almost_equal(ref_right_I, comp_right_I)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -315,29 +315,29 @@ def test_scrump_self_join_larger_window(T_A, T_B, m, percentages):
             seed = np.random.randint(100000)
 
             np.random.seed(seed)
-            left = naive_scrump(T_B, m, T_B, percentage, zone, False, None)
-            left_P = left[:, 0]
-            left_I = left[:, 1]
-            left_left_I = left[:, 2]
-            left_right_I = left[:, 3]
+            ref_mp = naive_scrump(T_B, m, T_B, percentage, zone, False, None)
+            ref_P = ref_mp[:, 0]
+            ref_I = ref_mp[:, 1]
+            ref_left_I = ref_mp[:, 2]
+            ref_right_I = ref_mp[:, 3]
 
             np.random.seed(seed)
             approx = scrump(
                 T_B, m, ignore_trivial=True, percentage=percentage, pre_scrump=False
             )
             approx.update()
-            right_P = approx.P_
-            right_I = approx.I_
-            right_left_I = approx.left_I_
-            right_right_I = approx.right_I_
+            comp_P = approx.P_
+            comp_I = approx.I_
+            comp_left_I = approx.left_I_
+            comp_right_I = approx.right_I_
 
-            naive.replace_inf(left_P)
-            naive.replace_inf(right_P)
+            naive.replace_inf(ref_P)
+            naive.replace_inf(comp_P)
 
-            npt.assert_almost_equal(left_P, right_P)
-            npt.assert_almost_equal(left_I, right_I)
-            npt.assert_almost_equal(left_left_I, right_left_I)
-            npt.assert_almost_equal(left_right_I, right_right_I)
+            npt.assert_almost_equal(ref_P, comp_P)
+            npt.assert_almost_equal(ref_I, comp_I)
+            npt.assert_almost_equal(ref_left_I, comp_left_I)
+            npt.assert_almost_equal(ref_right_I, comp_right_I)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -345,37 +345,37 @@ def test_scrump_self_join_full(T_A, T_B):
     m = 3
     zone = int(np.ceil(m / 4))
 
-    left = naive.stamp(T_B, m, exclusion_zone=zone)
-    left_P = left[:, 0]
-    left_I = left[:, 1]
-    left_left_I = left[:, 2]
-    left_right_I = left[:, 3]
+    ref_mp = naive.stamp(T_B, m, exclusion_zone=zone)
+    ref_P = ref_mp[:, 0]
+    ref_I = ref_mp[:, 1]
+    ref_left_I = ref_mp[:, 2]
+    ref_right_I = ref_mp[:, 3]
 
     approx = scrump(T_B, m, ignore_trivial=True, percentage=1.0, pre_scrump=False)
     approx.update()
-    right_P = approx.P_
-    right_I = approx.I_
-    right_left_I = approx.left_I_
-    right_right_I = approx.right_I_
+    comp_P = approx.P_
+    comp_I = approx.I_
+    comp_left_I = approx.left_I_
+    comp_right_I = approx.right_I_
 
-    naive.replace_inf(left_P)
-    naive.replace_inf(right_P)
+    naive.replace_inf(ref_P)
+    naive.replace_inf(comp_P)
 
-    npt.assert_almost_equal(left_P, right_P)
-    npt.assert_almost_equal(left_I, right_I)
-    npt.assert_almost_equal(left_left_I, right_left_I)
-    npt.assert_almost_equal(left_right_I, right_right_I)
+    npt.assert_almost_equal(ref_P, comp_P)
+    npt.assert_almost_equal(ref_I, comp_I)
+    npt.assert_almost_equal(ref_left_I, comp_left_I)
+    npt.assert_almost_equal(ref_right_I, comp_right_I)
 
-    left = stump(T_B, m, ignore_trivial=True)
-    left_P = left[:, 0]
-    left_I = left[:, 1]
-    left_left_I = left[:, 2]
-    left_right_I = left[:, 3]
+    ref_mp = stump(T_B, m, ignore_trivial=True)
+    ref_P = ref_mp[:, 0]
+    ref_I = ref_mp[:, 1]
+    ref_left_I = ref_mp[:, 2]
+    ref_right_I = ref_mp[:, 3]
 
-    npt.assert_almost_equal(left_P, right_P)
-    npt.assert_almost_equal(left_I, right_I)
-    npt.assert_almost_equal(left_left_I, right_left_I)
-    npt.assert_almost_equal(left_right_I, right_right_I)
+    npt.assert_almost_equal(ref_P, comp_P)
+    npt.assert_almost_equal(ref_I, comp_I)
+    npt.assert_almost_equal(ref_left_I, comp_left_I)
+    npt.assert_almost_equal(ref_right_I, comp_right_I)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -384,37 +384,37 @@ def test_scrump_A_B_join_full(T_A, T_B):
     m = 3
     zone = int(np.ceil(m / 4))
 
-    left = naive.stamp(T_A, m, T_B=T_B)
-    left_P = left[:, 0]
-    left_I = left[:, 1]
-    left_left_I = left[:, 2]
-    left_right_I = left[:, 3]
+    ref_mp = naive.stamp(T_A, m, T_B=T_B)
+    ref_P = ref_mp[:, 0]
+    ref_I = ref_mp[:, 1]
+    ref_left_I = ref_mp[:, 2]
+    ref_right_I = ref_mp[:, 3]
 
     approx = scrump(T_A, m, T_B, ignore_trivial=False, percentage=1.0, pre_scrump=False)
     approx.update()
-    right_P = approx.P_
-    right_I = approx.I_
-    right_left_I = approx.left_I_
-    right_right_I = approx.right_I_
+    comp_P = approx.P_
+    comp_I = approx.I_
+    comp_left_I = approx.left_I_
+    comp_right_I = approx.right_I_
 
-    naive.replace_inf(left_P)
-    naive.replace_inf(right_P)
+    naive.replace_inf(ref_P)
+    naive.replace_inf(comp_P)
 
-    npt.assert_almost_equal(left_P, right_P)
-    npt.assert_almost_equal(left_I, right_I)
-    npt.assert_almost_equal(left_left_I, right_left_I)
-    npt.assert_almost_equal(left_right_I, right_right_I)
+    npt.assert_almost_equal(ref_P, comp_P)
+    npt.assert_almost_equal(ref_I, comp_I)
+    npt.assert_almost_equal(ref_left_I, comp_left_I)
+    npt.assert_almost_equal(ref_right_I, comp_right_I)
 
-    left = stump(T_A, m, T_B=T_B, ignore_trivial=False)
-    left_P = left[:, 0]
-    left_I = left[:, 1]
-    left_left_I = left[:, 2]
-    left_right_I = left[:, 3]
+    ref_mp = stump(T_A, m, T_B=T_B, ignore_trivial=False)
+    ref_P = ref_mp[:, 0]
+    ref_I = ref_mp[:, 1]
+    ref_left_I = ref_mp[:, 2]
+    ref_right_I = ref_mp[:, 3]
 
-    npt.assert_almost_equal(left_P, right_P)
-    npt.assert_almost_equal(left_I, right_I)
-    npt.assert_almost_equal(left_left_I, right_left_I)
-    npt.assert_almost_equal(left_right_I, right_right_I)
+    npt.assert_almost_equal(ref_P, comp_P)
+    npt.assert_almost_equal(ref_I, comp_I)
+    npt.assert_almost_equal(ref_left_I, comp_left_I)
+    npt.assert_almost_equal(ref_right_I, comp_right_I)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -423,26 +423,26 @@ def test_scrump_A_B_join_full_swap(T_A, T_B):
     m = 3
     zone = int(np.ceil(m / 4))
 
-    left = naive.stamp(T_B, m, T_B=T_A)
-    left_P = left[:, 0]
-    left_I = left[:, 1]
-    left_left_I = left[:, 2]
-    left_right_I = left[:, 3]
+    ref_mp = naive.stamp(T_B, m, T_B=T_A)
+    ref_P = ref_mp[:, 0]
+    ref_I = ref_mp[:, 1]
+    ref_left_I = ref_mp[:, 2]
+    ref_right_I = ref_mp[:, 3]
 
     approx = scrump(T_B, m, T_A, ignore_trivial=False, percentage=1.0, pre_scrump=False)
     approx.update()
-    right_P = approx.P_
-    right_I = approx.I_
-    right_left_I = approx.left_I_
-    right_right_I = approx.right_I_
+    comp_P = approx.P_
+    comp_I = approx.I_
+    comp_left_I = approx.left_I_
+    comp_right_I = approx.right_I_
 
-    naive.replace_inf(left_P)
-    naive.replace_inf(right_P)
+    naive.replace_inf(ref_P)
+    naive.replace_inf(comp_P)
 
-    npt.assert_almost_equal(left_P, right_P)
-    npt.assert_almost_equal(left_I, right_I)
-    npt.assert_almost_equal(left_left_I, right_left_I)
-    npt.assert_almost_equal(left_right_I, right_right_I)
+    npt.assert_almost_equal(ref_P, comp_P)
+    npt.assert_almost_equal(ref_I, comp_I)
+    npt.assert_almost_equal(ref_left_I, comp_left_I)
+    npt.assert_almost_equal(ref_right_I, comp_right_I)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -451,26 +451,26 @@ def test_scrump_self_join_full_larger_window(T_A, T_B, m):
     if len(T_B) > m:
         zone = int(np.ceil(m / 4))
 
-        left = naive.stamp(T_B, m, exclusion_zone=zone)
-        left_P = left[:, 0]
-        left_I = left[:, 1]
-        left_left_I = left[:, 2]
-        left_right_I = left[:, 3]
+        ref_mp = naive.stamp(T_B, m, exclusion_zone=zone)
+        ref_P = ref_mp[:, 0]
+        ref_I = ref_mp[:, 1]
+        ref_left_I = ref_mp[:, 2]
+        ref_right_I = ref_mp[:, 3]
 
         approx = scrump(T_B, m, ignore_trivial=True, percentage=1.0, pre_scrump=False)
         approx.update()
-        right_P = approx.P_
-        right_I = approx.I_
-        right_left_I = approx.left_I_
-        right_right_I = approx.right_I_
+        comp_P = approx.P_
+        comp_I = approx.I_
+        comp_left_I = approx.left_I_
+        comp_right_I = approx.right_I_
 
-        naive.replace_inf(left_P)
-        naive.replace_inf(right_P)
+        naive.replace_inf(ref_P)
+        naive.replace_inf(comp_P)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
-        npt.assert_almost_equal(left_left_I, right_left_I)
-        npt.assert_almost_equal(left_right_I, right_right_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
+        npt.assert_almost_equal(ref_left_I, comp_left_I)
+        npt.assert_almost_equal(ref_right_I, comp_right_I)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -484,34 +484,34 @@ def test_scrump_plus_plus_self_join(T_A, T_B, percentages):
             seed = np.random.randint(100000)
 
             np.random.seed(seed)
-            left_P, left_I = naive_prescrump(T_B, m, T_B, s=s, exclusion_zone=zone)
-            left = naive_scrump(T_B, m, T_B, percentage, zone, True, s)
-            for i in range(left.shape[0]):
-                if left_P[i] < left[i, 0]:
-                    left[i, 0] = left_P[i]
-                    left[i, 1] = left_I[i]
-            left_P = left[:, 0]
-            left_I = left[:, 1]
-            left_left_I = left[:, 2]
-            left_right_I = left[:, 3]
+            ref_P, ref_I = naive_prescrump(T_B, m, T_B, s=s, exclusion_zone=zone)
+            ref_mp = naive_scrump(T_B, m, T_B, percentage, zone, True, s)
+            for i in range(ref_mp.shape[0]):
+                if ref_P[i] < ref_mp[i, 0]:
+                    ref_mp[i, 0] = ref_P[i]
+                    ref_mp[i, 1] = ref_I[i]
+            ref_P = ref_mp[:, 0]
+            ref_I = ref_mp[:, 1]
+            ref_left_I = ref_mp[:, 2]
+            ref_right_I = ref_mp[:, 3]
 
             np.random.seed(seed)
             approx = scrump(
                 T_B, m, ignore_trivial=True, percentage=percentage, pre_scrump=True, s=s
             )
             approx.update()
-            right_P = approx.P_
-            right_I = approx.I_
-            right_left_I = approx.left_I_
-            right_right_I = approx.right_I_
+            comp_P = approx.P_
+            comp_I = approx.I_
+            comp_left_I = approx.left_I_
+            comp_right_I = approx.right_I_
 
-            naive.replace_inf(left_P)
-            naive.replace_inf(right_I)
+            naive.replace_inf(ref_P)
+            naive.replace_inf(comp_I)
 
-            npt.assert_almost_equal(left_P, right_P)
-            npt.assert_almost_equal(left_I, right_I)
-            # npt.assert_almost_equal(left_left_I, right_left_I)
-            # npt.assert_almost_equal(left_right_I, right_right_I)
+            npt.assert_almost_equal(ref_P, comp_P)
+            npt.assert_almost_equal(ref_I, comp_I)
+            # npt.assert_almost_equal(ref_left_I, comp_left_I)
+            # npt.assert_almost_equal(ref_right_I, comp_right_I)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -525,16 +525,16 @@ def test_scrump_plus_plus_A_B_join(T_A, T_B, percentages):
             seed = np.random.randint(100000)
 
             np.random.seed(seed)
-            left_P, left_I = naive_prescrump(T_A, m, T_B, s=s)
-            left = naive_scrump(T_A, m, T_B, percentage, None, False, None)
-            for i in range(left.shape[0]):
-                if left_P[i] < left[i, 0]:
-                    left[i, 0] = left_P[i]
-                    left[i, 1] = left_I[i]
-            left_P = left[:, 0]
-            left_I = left[:, 1]
-            left_left_I = left[:, 2]
-            left_right_I = left[:, 3]
+            ref_P, ref_I = naive_prescrump(T_A, m, T_B, s=s)
+            ref_mp = naive_scrump(T_A, m, T_B, percentage, None, False, None)
+            for i in range(ref_mp.shape[0]):
+                if ref_P[i] < ref_mp[i, 0]:
+                    ref_mp[i, 0] = ref_P[i]
+                    ref_mp[i, 1] = ref_I[i]
+            ref_P = ref_mp[:, 0]
+            ref_I = ref_mp[:, 1]
+            ref_left_I = ref_mp[:, 2]
+            ref_right_I = ref_mp[:, 3]
 
             approx = scrump(
                 T_A,
@@ -546,18 +546,18 @@ def test_scrump_plus_plus_A_B_join(T_A, T_B, percentages):
                 s=s,
             )
             approx.update()
-            right_P = approx.P_
-            right_I = approx.I_
-            right_left_I = approx.left_I_
-            right_right_I = approx.right_I_
+            comp_P = approx.P_
+            comp_I = approx.I_
+            comp_left_I = approx.left_I_
+            comp_right_I = approx.right_I_
 
-            naive.replace_inf(left_P)
-            naive.replace_inf(right_P)
+            naive.replace_inf(ref_P)
+            naive.replace_inf(comp_P)
 
-            npt.assert_almost_equal(left_P, right_P)
-            npt.assert_almost_equal(left_I, right_I)
-            npt.assert_almost_equal(left_left_I, right_left_I)
-            npt.assert_almost_equal(left_right_I, right_right_I)
+            npt.assert_almost_equal(ref_P, comp_P)
+            npt.assert_almost_equal(ref_I, comp_I)
+            npt.assert_almost_equal(ref_left_I, comp_left_I)
+            npt.assert_almost_equal(ref_right_I, comp_right_I)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -565,28 +565,28 @@ def test_scrump_plus_plus_self_join_full(T_A, T_B):
     m = 3
     zone = int(np.ceil(m / 4))
 
-    left = naive.stamp(T_B, m, exclusion_zone=zone)
-    left_P = left[:, 0]
-    left_I = left[:, 1]
-    left_left_I = left[:, 2]
-    left_right_I = left[:, 3]
+    ref_mp = naive.stamp(T_B, m, exclusion_zone=zone)
+    ref_P = ref_mp[:, 0]
+    ref_I = ref_mp[:, 1]
+    ref_left_I = ref_mp[:, 2]
+    ref_right_I = ref_mp[:, 3]
 
     approx = scrump(
         T_B, m, ignore_trivial=True, percentage=1.0, pre_scrump=True, s=zone
     )
     approx.update()
-    right_P = approx.P_
-    right_I = approx.I_
-    right_left_I = approx.left_I_
-    right_right_I = approx.right_I_
+    comp_P = approx.P_
+    comp_I = approx.I_
+    comp_left_I = approx.left_I_
+    comp_right_I = approx.right_I_
 
-    naive.replace_inf(left_P)
-    naive.replace_inf(right_P)
+    naive.replace_inf(ref_P)
+    naive.replace_inf(comp_P)
 
-    npt.assert_almost_equal(left_P, right_P)
-    npt.assert_almost_equal(left_I, right_I)
-    npt.assert_almost_equal(left_left_I, right_left_I)
-    npt.assert_almost_equal(left_right_I, right_right_I)
+    npt.assert_almost_equal(ref_P, comp_P)
+    npt.assert_almost_equal(ref_I, comp_I)
+    npt.assert_almost_equal(ref_left_I, comp_left_I)
+    npt.assert_almost_equal(ref_right_I, comp_right_I)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -594,28 +594,28 @@ def test_scrump_plus_plus_A_B_join_full(T_A, T_B):
     m = 3
     zone = int(np.ceil(m / 4))
 
-    left = naive.stamp(T_A, m, T_B=T_B)
-    left_P = left[:, 0]
-    left_I = left[:, 1]
-    left_left_I = left[:, 2]
-    left_right_I = left[:, 3]
+    ref_mp = naive.stamp(T_A, m, T_B=T_B)
+    ref_P = ref_mp[:, 0]
+    ref_I = ref_mp[:, 1]
+    ref_left_I = ref_mp[:, 2]
+    ref_right_I = ref_mp[:, 3]
 
     approx = scrump(
         T_A, m, T_B=T_B, ignore_trivial=False, percentage=1.0, pre_scrump=True, s=zone
     )
     approx.update()
-    right_P = approx.P_
-    right_I = approx.I_
-    right_left_I = approx.left_I_
-    right_right_I = approx.right_I_
+    comp_P = approx.P_
+    comp_I = approx.I_
+    comp_left_I = approx.left_I_
+    comp_right_I = approx.right_I_
 
-    naive.replace_inf(left_P)
-    naive.replace_inf(right_P)
+    naive.replace_inf(ref_P)
+    naive.replace_inf(comp_P)
 
-    npt.assert_almost_equal(left_P, right_P)
-    npt.assert_almost_equal(left_I, right_I)
-    npt.assert_almost_equal(left_left_I, right_left_I)
-    npt.assert_almost_equal(left_right_I, right_right_I)
+    npt.assert_almost_equal(ref_P, comp_P)
+    npt.assert_almost_equal(ref_I, comp_I)
+    npt.assert_almost_equal(ref_left_I, comp_left_I)
+    npt.assert_almost_equal(ref_right_I, comp_right_I)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -623,28 +623,28 @@ def test_scrump_plus_plus_A_B_join_full_swap(T_A, T_B):
     m = 3
     zone = int(np.ceil(m / 4))
 
-    left = naive.stamp(T_B, m, T_B=T_A)
-    left_P = left[:, 0]
-    left_I = left[:, 1]
-    left_left_I = left[:, 2]
-    left_right_I = left[:, 3]
+    ref_mp = naive.stamp(T_B, m, T_B=T_A)
+    ref_P = ref_mp[:, 0]
+    ref_I = ref_mp[:, 1]
+    ref_left_I = ref_mp[:, 2]
+    ref_right_I = ref_mp[:, 3]
 
     approx = scrump(
         T_B, m, T_B=T_A, ignore_trivial=False, percentage=1.0, pre_scrump=True, s=zone
     )
     approx.update()
-    right_P = approx.P_
-    right_I = approx.I_
-    right_left_I = approx.left_I_
-    right_right_I = approx.right_I_
+    comp_P = approx.P_
+    comp_I = approx.I_
+    comp_left_I = approx.left_I_
+    comp_right_I = approx.right_I_
 
-    naive.replace_inf(left_P)
-    naive.replace_inf(right_P)
+    naive.replace_inf(ref_P)
+    naive.replace_inf(comp_P)
 
-    npt.assert_almost_equal(left_P, right_P)
-    npt.assert_almost_equal(left_I, right_I)
-    npt.assert_almost_equal(left_left_I, right_left_I)
-    npt.assert_almost_equal(left_right_I, right_right_I)
+    npt.assert_almost_equal(ref_P, comp_P)
+    npt.assert_almost_equal(ref_I, comp_I)
+    npt.assert_almost_equal(ref_left_I, comp_left_I)
+    npt.assert_almost_equal(ref_right_I, comp_right_I)
 
 
 @pytest.mark.parametrize("percentages", percentages)
@@ -658,29 +658,29 @@ def test_scrump_constant_subsequence_self_join(percentages):
         seed = np.random.randint(100000)
 
         np.random.seed(seed)
-        left = naive_scrump(T, m, T, percentage, zone, False, None)
-        left_P = left[:, 0]
-        left_I = left[:, 1]
-        left_left_I = left[:, 2]
-        left_right_I = left[:, 3]
+        ref_mp = naive_scrump(T, m, T, percentage, zone, False, None)
+        ref_P = ref_mp[:, 0]
+        ref_I = ref_mp[:, 1]
+        ref_left_I = ref_mp[:, 2]
+        ref_right_I = ref_mp[:, 3]
 
         np.random.seed(seed)
         approx = scrump(
             T, m, ignore_trivial=True, percentage=percentage, pre_scrump=False
         )
         approx.update()
-        right_P = approx.P_
-        right_I = approx.I_
-        right_left_I = approx.left_I_
-        right_right_I = approx.right_I_
+        comp_P = approx.P_
+        comp_I = approx.I_
+        comp_left_I = approx.left_I_
+        comp_right_I = approx.right_I_
 
-        naive.replace_inf(left_P)
-        naive.replace_inf(right_P)
+        naive.replace_inf(ref_P)
+        naive.replace_inf(comp_P)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
-        npt.assert_almost_equal(left_left_I, right_left_I)
-        npt.assert_almost_equal(left_right_I, right_right_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
+        npt.assert_almost_equal(ref_left_I, comp_left_I)
+        npt.assert_almost_equal(ref_right_I, comp_right_I)
 
 
 @pytest.mark.parametrize("percentages", percentages)
@@ -696,29 +696,29 @@ def test_scrump_identical_subsequence_self_join(percentages):
         seed = np.random.randint(100000)
 
         np.random.seed(seed)
-        left = naive_scrump(T, m, T, percentage, zone, False, None)
-        left_P = left[:, 0]
-        left_I = left[:, 1]
-        left_left_I = left[:, 2]
-        left_right_I = left[:, 3]
+        ref_mp = naive_scrump(T, m, T, percentage, zone, False, None)
+        ref_P = ref_mp[:, 0]
+        ref_I = ref_mp[:, 1]
+        ref_left_I = ref_mp[:, 2]
+        ref_right_I = ref_mp[:, 3]
 
         np.random.seed(seed)
         approx = scrump(
             T, m, ignore_trivial=True, percentage=percentage, pre_scrump=False
         )
         approx.update()
-        right_P = approx.P_
-        right_I = approx.I_
-        right_left_I = approx.left_I_
-        right_right_I = approx.right_I_
+        comp_P = approx.P_
+        comp_I = approx.I_
+        comp_left_I = approx.left_I_
+        comp_right_I = approx.right_I_
 
-        naive.replace_inf(left_P)
-        naive.replace_inf(right_P)
+        naive.replace_inf(ref_P)
+        naive.replace_inf(comp_P)
 
-        npt.assert_almost_equal(left_P, right_P, decimal=config.STUMPY_TEST_PRECISION)
-        # npt.assert_almost_equal(left_I, right_I)
-        # npt.assert_almost_equal(left_left_I, right_left_I)
-        # npt.assert_almost_equal(left_right_I, right_right_I)
+        npt.assert_almost_equal(ref_P, comp_P, decimal=config.STUMPY_TEST_PRECISION)
+        # npt.assert_almost_equal(ref_I, comp_I)
+        # npt.assert_almost_equal(ref_left_I, comp_left_I)
+        # npt.assert_almost_equal(ref_right_I, comp_right_I)
 
 
 @pytest.mark.parametrize("T_A, T_B", test_data)
@@ -742,27 +742,27 @@ def test_scrump_nan_inf_self_join(
             seed = np.random.randint(100000)
 
             np.random.seed(seed)
-            left = naive_scrump(T_B_sub, m, T_B_sub, percentage, zone, False, None)
-            left_P = left[:, 0]
-            left_I = left[:, 1]
-            left_left_I = left[:, 2]
-            left_right_I = left[:, 3]
+            ref_mp = naive_scrump(T_B_sub, m, T_B_sub, percentage, zone, False, None)
+            ref_P = ref_mp[:, 0]
+            ref_I = ref_mp[:, 1]
+            ref_left_I = ref_mp[:, 2]
+            ref_right_I = ref_mp[:, 3]
 
             np.random.seed(seed)
             approx = scrump(T_B_sub, m, percentage=percentage, pre_scrump=False)
             approx.update()
-            right_P = approx.P_
-            right_I = approx.I_
-            right_left_I = approx.left_I_
-            right_right_I = approx.right_I_
+            comp_P = approx.P_
+            comp_I = approx.I_
+            comp_left_I = approx.left_I_
+            comp_right_I = approx.right_I_
 
-            naive.replace_inf(left_P)
-            naive.replace_inf(right_P)
+            naive.replace_inf(ref_P)
+            naive.replace_inf(comp_P)
 
-            npt.assert_almost_equal(left_P, right_P)
-            npt.assert_almost_equal(left_I, right_I)
-            npt.assert_almost_equal(left_left_I, right_left_I)
-            npt.assert_almost_equal(left_right_I, right_right_I)
+            npt.assert_almost_equal(ref_P, comp_P)
+            npt.assert_almost_equal(ref_I, comp_I)
+            npt.assert_almost_equal(ref_left_I, comp_left_I)
+            npt.assert_almost_equal(ref_right_I, comp_right_I)
 
 
 @pytest.mark.parametrize("percentages", percentages)
@@ -776,24 +776,24 @@ def test_scrump_nan_zero_mean_self_join(percentages):
         seed = np.random.randint(100000)
 
         np.random.seed(seed)
-        left = naive_scrump(T, m, T, percentage, zone, False, None)
-        left_P = left[:, 0]
-        left_I = left[:, 1]
-        left_left_I = left[:, 2]
-        left_right_I = left[:, 3]
+        ref_mp = naive_scrump(T, m, T, percentage, zone, False, None)
+        ref_P = ref_mp[:, 0]
+        ref_I = ref_mp[:, 1]
+        ref_left_I = ref_mp[:, 2]
+        ref_right_I = ref_mp[:, 3]
 
         np.random.seed(seed)
         approx = scrump(T, m, percentage=percentage, pre_scrump=False)
         approx.update()
-        right_P = approx.P_
-        right_I = approx.I_
-        right_left_I = approx.left_I_
-        right_right_I = approx.right_I_
+        comp_P = approx.P_
+        comp_I = approx.I_
+        comp_left_I = approx.left_I_
+        comp_right_I = approx.right_I_
 
-        naive.replace_inf(left_P)
-        naive.replace_inf(right_P)
+        naive.replace_inf(ref_P)
+        naive.replace_inf(comp_P)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
-        npt.assert_almost_equal(left_left_I, right_left_I)
-        npt.assert_almost_equal(left_right_I, right_right_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
+        npt.assert_almost_equal(ref_left_I, comp_left_I)
+        npt.assert_almost_equal(ref_right_I, comp_right_I)

--- a/tests/test_stamp.py
+++ b/tests/test_stamp.py
@@ -26,27 +26,27 @@ def test_stamp_mass_PI(T_A, T_B):
     zone = int(np.ceil(m / 2))
     Q = T_B[trivial_idx : trivial_idx + m]
     M_T, Σ_T = core.compute_mean_std(T_B, m)
-    left_P, left_I, left_left_I, left_right_I = naive.mass(
+    ref_P, ref_I, ref_left_I, ref_right_I = naive.mass(
         Q, T_B, m, trivial_idx=trivial_idx, excl_zone=zone, ignore_trivial=True
     )
-    right_P, right_I = stamp._mass_PI(
+    comp_P, comp_I = stamp._mass_PI(
         Q, T_B, M_T, Σ_T, trivial_idx=trivial_idx, excl_zone=zone
     )
 
-    npt.assert_almost_equal(left_P, right_P)
-    npt.assert_almost_equal(left_I, right_I)
+    npt.assert_almost_equal(ref_P, comp_P)
+    npt.assert_almost_equal(ref_I, comp_I)
 
-    right_left_P, right_left_I = stamp._mass_PI(
+    comp_left_P, comp_left_I = stamp._mass_PI(
         Q, T_B, M_T, Σ_T, trivial_idx=trivial_idx, excl_zone=zone, left=True
     )
 
-    npt.assert_almost_equal(left_left_I, right_left_I)
+    npt.assert_almost_equal(ref_left_I, comp_left_I)
 
-    right_right_P, right_right_I = stamp._mass_PI(
+    comp_right_P, comp_right_I = stamp._mass_PI(
         Q, T_B, M_T, Σ_T, trivial_idx=trivial_idx, excl_zone=zone, right=True
     )
 
-    npt.assert_almost_equal(left_right_I, right_right_I)
+    npt.assert_almost_equal(ref_right_I, comp_right_I)
 
 
 def test_stamp_int_input():

--- a/tests/test_stumpi.py
+++ b/tests/test_stumpi.py
@@ -27,31 +27,31 @@ def test_stumpi_self_join():
         t = np.random.rand()
         stream.update(t)
 
-    right_P = stream.P_
-    right_I = stream.I_
-    right_left_P = stream.left_P_
-    right_left_I = stream.left_I_
+    comp_P = stream.P_
+    comp_I = stream.I_
+    comp_left_P = stream.left_P_
+    comp_left_I = stream.left_I_
 
-    left = naive.stamp(stream.T_, m, exclusion_zone=zone)
-    left_P = left[:, 0]
-    left_I = left[:, 1]
-    left_left_P = np.empty(left_P.shape)
-    left_left_P[:] = np.inf
-    left_left_I = left[:, 2]
-    for i, j in enumerate(left_left_I):
+    ref_mp = naive.stamp(stream.T_, m, exclusion_zone=zone)
+    ref_P = ref_mp[:, 0]
+    ref_I = ref_mp[:, 1]
+    ref_left_P = np.empty(ref_P.shape)
+    ref_left_P[:] = np.inf
+    ref_left_I = ref_mp[:, 2]
+    for i, j in enumerate(ref_left_I):
         if j >= 0:
             D = core.mass(stream.T_[i : i + m], stream.T_[j : j + m])
-            left_left_P[i] = D[0]
+            ref_left_P[i] = D[0]
 
-    naive.replace_inf(left_P)
-    naive.replace_inf(left_left_P)
-    naive.replace_inf(right_P)
-    naive.replace_inf(right_left_P)
+    naive.replace_inf(ref_P)
+    naive.replace_inf(ref_left_P)
+    naive.replace_inf(comp_P)
+    naive.replace_inf(comp_left_P)
 
-    npt.assert_almost_equal(left_P, right_P)
-    npt.assert_almost_equal(left_I, right_I)
-    npt.assert_almost_equal(left_left_P, right_left_P)
-    npt.assert_almost_equal(left_left_I, right_left_I)
+    npt.assert_almost_equal(ref_P, comp_P)
+    npt.assert_almost_equal(ref_I, comp_I)
+    npt.assert_almost_equal(ref_left_P, comp_left_P)
+    npt.assert_almost_equal(ref_left_I, comp_left_I)
 
     np.random.seed(seed)
     T = np.random.rand(30)
@@ -61,18 +61,18 @@ def test_stumpi_self_join():
         t = np.random.rand()
         stream.update(t)
 
-    right_P = stream.P_
-    right_I = stream.I_
-    right_left_P = stream.left_P_
-    right_left_I = stream.left_I_
+    comp_P = stream.P_
+    comp_I = stream.I_
+    comp_left_P = stream.left_P_
+    comp_left_I = stream.left_I_
 
-    naive.replace_inf(right_P)
-    naive.replace_inf(right_left_P)
+    naive.replace_inf(comp_P)
+    naive.replace_inf(comp_left_P)
 
-    npt.assert_almost_equal(left_P, right_P)
-    npt.assert_almost_equal(left_I, right_I)
-    npt.assert_almost_equal(left_left_P, right_left_P)
-    npt.assert_almost_equal(left_left_I, right_left_I)
+    npt.assert_almost_equal(ref_P, comp_P)
+    npt.assert_almost_equal(ref_I, comp_I)
+    npt.assert_almost_equal(ref_left_P, comp_left_P)
+    npt.assert_almost_equal(ref_left_I, comp_left_I)
 
 
 def test_stumpi_self_join_egress():
@@ -84,106 +84,106 @@ def test_stumpi_self_join_egress():
     n = 30
     T = np.random.rand(n)
 
-    left = naive.stumpi_egress(T, m)
-    left_P = left.P_.copy()
-    left_I = left.I_
-    left_left_P = left.left_P_.copy()
-    left_left_I = left.left_I_
+    ref_mp = naive.stumpi_egress(T, m)
+    ref_P = ref_mp.P_.copy()
+    ref_I = ref_mp.I_
+    ref_left_P = ref_mp.left_P_.copy()
+    ref_left_I = ref_mp.left_I_
 
     stream = stumpi(T, m, egress=True)
 
-    right_P = stream.P_.copy()
-    right_I = stream.I_
-    right_left_P = stream.left_P_.copy()
-    right_left_I = stream.left_I_
+    comp_P = stream.P_.copy()
+    comp_I = stream.I_
+    comp_left_P = stream.left_P_.copy()
+    comp_left_I = stream.left_I_
 
-    naive.replace_inf(left_P)
-    naive.replace_inf(left_left_P)
-    naive.replace_inf(right_P)
-    naive.replace_inf(right_left_P)
+    naive.replace_inf(ref_P)
+    naive.replace_inf(ref_left_P)
+    naive.replace_inf(comp_P)
+    naive.replace_inf(comp_left_P)
 
-    npt.assert_almost_equal(left_P, right_P)
-    npt.assert_almost_equal(left_I, right_I)
-    npt.assert_almost_equal(left_left_P, right_left_P)
-    npt.assert_almost_equal(left_left_I, right_left_I)
+    npt.assert_almost_equal(ref_P, comp_P)
+    npt.assert_almost_equal(ref_I, comp_I)
+    npt.assert_almost_equal(ref_left_P, comp_left_P)
+    npt.assert_almost_equal(ref_left_I, comp_left_I)
 
     for i in range(34):
         t = np.random.rand()
-        left.update(t)
+        ref_mp.update(t)
         stream.update(t)
 
-        right_P = stream.P_.copy()
-        right_I = stream.I_
-        right_left_P = stream.left_P_.copy()
-        right_left_I = stream.left_I_
+        comp_P = stream.P_.copy()
+        comp_I = stream.I_
+        comp_left_P = stream.left_P_.copy()
+        comp_left_I = stream.left_I_
 
-        left_P = left.P_.copy()
-        left_I = left.I_
-        left_left_P = left.left_P_.copy()
-        left_left_I = left.left_I_
+        ref_P = ref_mp.P_.copy()
+        ref_I = ref_mp.I_
+        ref_left_P = ref_mp.left_P_.copy()
+        ref_left_I = ref_mp.left_I_
 
-        naive.replace_inf(left_P)
-        naive.replace_inf(left_left_P)
-        naive.replace_inf(right_P)
-        naive.replace_inf(right_left_P)
+        naive.replace_inf(ref_P)
+        naive.replace_inf(ref_left_P)
+        naive.replace_inf(comp_P)
+        naive.replace_inf(comp_left_P)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
-        npt.assert_almost_equal(left_left_P, right_left_P)
-        npt.assert_almost_equal(left_left_I, right_left_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
+        npt.assert_almost_equal(ref_left_P, comp_left_P)
+        npt.assert_almost_equal(ref_left_I, comp_left_I)
 
     np.random.seed(seed)
     T = np.random.rand(n)
     T = pd.Series(T)
 
-    left = naive.stumpi_egress(T, m)
-    left_P = left.P_.copy()
-    left_I = left.I_
-    left_left_P = left.left_P_.copy()
-    left_left_I = left.left_I_
+    ref_mp = naive.stumpi_egress(T, m)
+    ref_P = ref_mp.P_.copy()
+    ref_I = ref_mp.I_
+    ref_left_P = ref_mp.left_P_.copy()
+    ref_left_I = ref_mp.left_I_
 
     stream = stumpi(T, m, egress=True)
 
-    right_P = stream.P_.copy()
-    right_I = stream.I_
-    right_left_P = stream.left_P_.copy()
-    right_left_I = stream.left_I_
+    comp_P = stream.P_.copy()
+    comp_I = stream.I_
+    comp_left_P = stream.left_P_.copy()
+    comp_left_I = stream.left_I_
 
-    naive.replace_inf(left_P)
-    naive.replace_inf(left_left_P)
-    naive.replace_inf(right_P)
-    naive.replace_inf(right_left_P)
+    naive.replace_inf(ref_P)
+    naive.replace_inf(ref_left_P)
+    naive.replace_inf(comp_P)
+    naive.replace_inf(comp_left_P)
 
-    npt.assert_almost_equal(left_P, right_P)
-    npt.assert_almost_equal(left_I, right_I)
-    npt.assert_almost_equal(left_left_P, right_left_P)
-    npt.assert_almost_equal(left_left_I, right_left_I)
+    npt.assert_almost_equal(ref_P, comp_P)
+    npt.assert_almost_equal(ref_I, comp_I)
+    npt.assert_almost_equal(ref_left_P, comp_left_P)
+    npt.assert_almost_equal(ref_left_I, comp_left_I)
 
     for i in range(34):
         t = np.random.rand()
         t = np.random.rand()
-        left.update(t)
+        ref_mp.update(t)
         stream.update(t)
 
-        right_P = stream.P_.copy()
-        right_I = stream.I_
-        right_left_P = stream.left_P_.copy()
-        right_left_I = stream.left_I_
+        comp_P = stream.P_.copy()
+        comp_I = stream.I_
+        comp_left_P = stream.left_P_.copy()
+        comp_left_I = stream.left_I_
 
-        left_P = left.P_.copy()
-        left_I = left.I_
-        left_left_P = left.left_P_.copy()
-        left_left_I = left.left_I_
+        ref_P = ref_mp.P_.copy()
+        ref_I = ref_mp.I_
+        ref_left_P = ref_mp.left_P_.copy()
+        ref_left_I = ref_mp.left_I_
 
-        naive.replace_inf(left_P)
-        naive.replace_inf(left_left_P)
-        naive.replace_inf(right_P)
-        naive.replace_inf(right_left_P)
+        naive.replace_inf(ref_P)
+        naive.replace_inf(ref_left_P)
+        naive.replace_inf(comp_P)
+        naive.replace_inf(comp_left_P)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
-        npt.assert_almost_equal(left_left_P, right_left_P)
-        npt.assert_almost_equal(left_left_I, right_left_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
+        npt.assert_almost_equal(ref_left_P, comp_left_P)
+        npt.assert_almost_equal(ref_left_I, comp_left_I)
 
 
 @pytest.mark.parametrize("substitute", substitution_values)
@@ -207,18 +207,18 @@ def test_stumpi_init_nan_inf_self_join(substitute, substitution_locations):
             t = np.random.rand()
             stream.update(t)
 
-        right_P = stream.P_
-        right_I = stream.I_
+        comp_P = stream.P_
+        comp_I = stream.I_
 
         stream.T_[substitution_location] = substitute
-        left = naive.stamp(stream.T_, m, exclusion_zone=zone)
-        left_P = left[:, 0]
-        left_I = left[:, 1]
+        ref_mp = naive.stamp(stream.T_, m, exclusion_zone=zone)
+        ref_P = ref_mp[:, 0]
+        ref_I = ref_mp[:, 1]
 
-        naive.replace_inf(left_P)
-        naive.replace_inf(right_P)
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
+        naive.replace_inf(ref_P)
+        naive.replace_inf(comp_P)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
 
         np.random.seed(seed)
         T = np.random.rand(30)
@@ -232,13 +232,13 @@ def test_stumpi_init_nan_inf_self_join(substitute, substitution_locations):
             t = np.random.rand()
             stream.update(t)
 
-        right_P = stream.P_
-        right_I = stream.I_
+        comp_P = stream.P_
+        comp_I = stream.I_
 
-        naive.replace_inf(right_P)
+        naive.replace_inf(comp_P)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
 
 
 @pytest.mark.parametrize("substitute", substitution_values)
@@ -259,53 +259,53 @@ def test_stumpi_init_nan_inf_self_join_egress(substitute, substitution_locations
             substitution_location = T.shape[0] - 1
         T[substitution_location] = substitute
 
-        left = naive.stumpi_egress(T, m)
-        left_P = left.P_.copy()
-        left_I = left.I_
-        left_left_P = left.left_P_.copy()
-        left_left_I = left.left_I_
+        ref_mp = naive.stumpi_egress(T, m)
+        ref_P = ref_mp.P_.copy()
+        ref_I = ref_mp.I_
+        ref_left_P = ref_mp.left_P_.copy()
+        ref_left_I = ref_mp.left_I_
 
         stream = stumpi(T, m, egress=True)
 
-        right_P = stream.P_.copy()
-        right_I = stream.I_
-        right_left_P = stream.left_P_.copy()
-        right_left_I = stream.left_I_
+        comp_P = stream.P_.copy()
+        comp_I = stream.I_
+        comp_left_P = stream.left_P_.copy()
+        comp_left_I = stream.left_I_
 
-        naive.replace_inf(left_P)
-        naive.replace_inf(left_left_P)
-        naive.replace_inf(right_P)
-        naive.replace_inf(right_left_P)
+        naive.replace_inf(ref_P)
+        naive.replace_inf(ref_left_P)
+        naive.replace_inf(comp_P)
+        naive.replace_inf(comp_left_P)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
-        npt.assert_almost_equal(left_left_P, right_left_P)
-        npt.assert_almost_equal(left_left_I, right_left_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
+        npt.assert_almost_equal(ref_left_P, comp_left_P)
+        npt.assert_almost_equal(ref_left_I, comp_left_I)
 
         for i in range(34):
             t = np.random.rand()
-            left.update(t)
+            ref_mp.update(t)
             stream.update(t)
 
-            right_P = stream.P_.copy()
-            right_I = stream.I_
-            right_left_P = stream.left_P_.copy()
-            right_left_I = stream.left_I_
+            comp_P = stream.P_.copy()
+            comp_I = stream.I_
+            comp_left_P = stream.left_P_.copy()
+            comp_left_I = stream.left_I_
 
-            left_P = left.P_.copy()
-            left_I = left.I_
-            left_left_P = left.left_P_.copy()
-            left_left_I = left.left_I_
+            ref_P = ref_mp.P_.copy()
+            ref_I = ref_mp.I_
+            ref_left_P = ref_mp.left_P_.copy()
+            ref_left_I = ref_mp.left_I_
 
-            naive.replace_inf(left_P)
-            naive.replace_inf(left_left_P)
-            naive.replace_inf(right_P)
-            naive.replace_inf(right_left_P)
+            naive.replace_inf(ref_P)
+            naive.replace_inf(ref_left_P)
+            naive.replace_inf(comp_P)
+            naive.replace_inf(comp_left_P)
 
-            npt.assert_almost_equal(left_P, right_P)
-            npt.assert_almost_equal(left_I, right_I)
-            npt.assert_almost_equal(left_left_P, right_left_P)
-            npt.assert_almost_equal(left_left_I, right_left_I)
+            npt.assert_almost_equal(ref_P, comp_P)
+            npt.assert_almost_equal(ref_I, comp_I)
+            npt.assert_almost_equal(ref_left_P, comp_left_P)
+            npt.assert_almost_equal(ref_left_I, comp_left_I)
 
         np.random.seed(seed)
         T = np.random.rand(n)
@@ -315,53 +315,53 @@ def test_stumpi_init_nan_inf_self_join_egress(substitute, substitution_locations
         T[substitution_location] = substitute
         T = pd.Series(T)
 
-        left = naive.stumpi_egress(T, m)
-        left_P = left.P_.copy()
-        left_I = left.I_
-        left_left_P = left.left_P_.copy()
-        left_left_I = left.left_I_
+        ref_mp = naive.stumpi_egress(T, m)
+        ref_P = ref_mp.P_.copy()
+        ref_I = ref_mp.I_
+        ref_left_P = ref_mp.left_P_.copy()
+        ref_left_I = ref_mp.left_I_
 
         stream = stumpi(T, m, egress=True)
 
-        right_P = stream.P_.copy()
-        right_I = stream.I_
-        right_left_P = stream.left_P_.copy()
-        right_left_I = stream.left_I_
+        comp_P = stream.P_.copy()
+        comp_I = stream.I_
+        comp_left_P = stream.left_P_.copy()
+        comp_left_I = stream.left_I_
 
-        naive.replace_inf(left_P)
-        naive.replace_inf(left_left_P)
-        naive.replace_inf(right_P)
-        naive.replace_inf(right_left_P)
+        naive.replace_inf(ref_P)
+        naive.replace_inf(ref_left_P)
+        naive.replace_inf(comp_P)
+        naive.replace_inf(comp_left_P)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
-        npt.assert_almost_equal(left_left_P, right_left_P)
-        npt.assert_almost_equal(left_left_I, right_left_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
+        npt.assert_almost_equal(ref_left_P, comp_left_P)
+        npt.assert_almost_equal(ref_left_I, comp_left_I)
 
         for i in range(34):
             t = np.random.rand()
-            left.update(t)
+            ref_mp.update(t)
             stream.update(t)
 
-            right_P = stream.P_.copy()
-            right_I = stream.I_
-            right_left_P = stream.left_P_.copy()
-            right_left_I = stream.left_I_
+            comp_P = stream.P_.copy()
+            comp_I = stream.I_
+            comp_left_P = stream.left_P_.copy()
+            comp_left_I = stream.left_I_
 
-            left_P = left.P_.copy()
-            left_I = left.I_
-            left_left_P = left.left_P_.copy()
-            left_left_I = left.left_I_
+            ref_P = ref_mp.P_.copy()
+            ref_I = ref_mp.I_
+            ref_left_P = ref_mp.left_P_.copy()
+            ref_left_I = ref_mp.left_I_
 
-            naive.replace_inf(left_P)
-            naive.replace_inf(left_left_P)
-            naive.replace_inf(right_P)
-            naive.replace_inf(right_left_P)
+            naive.replace_inf(ref_P)
+            naive.replace_inf(ref_left_P)
+            naive.replace_inf(comp_P)
+            naive.replace_inf(comp_left_P)
 
-            npt.assert_almost_equal(left_P, right_P)
-            npt.assert_almost_equal(left_I, right_I)
-            npt.assert_almost_equal(left_left_P, right_left_P)
-            npt.assert_almost_equal(left_left_I, right_left_I)
+            npt.assert_almost_equal(ref_P, comp_P)
+            npt.assert_almost_equal(ref_I, comp_I)
+            npt.assert_almost_equal(ref_left_P, comp_left_P)
+            npt.assert_almost_equal(ref_left_I, comp_left_I)
 
 
 @pytest.mark.parametrize("substitute", substitution_values)
@@ -383,19 +383,19 @@ def test_stumpi_stream_nan_inf_self_join(substitute, substitution_locations):
         for t in T[30:]:
             stream.update(t)
 
-        right_P = stream.P_
-        right_I = stream.I_
+        comp_P = stream.P_
+        comp_I = stream.I_
 
         stream.T_[30:][substitution_location] = substitute
-        left = naive.stamp(stream.T_, m, exclusion_zone=zone)
-        left_P = left[:, 0]
-        left_I = left[:, 1]
+        ref_mp = naive.stamp(stream.T_, m, exclusion_zone=zone)
+        ref_P = ref_mp[:, 0]
+        ref_I = ref_mp[:, 1]
 
-        naive.replace_inf(left_P)
-        naive.replace_inf(right_P)
+        naive.replace_inf(ref_P)
+        naive.replace_inf(comp_P)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
 
         np.random.seed(seed)
         T = np.random.rand(64)
@@ -407,13 +407,13 @@ def test_stumpi_stream_nan_inf_self_join(substitute, substitution_locations):
         for t in T[30:]:
             stream.update(t)
 
-        right_P = stream.P_
-        right_I = stream.I_
+        comp_P = stream.P_
+        comp_I = stream.I_
 
-        naive.replace_inf(right_P)
+        naive.replace_inf(comp_P)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
 
 
 @pytest.mark.parametrize("substitute", substitution_values)
@@ -429,108 +429,108 @@ def test_stumpi_stream_nan_inf_self_join_egress(substitute, substitution_locatio
         T = np.random.rand(64)
         n = 30
 
-        left = naive.stumpi_egress(T[:n], m)
-        left_P = left.P_.copy()
-        left_I = left.I_
-        left_left_P = left.left_P_.copy()
-        left_left_I = left.left_I_
+        ref_mp = naive.stumpi_egress(T[:n], m)
+        ref_P = ref_mp.P_.copy()
+        ref_I = ref_mp.I_
+        ref_left_P = ref_mp.left_P_.copy()
+        ref_left_I = ref_mp.left_I_
 
         stream = stumpi(T[:n], m, egress=True)
 
-        right_P = stream.P_.copy()
-        right_I = stream.I_
-        right_left_P = stream.left_P_.copy()
-        right_left_I = stream.left_I_
+        comp_P = stream.P_.copy()
+        comp_I = stream.I_
+        comp_left_P = stream.left_P_.copy()
+        comp_left_I = stream.left_I_
 
-        naive.replace_inf(left_P)
-        naive.replace_inf(left_left_P)
-        naive.replace_inf(right_P)
-        naive.replace_inf(right_left_P)
+        naive.replace_inf(ref_P)
+        naive.replace_inf(ref_left_P)
+        naive.replace_inf(comp_P)
+        naive.replace_inf(comp_left_P)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
-        npt.assert_almost_equal(left_left_P, right_left_P)
-        npt.assert_almost_equal(left_left_I, right_left_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
+        npt.assert_almost_equal(ref_left_P, comp_left_P)
+        npt.assert_almost_equal(ref_left_I, comp_left_I)
 
         if substitution_location == -1:
             substitution_location = T[30:].shape[0] - 1
         T[n:][substitution_location] = substitute
         for t in T[n:]:
-            left.update(t)
+            ref_mp.update(t)
             stream.update(t)
 
-            right_P = stream.P_.copy()
-            right_I = stream.I_
-            right_left_P = stream.left_P_.copy()
-            right_left_I = stream.left_I_
+            comp_P = stream.P_.copy()
+            comp_I = stream.I_
+            comp_left_P = stream.left_P_.copy()
+            comp_left_I = stream.left_I_
 
-            left_P = left.P_.copy()
-            left_I = left.I_
-            left_left_P = left.left_P_.copy()
-            left_left_I = left.left_I_
+            ref_P = ref_mp.P_.copy()
+            ref_I = ref_mp.I_
+            ref_left_P = ref_mp.left_P_.copy()
+            ref_left_I = ref_mp.left_I_
 
-            naive.replace_inf(left_P)
-            naive.replace_inf(left_left_P)
-            naive.replace_inf(right_P)
-            naive.replace_inf(right_left_P)
+            naive.replace_inf(ref_P)
+            naive.replace_inf(ref_left_P)
+            naive.replace_inf(comp_P)
+            naive.replace_inf(comp_left_P)
 
-            npt.assert_almost_equal(left_P, right_P)
-            npt.assert_almost_equal(left_I, right_I)
-            npt.assert_almost_equal(left_left_P, right_left_P)
-            npt.assert_almost_equal(left_left_I, right_left_I)
+            npt.assert_almost_equal(ref_P, comp_P)
+            npt.assert_almost_equal(ref_I, comp_I)
+            npt.assert_almost_equal(ref_left_P, comp_left_P)
+            npt.assert_almost_equal(ref_left_I, comp_left_I)
 
         np.random.seed(seed)
         T = np.random.rand(64)
 
-        left = naive.stumpi_egress(T[:n], m)
-        left_P = left.P_.copy()
-        left_I = left.I_
-        left_left_P = left.left_P_.copy()
-        left_left_I = left.left_I_
+        ref_mp = naive.stumpi_egress(T[:n], m)
+        ref_P = ref_mp.P_.copy()
+        ref_I = ref_mp.I_
+        ref_left_P = ref_mp.left_P_.copy()
+        ref_left_I = ref_mp.left_I_
 
         stream = stumpi(T[:n], m, egress=True)
 
-        right_P = stream.P_.copy()
-        right_I = stream.I_
-        right_left_P = stream.left_P_.copy()
-        right_left_I = stream.left_I_
+        comp_P = stream.P_.copy()
+        comp_I = stream.I_
+        comp_left_P = stream.left_P_.copy()
+        comp_left_I = stream.left_I_
 
-        naive.replace_inf(left_P)
-        naive.replace_inf(left_left_P)
-        naive.replace_inf(right_P)
-        naive.replace_inf(right_left_P)
+        naive.replace_inf(ref_P)
+        naive.replace_inf(ref_left_P)
+        naive.replace_inf(comp_P)
+        naive.replace_inf(comp_left_P)
 
-        npt.assert_almost_equal(left_P, right_P)
-        npt.assert_almost_equal(left_I, right_I)
-        npt.assert_almost_equal(left_left_P, right_left_P)
-        npt.assert_almost_equal(left_left_I, right_left_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
+        npt.assert_almost_equal(ref_left_P, comp_left_P)
+        npt.assert_almost_equal(ref_left_I, comp_left_I)
 
         if substitution_location == -1:
             substitution_location = T[n:].shape[0] - 1
         T[n:][substitution_location] = substitute
         for t in T[n:]:
-            left.update(t)
+            ref_mp.update(t)
             stream.update(t)
 
-            right_P = stream.P_.copy()
-            right_I = stream.I_
-            right_left_P = stream.left_P_.copy()
-            right_left_I = stream.left_I_
+            comp_P = stream.P_.copy()
+            comp_I = stream.I_
+            comp_left_P = stream.left_P_.copy()
+            comp_left_I = stream.left_I_
 
-            left_P = left.P_.copy()
-            left_I = left.I_
-            left_left_P = left.left_P_.copy()
-            left_left_I = left.left_I_
+            ref_P = ref_mp.P_.copy()
+            ref_I = ref_mp.I_
+            ref_left_P = ref_mp.left_P_.copy()
+            ref_left_I = ref_mp.left_I_
 
-            naive.replace_inf(left_P)
-            naive.replace_inf(left_left_P)
-            naive.replace_inf(right_P)
-            naive.replace_inf(right_left_P)
+            naive.replace_inf(ref_P)
+            naive.replace_inf(ref_left_P)
+            naive.replace_inf(comp_P)
+            naive.replace_inf(comp_left_P)
 
-            npt.assert_almost_equal(left_P, right_P)
-            npt.assert_almost_equal(left_I, right_I)
-            npt.assert_almost_equal(left_left_P, right_left_P)
-            npt.assert_almost_equal(left_left_I, right_left_I)
+            npt.assert_almost_equal(ref_P, comp_P)
+            npt.assert_almost_equal(ref_I, comp_I)
+            npt.assert_almost_equal(ref_left_P, comp_left_P)
+            npt.assert_almost_equal(ref_left_I, comp_left_I)
 
 
 def test_stumpi_constant_subsequence_self_join():
@@ -546,18 +546,18 @@ def test_stumpi_constant_subsequence_self_join():
         t = np.random.rand()
         stream.update(t)
 
-    right_P = stream.P_
-    right_I = stream.I_
+    comp_P = stream.P_
+    comp_I = stream.I_
 
-    left = naive.stamp(stream.T_, m, exclusion_zone=zone)
-    left_P = left[:, 0]
-    left_I = left[:, 1]
+    ref_mp = naive.stamp(stream.T_, m, exclusion_zone=zone)
+    ref_P = ref_mp[:, 0]
+    ref_I = ref_mp[:, 1]
 
-    naive.replace_inf(left_P)
-    naive.replace_inf(right_P)
+    naive.replace_inf(ref_P)
+    naive.replace_inf(comp_P)
 
-    npt.assert_almost_equal(left_P, right_P)
-    # npt.assert_almost_equal(left_I, right_I)
+    npt.assert_almost_equal(ref_P, comp_P)
+    # npt.assert_almost_equal(ref_I, comp_I)
 
     np.random.seed(seed)
     T = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(10, dtype=np.float64)))
@@ -567,13 +567,13 @@ def test_stumpi_constant_subsequence_self_join():
         t = np.random.rand()
         stream.update(t)
 
-    right_P = stream.P_
-    right_I = stream.I_
+    comp_P = stream.P_
+    comp_I = stream.I_
 
-    naive.replace_inf(right_P)
+    naive.replace_inf(comp_P)
 
-    npt.assert_almost_equal(left_P, right_P)
-    # npt.assert_almost_equal(left_I, right_I)
+    npt.assert_almost_equal(ref_P, comp_P)
+    # npt.assert_almost_equal(ref_I, comp_I)
 
 
 def test_stumpi_constant_subsequence_self_join_egress():
@@ -585,105 +585,105 @@ def test_stumpi_constant_subsequence_self_join_egress():
 
     T = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(10, dtype=np.float64)))
 
-    left = naive.stumpi_egress(T, m)
-    left_P = left.P_.copy()
-    left_I = left.I_
-    left_left_P = left.left_P_.copy()
-    left_left_I = left.left_I_
+    ref_mp = naive.stumpi_egress(T, m)
+    ref_P = ref_mp.P_.copy()
+    ref_I = ref_mp.I_
+    ref_left_P = ref_mp.left_P_.copy()
+    ref_left_I = ref_mp.left_I_
 
     stream = stumpi(T, m, egress=True)
 
-    right_P = stream.P_.copy()
-    right_I = stream.I_
-    right_left_P = stream.left_P_.copy()
-    right_left_I = stream.left_I_
+    comp_P = stream.P_.copy()
+    comp_I = stream.I_
+    comp_left_P = stream.left_P_.copy()
+    comp_left_I = stream.left_I_
 
-    naive.replace_inf(left_P)
-    naive.replace_inf(left_left_P)
-    naive.replace_inf(right_P)
-    naive.replace_inf(right_left_P)
+    naive.replace_inf(ref_P)
+    naive.replace_inf(ref_left_P)
+    naive.replace_inf(comp_P)
+    naive.replace_inf(comp_left_P)
 
-    npt.assert_almost_equal(left_P, right_P)
-    # npt.assert_almost_equal(left_I, right_I)
-    npt.assert_almost_equal(left_left_P, right_left_P)
-    # npt.assert_almost_equal(left_left_I, right_left_I)
+    npt.assert_almost_equal(ref_P, comp_P)
+    # npt.assert_almost_equal(ref_I, comp_I)
+    npt.assert_almost_equal(ref_left_P, comp_left_P)
+    # npt.assert_almost_equal(ref_left_I, comp_left_I)
 
     for i in range(34):
         t = np.random.rand()
-        left.update(t)
+        ref_mp.update(t)
         stream.update(t)
 
-        right_P = stream.P_.copy()
-        right_I = stream.I_
-        right_left_P = stream.left_P_.copy()
-        right_left_I = stream.left_I_
+        comp_P = stream.P_.copy()
+        comp_I = stream.I_
+        comp_left_P = stream.left_P_.copy()
+        comp_left_I = stream.left_I_
 
-        left_P = left.P_.copy()
-        left_I = left.I_
-        left_left_P = left.left_P_.copy()
-        left_left_I = left.left_I_
+        ref_P = ref_mp.P_.copy()
+        ref_I = ref_mp.I_
+        ref_left_P = ref_mp.left_P_.copy()
+        ref_left_I = ref_mp.left_I_
 
-        naive.replace_inf(left_P)
-        naive.replace_inf(left_left_P)
-        naive.replace_inf(right_P)
-        naive.replace_inf(right_left_P)
+        naive.replace_inf(ref_P)
+        naive.replace_inf(ref_left_P)
+        naive.replace_inf(comp_P)
+        naive.replace_inf(comp_left_P)
 
-        npt.assert_almost_equal(left_P, right_P)
-        # npt.assert_almost_equal(left_I, right_I)
-        npt.assert_almost_equal(left_left_P, right_left_P)
-        # npt.assert_almost_equal(left_left_I, right_left_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        # npt.assert_almost_equal(ref_I, comp_I)
+        npt.assert_almost_equal(ref_left_P, comp_left_P)
+        # npt.assert_almost_equal(ref_left_I, comp_left_I)
 
     np.random.seed(seed)
     T = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(10, dtype=np.float64)))
     T = pd.Series(T)
 
-    left = naive.stumpi_egress(T, m)
-    left_P = left.P_.copy()
-    left_I = left.I_
-    left_left_P = left.left_P_.copy()
-    left_left_I = left.left_I_
+    ref_mp = naive.stumpi_egress(T, m)
+    ref_P = ref_mp.P_.copy()
+    ref_I = ref_mp.I_
+    ref_left_P = ref_mp.left_P_.copy()
+    ref_left_I = ref_mp.left_I_
 
     stream = stumpi(T, m, egress=True)
 
-    right_P = stream.P_.copy()
-    right_I = stream.I_
-    right_left_P = stream.left_P_.copy()
-    right_left_I = stream.left_I_
+    comp_P = stream.P_.copy()
+    comp_I = stream.I_
+    comp_left_P = stream.left_P_.copy()
+    comp_left_I = stream.left_I_
 
-    naive.replace_inf(left_P)
-    naive.replace_inf(left_left_P)
-    naive.replace_inf(right_P)
-    naive.replace_inf(right_left_P)
+    naive.replace_inf(ref_P)
+    naive.replace_inf(ref_left_P)
+    naive.replace_inf(comp_P)
+    naive.replace_inf(comp_left_P)
 
-    npt.assert_almost_equal(left_P, right_P)
-    # npt.assert_almost_equal(left_I, right_I)
-    npt.assert_almost_equal(left_left_P, right_left_P)
-    # npt.assert_almost_equal(left_left_I, right_left_I)
+    npt.assert_almost_equal(ref_P, comp_P)
+    # npt.assert_almost_equal(ref_I, comp_I)
+    npt.assert_almost_equal(ref_left_P, comp_left_P)
+    # npt.assert_almost_equal(ref_left_I, comp_left_I)
 
     for i in range(34):
         t = np.random.rand()
-        left.update(t)
+        ref_mp.update(t)
         stream.update(t)
 
-        right_P = stream.P_.copy()
-        right_I = stream.I_
-        right_left_P = stream.left_P_.copy()
-        right_left_I = stream.left_I_
+        comp_P = stream.P_.copy()
+        comp_I = stream.I_
+        comp_left_P = stream.left_P_.copy()
+        comp_left_I = stream.left_I_
 
-        left_P = left.P_.copy()
-        left_I = left.I_
-        left_left_P = left.left_P_.copy()
-        left_left_I = left.left_I_
+        ref_P = ref_mp.P_.copy()
+        ref_I = ref_mp.I_
+        ref_left_P = ref_mp.left_P_.copy()
+        ref_left_I = ref_mp.left_I_
 
-        naive.replace_inf(left_P)
-        naive.replace_inf(left_left_P)
-        naive.replace_inf(right_P)
-        naive.replace_inf(right_left_P)
+        naive.replace_inf(ref_P)
+        naive.replace_inf(ref_left_P)
+        naive.replace_inf(comp_P)
+        naive.replace_inf(comp_left_P)
 
-        npt.assert_almost_equal(left_P, right_P)
-        # npt.assert_almost_equal(left_I, right_I)
-        npt.assert_almost_equal(left_left_P, right_left_P)
-        # npt.assert_almost_equal(left_left_I, right_left_I)
+        npt.assert_almost_equal(ref_P, comp_P)
+        # npt.assert_almost_equal(ref_I, comp_I)
+        npt.assert_almost_equal(ref_left_P, comp_left_P)
+        # npt.assert_almost_equal(ref_left_I, comp_left_I)
 
 
 def test_stumpi_identical_subsequence_self_join():
@@ -702,18 +702,18 @@ def test_stumpi_identical_subsequence_self_join():
         t = np.random.rand()
         stream.update(t)
 
-    right_P = stream.P_
-    right_I = stream.I_
+    comp_P = stream.P_
+    comp_I = stream.I_
 
-    left = naive.stamp(stream.T_, m, exclusion_zone=zone)
-    left_P = left[:, 0]
-    left_I = left[:, 1]
+    ref_mp = naive.stamp(stream.T_, m, exclusion_zone=zone)
+    ref_P = ref_mp[:, 0]
+    ref_I = ref_mp[:, 1]
 
-    naive.replace_inf(left_P)
-    naive.replace_inf(right_P)
+    naive.replace_inf(ref_P)
+    naive.replace_inf(comp_P)
 
-    npt.assert_almost_equal(left_P, right_P, decimal=config.STUMPY_TEST_PRECISION)
-    # npt.assert_almost_equal(left_I, right_I)
+    npt.assert_almost_equal(ref_P, comp_P, decimal=config.STUMPY_TEST_PRECISION)
+    # npt.assert_almost_equal(ref_I, comp_I)
 
     np.random.seed(seed)
     identical = np.random.rand(8)
@@ -726,13 +726,13 @@ def test_stumpi_identical_subsequence_self_join():
         t = np.random.rand()
         stream.update(t)
 
-    right_P = stream.P_
-    right_I = stream.I_
+    comp_P = stream.P_
+    comp_I = stream.I_
 
-    naive.replace_inf(right_P)
+    naive.replace_inf(comp_P)
 
-    npt.assert_almost_equal(left_P, right_P, decimal=config.STUMPY_TEST_PRECISION)
-    # npt.assert_almost_equal(left_I, right_I)
+    npt.assert_almost_equal(ref_P, comp_P, decimal=config.STUMPY_TEST_PRECISION)
+    # npt.assert_almost_equal(ref_I, comp_I)
 
 
 def test_stumpi_identical_subsequence_self_join_egress():
@@ -747,57 +747,57 @@ def test_stumpi_identical_subsequence_self_join_egress():
     T[1 : 1 + identical.shape[0]] = identical
     T[11 : 11 + identical.shape[0]] = identical
 
-    left = naive.stumpi_egress(T, m)
-    left_P = left.P_.copy()
-    left_I = left.I_
-    left_left_P = left.left_P_.copy()
-    left_left_I = left.left_I_
+    ref_mp = naive.stumpi_egress(T, m)
+    ref_P = ref_mp.P_.copy()
+    ref_I = ref_mp.I_
+    ref_left_P = ref_mp.left_P_.copy()
+    ref_left_I = ref_mp.left_I_
 
     stream = stumpi(T, m, egress=True)
 
-    right_P = stream.P_.copy()
-    right_I = stream.I_
-    right_left_P = stream.left_P_.copy()
-    right_left_I = stream.left_I_
+    comp_P = stream.P_.copy()
+    comp_I = stream.I_
+    comp_left_P = stream.left_P_.copy()
+    comp_left_I = stream.left_I_
 
-    naive.replace_inf(left_P)
-    naive.replace_inf(left_left_P)
-    naive.replace_inf(right_P)
-    naive.replace_inf(right_left_P)
+    naive.replace_inf(ref_P)
+    naive.replace_inf(ref_left_P)
+    naive.replace_inf(comp_P)
+    naive.replace_inf(comp_left_P)
 
-    npt.assert_almost_equal(left_P, right_P, decimal=config.STUMPY_TEST_PRECISION)
-    # npt.assert_almost_equal(left_I, right_I)
+    npt.assert_almost_equal(ref_P, comp_P, decimal=config.STUMPY_TEST_PRECISION)
+    # npt.assert_almost_equal(ref_I, comp_I)
     npt.assert_almost_equal(
-        left_left_P, right_left_P, decimal=config.STUMPY_TEST_PRECISION
+        ref_left_P, comp_left_P, decimal=config.STUMPY_TEST_PRECISION
     )
-    # npt.assert_almost_equal(left_left_I, right_left_I)
+    # npt.assert_almost_equal(ref_left_I, comp_left_I)
 
     for i in range(34):
         t = np.random.rand()
-        left.update(t)
+        ref_mp.update(t)
         stream.update(t)
 
-        right_P = stream.P_.copy()
-        right_I = stream.I_
-        right_left_P = stream.left_P_.copy()
-        right_left_I = stream.left_I_
+        comp_P = stream.P_.copy()
+        comp_I = stream.I_
+        comp_left_P = stream.left_P_.copy()
+        comp_left_I = stream.left_I_
 
-        left_P = left.P_.copy()
-        left_I = left.I_
-        left_left_P = left.left_P_.copy()
-        left_left_I = left.left_I_
+        ref_P = ref_mp.P_.copy()
+        ref_I = ref_mp.I_
+        ref_left_P = ref_mp.left_P_.copy()
+        ref_left_I = ref_mp.left_I_
 
-        naive.replace_inf(left_P)
-        naive.replace_inf(left_left_P)
-        naive.replace_inf(right_P)
-        naive.replace_inf(right_left_P)
+        naive.replace_inf(ref_P)
+        naive.replace_inf(ref_left_P)
+        naive.replace_inf(comp_P)
+        naive.replace_inf(comp_left_P)
 
-        npt.assert_almost_equal(left_P, right_P, decimal=config.STUMPY_TEST_PRECISION)
-        # npt.assert_almost_equal(left_I, right_I)
+        npt.assert_almost_equal(ref_P, comp_P, decimal=config.STUMPY_TEST_PRECISION)
+        # npt.assert_almost_equal(ref_I, comp_I)
         npt.assert_almost_equal(
-            left_left_P, right_left_P, decimal=config.STUMPY_TEST_PRECISION
+            ref_left_P, comp_left_P, decimal=config.STUMPY_TEST_PRECISION
         )
-        # npt.assert_almost_equal(left_left_I, right_left_I)
+        # npt.assert_almost_equal(ref_left_I, comp_left_I)
 
     np.random.seed(seed)
     identical = np.random.rand(8)
@@ -805,57 +805,57 @@ def test_stumpi_identical_subsequence_self_join_egress():
     T[1 : 1 + identical.shape[0]] = identical
     T[11 : 11 + identical.shape[0]] = identical
     T = pd.Series(T)
-    left = naive.stumpi_egress(T, m)
-    left_P = left.P_.copy()
-    left_I = left.I_
-    left_left_P = left.left_P_.copy()
-    left_left_I = left.left_I_
+    ref_mp = naive.stumpi_egress(T, m)
+    ref_P = ref_mp.P_.copy()
+    ref_I = ref_mp.I_
+    ref_left_P = ref_mp.left_P_.copy()
+    ref_left_I = ref_mp.left_I_
 
     stream = stumpi(T, m, egress=True)
 
-    right_P = stream.P_.copy()
-    right_I = stream.I_
-    right_left_P = stream.left_P_.copy()
-    right_left_I = stream.left_I_
+    comp_P = stream.P_.copy()
+    comp_I = stream.I_
+    comp_left_P = stream.left_P_.copy()
+    comp_left_I = stream.left_I_
 
-    naive.replace_inf(left_P)
-    naive.replace_inf(left_left_P)
-    naive.replace_inf(right_P)
-    naive.replace_inf(right_left_P)
+    naive.replace_inf(ref_P)
+    naive.replace_inf(ref_left_P)
+    naive.replace_inf(comp_P)
+    naive.replace_inf(comp_left_P)
 
-    npt.assert_almost_equal(left_P, right_P, decimal=config.STUMPY_TEST_PRECISION)
-    # npt.assert_almost_equal(left_I, right_I)
+    npt.assert_almost_equal(ref_P, comp_P, decimal=config.STUMPY_TEST_PRECISION)
+    # npt.assert_almost_equal(ref_I, comp_I)
     npt.assert_almost_equal(
-        left_left_P, right_left_P, decimal=config.STUMPY_TEST_PRECISION
+        ref_left_P, comp_left_P, decimal=config.STUMPY_TEST_PRECISION
     )
-    # npt.assert_almost_equal(left_left_I, right_left_I)
+    # npt.assert_almost_equal(ref_left_I, comp_left_I)
 
     for i in range(34):
         t = np.random.rand()
-        left.update(t)
+        ref_mp.update(t)
         stream.update(t)
 
-        right_P = stream.P_.copy()
-        right_I = stream.I_
-        right_left_P = stream.left_P_.copy()
-        right_left_I = stream.left_I_
+        comp_P = stream.P_.copy()
+        comp_I = stream.I_
+        comp_left_P = stream.left_P_.copy()
+        comp_left_I = stream.left_I_
 
-        left_P = left.P_.copy()
-        left_I = left.I_
-        left_left_P = left.left_P_.copy()
-        left_left_I = left.left_I_
+        ref_P = ref_mp.P_.copy()
+        ref_I = ref_mp.I_
+        ref_left_P = ref_mp.left_P_.copy()
+        ref_left_I = ref_mp.left_I_
 
-        naive.replace_inf(left_P)
-        naive.replace_inf(left_left_P)
-        naive.replace_inf(right_P)
-        naive.replace_inf(right_left_P)
+        naive.replace_inf(ref_P)
+        naive.replace_inf(ref_left_P)
+        naive.replace_inf(comp_P)
+        naive.replace_inf(comp_left_P)
 
-        npt.assert_almost_equal(left_P, right_P, decimal=config.STUMPY_TEST_PRECISION)
-        # npt.assert_almost_equal(left_I, right_I)
+        npt.assert_almost_equal(ref_P, comp_P, decimal=config.STUMPY_TEST_PRECISION)
+        # npt.assert_almost_equal(ref_I, comp_I)
         npt.assert_almost_equal(
-            left_left_P, right_left_P, decimal=config.STUMPY_TEST_PRECISION
+            ref_left_P, comp_left_P, decimal=config.STUMPY_TEST_PRECISION
         )
-        # npt.assert_almost_equal(left_left_I, right_left_I)
+        # npt.assert_almost_equal(ref_left_I, comp_left_I)
 
 
 def test_stumpi_profile_index_match():


### PR DESCRIPTION
The issue TDAmeritrade/stumpy#235 has the context for this change and the suggested naming.
In this change, not all references are `ref_mp/comp_mp` but `ref/comp` in some cases. Please let me know if those still look good.

This is the final change to close #235

---------------- 
 Checklist:

 - Run `./setup.sh && ./test.sh` in the root stumpy directory

