### PR TITLE
Install stumpy in binder environment

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -2,3 +2,4 @@
 
 conda install pandas
 conda install matplotlib
+python -m pip install .

--- a/postBuild
+++ b/postBuild
@@ -2,4 +2,4 @@
 
 conda install pandas
 conda install matplotlib
-python -m pip install .
+conda install -c conda-forge stumpy


### PR DESCRIPTION
When clicking the binder button on the README, I noticed that `stumpy` wasn't installed into the binder environment. This PR makes sure `stumpy` is installed by adding `pip install .` to the `postBuild` file used by binder (you can test it out [here](https://mybinder.org/v2/gh/jrbourbeau/stumpy/install-stumpy-binder?filepath=notebooks))

Alternatively, we could add `stumpy` to `environment.yml` in the root of the repo, but I saw developer tools like `black` and `flake8` in there so I wasn't sure if that file is used for purposes other than binder. 


# Pull Request Checklist

Below is a simple checklist but please do not hesitate to ask for assistance!

- [x] Fork, clone, and checkout the newest version of the code
- [x] Create a new branch
- [x] Make necessary code changes
- [x] Install `black` (i.e., `python -m pip install black` or `conda install black`)
- [x] Install `flake8` (i.e., `python -m pip install flake8` or `conda install flake8`)
- [x] Install `pytest-cov` (i.e., `python -m pip install pytest-cov` or `conda install pytest-cov`)
- [x] Run `black .` in the root stumpy directory
- [x] Run `flake8 .` in the root stumpy directory
- [x] Run `./setup.sh && ./test.sh` in the root stumpy directory
- [x] Reference a Github issue (and create one if one doesn't already exist)
