### PR TITLE
Fixed #596 Rename naive.mass to naive.mass_PI

### DIFF
--- a/tests/naive.py
+++ b/tests/naive.py
@@ -94,7 +94,7 @@ def aamp_distance_matrix(T_A, T_B, m, p):
     return distance_matrix
 
 
-def mass(Q, T, m, trivial_idx=None, excl_zone=0, ignore_trivial=False):
+def mass_PI(Q, T, m, trivial_idx=None, excl_zone=0, ignore_trivial=False):
     Q = np.asarray(Q)
     T = np.asarray(T)
 
@@ -143,14 +143,14 @@ def stamp(T_A, m, T_B=None, exclusion_zone=None):
     if T_B is None:  # self-join
         result = np.array(
             [
-                mass(Q, T_A, m, i, exclusion_zone, True)
+                mass_PI(Q, T_A, m, i, exclusion_zone, True)
                 for i, Q in enumerate(core.rolling_window(T_A, m))
             ],
             dtype=object,
         )
     else:
         result = np.array(
-            [mass(Q, T_B, m) for Q in core.rolling_window(T_A, m)],
+            [mass_PI(Q, T_B, m) for Q in core.rolling_window(T_A, m)],
             dtype=object,
         )
     return result

--- a/tests/test_stamp.py
+++ b/tests/test_stamp.py
@@ -26,7 +26,7 @@ def test_stamp_mass_PI(T_A, T_B):
     zone = int(np.ceil(m / 2))
     Q = T_B[trivial_idx : trivial_idx + m]
     M_T, Σ_T = core.compute_mean_std(T_B, m)
-    ref_P, ref_I, ref_left_I, ref_right_I = naive.mass(
+    ref_P, ref_I, ref_left_I, ref_right_I = naive.mass_PI(
         Q, T_B, m, trivial_idx=trivial_idx, excl_zone=zone, ignore_trivial=True
     )
     comp_P, comp_I = stamp._mass_PI(


### PR DESCRIPTION
Not sure if it is what you had in mind or not, but I only renamed `naive.mass` to `naive.mass_PI`

---

**I did NOT rename `naive.distance_profile` to `naive.mass` because:**
* I think `naive.distance_profile` handles `nan/inf` differently.
* I think the name `distance_profile` shows the purpose of function better.