### PR TITLE
Replace matplotlib style sheet with url #452

### DIFF
--- a/docs/Tutorial_AB_Joins.ipynb
+++ b/docs/Tutorial_AB_Joins.ipynb
@@ -37,7 +37,7 @@
     "from IPython.display import IFrame\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "plt.style.use('https://github.com/TDAmeritrade/stumpy/blob/main/notebooks/stumpy.mplstyle')"
+    "plt.style.use('https://raw.githubusercontent.com/TDAmeritrade/stumpy/main/docs/stumpy.mplstyle')"
    ]
   },
   {

--- a/docs/Tutorial_AB_Joins.ipynb
+++ b/docs/Tutorial_AB_Joins.ipynb
@@ -37,7 +37,7 @@
     "from IPython.display import IFrame\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "plt.style.use('stumpy.mplstyle')"
+    "plt.style.use('https://github.com/TDAmeritrade/stumpy/blob/main/notebooks/stumpy.mplstyle')"
    ]
   },
   {

--- a/docs/Tutorial_Advanced_Annotation_Vectors.ipynb
+++ b/docs/Tutorial_Advanced_Annotation_Vectors.ipynb
@@ -64,7 +64,7 @@
     "from stumpy import stump\n",
     "from stumpy import mass\n",
     "\n",
-    "plt.style.use('stumpy.mplstyle')"
+    "plt.style.use('https://github.com/TDAmeritrade/stumpy/blob/main/notebooks/stumpy.mplstyle')"
    ]
   },
   {

--- a/docs/Tutorial_Advanced_Annotation_Vectors.ipynb
+++ b/docs/Tutorial_Advanced_Annotation_Vectors.ipynb
@@ -64,7 +64,7 @@
     "from stumpy import stump\n",
     "from stumpy import mass\n",
     "\n",
-    "plt.style.use('https://github.com/TDAmeritrade/stumpy/blob/main/notebooks/stumpy.mplstyle')"
+    "plt.style.use('https://raw.githubusercontent.com/TDAmeritrade/stumpy/main/docs/stumpy.mplstyle')"
    ]
   },
   {

--- a/docs/Tutorial_Consensus_Motif.ipynb
+++ b/docs/Tutorial_Consensus_Motif.ipynb
@@ -45,7 +45,7 @@
     "from scipy.cluster.hierarchy import linkage, dendrogram\n",
     "from scipy.special import comb\n",
     "\n",
-    "plt.style.use('stumpy.mplstyle')"
+    "plt.style.use('https://github.com/TDAmeritrade/stumpy/blob/main/notebooks/stumpy.mplstyle')"
    ]
   },
   {

--- a/docs/Tutorial_Consensus_Motif.ipynb
+++ b/docs/Tutorial_Consensus_Motif.ipynb
@@ -45,7 +45,7 @@
     "from scipy.cluster.hierarchy import linkage, dendrogram\n",
     "from scipy.special import comb\n",
     "\n",
-    "plt.style.use('https://github.com/TDAmeritrade/stumpy/blob/main/notebooks/stumpy.mplstyle')"
+    "plt.style.use('https://raw.githubusercontent.com/TDAmeritrade/stumpy/main/docs/stumpy.mplstyle')"
    ]
   },
   {

--- a/docs/Tutorial_Fast_Approximate_Matrix_Profiles.ipynb
+++ b/docs/Tutorial_Fast_Approximate_Matrix_Profiles.ipynb
@@ -37,7 +37,7 @@
     "import matplotlib.pyplot as plt\n",
     "from matplotlib.patches import Rectangle\n",
     "\n",
-    "plt.style.use('stumpy.mplstyle')"
+    "plt.style.use('https://github.com/TDAmeritrade/stumpy/blob/main/notebooks/stumpy.mplstyle')"
    ]
   },
   {

--- a/docs/Tutorial_Fast_Approximate_Matrix_Profiles.ipynb
+++ b/docs/Tutorial_Fast_Approximate_Matrix_Profiles.ipynb
@@ -37,7 +37,7 @@
     "import matplotlib.pyplot as plt\n",
     "from matplotlib.patches import Rectangle\n",
     "\n",
-    "plt.style.use('https://github.com/TDAmeritrade/stumpy/blob/main/notebooks/stumpy.mplstyle')"
+    "plt.style.use('https://raw.githubusercontent.com/TDAmeritrade/stumpy/main/docs/stumpy.mplstyle')"
    ]
   },
   {

--- a/docs/Tutorial_Multidimensional_Motif_Discovery.ipynb
+++ b/docs/Tutorial_Multidimensional_Motif_Discovery.ipynb
@@ -74,7 +74,7 @@
     "import stumpy\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "plt.style.use('stumpy.mplstyle')"
+    "plt.style.use('https://github.com/TDAmeritrade/stumpy/blob/main/notebooks/stumpy.mplstyle')"
    ]
   },
   {

--- a/docs/Tutorial_Multidimensional_Motif_Discovery.ipynb
+++ b/docs/Tutorial_Multidimensional_Motif_Discovery.ipynb
@@ -74,7 +74,7 @@
     "import stumpy\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "plt.style.use('https://github.com/TDAmeritrade/stumpy/blob/main/notebooks/stumpy.mplstyle')"
+    "plt.style.use('https://raw.githubusercontent.com/TDAmeritrade/stumpy/main/docs/stumpy.mplstyle')"
    ]
   },
   {

--- a/docs/Tutorial_Pan_Matrix_Profile.ipynb
+++ b/docs/Tutorial_Pan_Matrix_Profile.ipynb
@@ -33,7 +33,7 @@
     "from ipywidgets import interact, Layout\n",
     "import stumpy\n",
     "\n",
-    "plt.style.use('stumpy.mplstyle')"
+    "plt.style.use('https://github.com/TDAmeritrade/stumpy/blob/main/notebooks/stumpy.mplstyle')"
    ]
   },
   {
@@ -464,7 +464,7 @@
    ],
    "source": [
     "%matplotlib widget\n",
-    "plt.style.use('stumpy.mplstyle')\n",
+    "plt.style.use('https://github.com/TDAmeritrade/stumpy/blob/main/notebooks/stumpy.mplstyle')\n",
     "\n",
     "plt.ioff()\n",
     "fig = plt.figure()\n",

--- a/docs/Tutorial_Pan_Matrix_Profile.ipynb
+++ b/docs/Tutorial_Pan_Matrix_Profile.ipynb
@@ -33,7 +33,7 @@
     "from ipywidgets import interact, Layout\n",
     "import stumpy\n",
     "\n",
-    "plt.style.use('https://github.com/TDAmeritrade/stumpy/blob/main/notebooks/stumpy.mplstyle')"
+    "plt.style.use('https://raw.githubusercontent.com/TDAmeritrade/stumpy/main/docs/stumpy.mplstyle')"
    ]
   },
   {
@@ -464,7 +464,7 @@
    ],
    "source": [
     "%matplotlib widget\n",
-    "plt.style.use('https://github.com/TDAmeritrade/stumpy/blob/main/notebooks/stumpy.mplstyle')\n",
+    "plt.style.use('https://raw.githubusercontent.com/TDAmeritrade/stumpy/main/docs/stumpy.mplstyle')\n",
     "\n",
     "plt.ioff()\n",
     "fig = plt.figure()\n",

--- a/docs/Tutorial_STUMPY_Basics.ipynb
+++ b/docs/Tutorial_STUMPY_Basics.ipynb
@@ -45,7 +45,7 @@
     "from matplotlib.patches import Rectangle\n",
     "import datetime as dt\n",
     "\n",
-    "plt.style.use('stumpy.mplstyle')"
+    "plt.style.use('https://github.com/TDAmeritrade/stumpy/blob/main/notebooks/stumpy.mplstyle')"
    ]
   },
   {

--- a/docs/Tutorial_STUMPY_Basics.ipynb
+++ b/docs/Tutorial_STUMPY_Basics.ipynb
@@ -45,7 +45,7 @@
     "from matplotlib.patches import Rectangle\n",
     "import datetime as dt\n",
     "\n",
-    "plt.style.use('https://github.com/TDAmeritrade/stumpy/blob/main/notebooks/stumpy.mplstyle')"
+    "plt.style.use('https://raw.githubusercontent.com/TDAmeritrade/stumpy/main/docs/stumpy.mplstyle')"
    ]
   },
   {

--- a/docs/Tutorial_Shapelet_Discovery.ipynb
+++ b/docs/Tutorial_Shapelet_Discovery.ipynb
@@ -43,7 +43,7 @@
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "plt.style.use('stumpy.mplstyle')"
+    "plt.style.use('https://github.com/TDAmeritrade/stumpy/blob/main/notebooks/stumpy.mplstyle')"
    ]
   },
   {

--- a/docs/Tutorial_Shapelet_Discovery.ipynb
+++ b/docs/Tutorial_Shapelet_Discovery.ipynb
@@ -43,7 +43,7 @@
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "plt.style.use('https://github.com/TDAmeritrade/stumpy/blob/main/notebooks/stumpy.mplstyle')"
+    "plt.style.use('https://raw.githubusercontent.com/TDAmeritrade/stumpy/main/docs/stumpy.mplstyle')"
    ]
   },
   {

--- a/docs/Tutorial_Time_Series_Chains.ipynb
+++ b/docs/Tutorial_Time_Series_Chains.ipynb
@@ -38,7 +38,7 @@
     "from matplotlib.patches import Rectangle, FancyArrowPatch\n",
     "import itertools\n",
     "\n",
-    "plt.style.use('stumpy.mplstyle')"
+    "plt.style.use('https://github.com/TDAmeritrade/stumpy/blob/main/notebooks/stumpy.mplstyle')"
    ]
   },
   {

--- a/docs/Tutorial_Time_Series_Chains.ipynb
+++ b/docs/Tutorial_Time_Series_Chains.ipynb
@@ -38,7 +38,7 @@
     "from matplotlib.patches import Rectangle, FancyArrowPatch\n",
     "import itertools\n",
     "\n",
-    "plt.style.use('https://github.com/TDAmeritrade/stumpy/blob/main/notebooks/stumpy.mplstyle')"
+    "plt.style.use('https://raw.githubusercontent.com/TDAmeritrade/stumpy/main/docs/stumpy.mplstyle')"
    ]
   },
   {

--- a/docs/Tutorial_Time_Series_Snippets.ipynb
+++ b/docs/Tutorial_Time_Series_Snippets.ipynb
@@ -91,7 +91,7 @@
     "import matplotlib.pyplot as plt\n",
     "from scipy.signal import resample, resample_poly\n",
     "\n",
-    "plt.style.use('stumpy.mplstyle')"
+    "plt.style.use('https://github.com/TDAmeritrade/stumpy/blob/main/notebooks/stumpy.mplstyle')"
    ]
   },
   {

--- a/docs/Tutorial_Time_Series_Snippets.ipynb
+++ b/docs/Tutorial_Time_Series_Snippets.ipynb
@@ -91,7 +91,7 @@
     "import matplotlib.pyplot as plt\n",
     "from scipy.signal import resample, resample_poly\n",
     "\n",
-    "plt.style.use('https://github.com/TDAmeritrade/stumpy/blob/main/notebooks/stumpy.mplstyle')"
+    "plt.style.use('https://raw.githubusercontent.com/TDAmeritrade/stumpy/main/docs/stumpy.mplstyle')"
    ]
   },
   {

--- a/docs/Tutorial_meter_swapping.ipynb
+++ b/docs/Tutorial_meter_swapping.ipynb
@@ -99,7 +99,7 @@
     "import matplotlib.pyplot as plt\n",
     "import datetime\n",
     "\n",
-    "plt.style.use('stumpy.mplstyle')\n",
+    "plt.style.use('https://github.com/TDAmeritrade/stumpy/blob/main/notebooks/stumpy.mplstyle')\n",
     "\n",
     "np.random.seed(1337)  # Random seed for reproducibility"
    ]

--- a/docs/Tutorial_meter_swapping.ipynb
+++ b/docs/Tutorial_meter_swapping.ipynb
@@ -99,7 +99,7 @@
     "import matplotlib.pyplot as plt\n",
     "import datetime\n",
     "\n",
-    "plt.style.use('https://github.com/TDAmeritrade/stumpy/blob/main/notebooks/stumpy.mplstyle')\n",
+    "plt.style.use('https://raw.githubusercontent.com/TDAmeritrade/stumpy/main/docs/stumpy.mplstyle')\n",
     "\n",
     "np.random.seed(1337)  # Random seed for reproducibility"
    ]


### PR DESCRIPTION
#452 
changed plt.style.use('stumpy.mplstyle') to plt.style.use('https://github.com/TDAmeritrade/stumpy/blob/main/notebooks/stumpy.mplstyle')

but i was not able to edit 4 files as they were fixed:
1.Tutorial_Annotation_Vectors.ipynb
2.Tutorial_Matrix_Profiles_For_Streaming_Data.ipynb
3.Tutorial_Pattern_Matching.ipynb
4.Tutorial_Semantic_Segmentation.ipynb