### PR TITLE
Added IPython to docs/requirements.txt; #409

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 nbsphinx
 pydata-sphinx-theme
+ipython


### PR DESCRIPTION
IPython was added as a dependency to docs/requirements.txt as a fix for #409. After this change, code blocks in tutorials should have syntax highlighting once the docs are built again.

I can confirm through my local build, this works:

![image](https://user-images.githubusercontent.com/35665983/121956099-b5f73980-cd2e-11eb-8574-e0e1bae5d737.png)

# Pull Request Checklist

Below is a simple checklist but please do not hesitate to ask for assistance!

- [x] Fork, clone, and checkout the newest version of the code
- [x] Create a new branch
- [x] Make necessary code changes
- [x] Install `black` (i.e., `python -m pip install black` or `conda install -c conda-forge black`)
- [x] Install `flake8` (i.e., `python -m pip install flake8` or `conda install -c conda-forge flake8`)
- [x] Install `pytest-cov` (i.e., `python -m pip install pytest-cov` or `conda install -c conda-forge pytest-cov`)
- [x] Run `black .` in the root stumpy directory
- [x] Run `flake8 .` in the root stumpy directory
- [x] Run `./setup.sh && ./test.sh` in the root stumpy directory
- [x] Reference a Github issue (and create one if one doesn't already exist)
