### PR TITLE
Fix Advanced Annotation Vectors broken links #431

### DIFF
--- a/docs/Tutorial_Advanced_Annotation_Vectors.ipynb
+++ b/docs/Tutorial_Advanced_Annotation_Vectors.ipynb
@@ -7,9 +7,9 @@
    "source": [
     "# Advanced Annotation Vectors\n",
     "\n",
-    "This tutorial is a continuation of [Annotation Vectors](https://stumpy.readthedocs.io/en/latest/Tutorial_Annotation_Vectors) and it summarizes the findings of the [Matrix Profile V](https://www.cs.ucr.edu/~eamonn/guided-motif-KDD17-new-format-10-pages-v005.pdf) paper and replicates the presented case studies.\n",
+    "This tutorial is a continuation of [Annotation Vectors](https://stumpy.readthedocs.io/en/latest/Tutorial_Annotation_Vectors.html) and it summarizes the findings of the [Matrix Profile V](https://www.cs.ucr.edu/~eamonn/guided-motif-KDD17-new-format-10-pages-v005.pdf) paper and replicates the presented case studies.\n",
     "\n",
-    "In [Annotation Vectors](https://stumpy.readthedocs.io/en/latest/Tutorial_Annotation_Vectors), we were introduced to the concept of **Guided Motif Search** and **Annotation Vectors**. In this tutorial, we will explore the use of annotation vectors in tackling **Stop-Word Motif Bias** and **Simplicity Bias.**"
+    "In [Annotation Vectors](https://stumpy.readthedocs.io/en/latest/Tutorial_Annotation_Vectors.html), we were introduced to the concept of **Guided Motif Search** and **Annotation Vectors**. In this tutorial, we will explore the use of annotation vectors in tackling **Stop-Word Motif Bias** and **Simplicity Bias.**"
    ]
   },
   {
@@ -880,7 +880,7 @@
     "\n",
     "[Matrix Profile V](https://www.cs.ucr.edu/~eamonn/guided-motif-KDD17-new-format-10-pages-v005.pdf)\n",
     "\n",
-    "[Annotation Vectors](https://stumpy.readthedocs.io/en/latest/Tutorial_Annotation_Vectors)\n",
+    "[Annotation Vectors](https://stumpy.readthedocs.io/en/latest/Tutorial_Annotation_Vectors.html)\n",
     "\n",
     "[A Complexity-Invariant Distance Measure for Time Series](https://link.springer.com/article/10.1007/s10618-013-0312-3)"
    ]


### PR DESCRIPTION
The Advanced Annotation Vectors Tutorial references the previous tutorial, Annotation Vectors Tutorial in it, but the links are broken. The links should include `.html` at the end to work. This was added.

# Pull Request Checklist

Below is a simple checklist but please do not hesitate to ask for assistance!

- [x] Fork, clone, and checkout the newest version of the code
- [x] Create a new branch
- [x] Make necessary code changes
- [x] Install `black` (i.e., `python -m pip install black` or `conda install -c conda-forge black`)
- [x] Install `flake8` (i.e., `python -m pip install flake8` or `conda install -c conda-forge flake8`)
- [x] Install `pytest-cov` (i.e., `python -m pip install pytest-cov` or `conda install -c conda-forge pytest-cov`)
- [x] Run `black .` in the root stumpy directory
- [x] Run `flake8 .` in the root stumpy directory
- [ ] Run `./setup.sh && ./test.sh` in the root stumpy directory
- [x] Reference a Github issue (and create one if one doesn't already exist)
