### PR TITLE
Fixed #598 Add parameter row_wise to naive.stump

### DIFF
--- a/tests/naive.py
+++ b/tests/naive.py
@@ -198,7 +198,7 @@ def stump(T_A, m, T_B=None, exclusion_zone=None, row_wise=False):
                 idx = -1
             I[i, 0] = idx
 
-            #self-join: left matrix profile
+            # self-join: left matrix profile
             IL = -1
             IR = -1
             if ignore_trivial and i > 0:
@@ -207,9 +207,9 @@ def stump(T_A, m, T_B=None, exclusion_zone=None, row_wise=False):
                     IL = -1
                 I[i, 1] = IL
 
-            #self-join: right matrix profile
+            # self-join: right matrix profile
             if ignore_trivial and i < D.shape[0]:
-                IR = i + np.argmin(D[i:]) #shift argmin by `i` to get true index
+                IR = i + np.argmin(D[i:])  # shift argmin by `i` to get true index
                 if D[IR] == np.inf:
                     IR = -1
                 I[i, 2] = IR

--- a/tests/naive.py
+++ b/tests/naive.py
@@ -139,7 +139,6 @@ def mass_PI(Q, T, m, trivial_idx=None, excl_zone=0, ignore_trivial=False):
     return P, I, IL, IR
 
 
-# just for reference
 def stamp(T_A, m, T_B=None, exclusion_zone=None):
     if T_B is None:  # self-join
         result = np.array(

--- a/tests/naive.py
+++ b/tests/naive.py
@@ -160,9 +160,9 @@ def stump(T_A, m, T_B=None, exclusion_zone=None, row_wise=False):
     """
     Traverse distance matrix and update the matrix profile and
     matrix profile indices
-    
-    If `row_wise=False`, then it is a diagonal traversal.
-    If `row_wise=True`, then it is a row-wise traversal.
+
+    If the parameter `row_wise` is set to `False`, then it is a diagonal traversal.
+    If the parameter `row_wise` is set `True`, then it is a row-wise traversal.
     """
     if T_B is None:  # self-join:
         ignore_trivial = True

--- a/tests/naive.py
+++ b/tests/naive.py
@@ -184,6 +184,7 @@ def stump(T_A, m, T_B=None, exclusion_zone=None, row_wise=False):
     P = np.full((l, 3), np.inf)
     I = np.full((l, 3), -1, dtype=np.int64)
 
+    result = np.empty((l, 4), dtype=object)
     if row_wise:  # row-wise traversal in distance matrix
         if ignore_trivial:  # self-join
             for i in range(l):
@@ -213,11 +214,8 @@ def stump(T_A, m, T_B=None, exclusion_zone=None, row_wise=False):
                     IR = -1
                 I[i, 2] = IR
 
-        result = np.empty((l, 4), dtype=object)
         result[:, 0] = P[:, 0]
         result[:, 1:4] = I[:, :]
-
-        return result
 
     else:  # diagonal traversal
         if ignore_trivial:
@@ -253,11 +251,10 @@ def stump(T_A, m, T_B=None, exclusion_zone=None, row_wise=False):
                             P[i, 2] = D
                             I[i, 2] = i + k
 
-        result = np.empty((l, 4), dtype=object)
         result[:, 0] = P[:, 0]
         result[:, 1:4] = I[:, :]
 
-        return result
+    return result
 
 
 def aamp(T_A, m, T_B=None, exclusion_zone=None, p=2.0):

--- a/tests/naive.py
+++ b/tests/naive.py
@@ -158,11 +158,9 @@ def stamp(T_A, m, T_B=None, exclusion_zone=None):  # pragma: no cover
 
 def stump(T_A, m, T_B=None, exclusion_zone=None, row_wise=False):
     """
-    Traverse distance matrix and update the matrix profile and
-    matrix profile indices
-
-    If the parameter `row_wise` is set to `False`, then it is a diagonal traversal.
-    If the parameter `row_wise` is set `True`, then it is a row-wise traversal.
+    Traverse distance matrix diagonally and update the matrix profile and
+    matrix profile indices if the parameter `row_wise` is set to `False`.
+    If the parameter `row_wise` is set to `True`, it is a row-wise traversal.
     """
     if T_B is None:  # self-join:
         ignore_trivial = True

--- a/tests/naive.py
+++ b/tests/naive.py
@@ -205,14 +205,13 @@ def stump(T_A, m, T_B=None, exclusion_zone=None, row_wise=False):
                 IL = np.argmin(D[:i])
                 if D[IL] == np.inf:
                     IL = -1
+                I[i, 1] = IL
 
             #self-join: right matrix profile
             if ignore_trivial and i < D.shape[0]:
                 IR = i + np.argmin(D[i:]) #shift argmin by `i` to get true index
                 if D[IR] == np.inf:
                     IR = -1
-
-                I[i, 1] = IL
                 I[i, 2] = IR
 
         result = np.empty((l, 4), dtype=object)

--- a/tests/naive.py
+++ b/tests/naive.py
@@ -138,6 +138,7 @@ def mass_PI(Q, T, m, trivial_idx=None, excl_zone=0, ignore_trivial=False):
 
     return P, I, IL, IR
 
+
 # just for reference
 def stamp(T_A, m, T_B=None, exclusion_zone=None):
     if T_B is None:  # self-join
@@ -181,8 +182,7 @@ def stump(T_A, m, T_B=None, exclusion_zone=None, row_wise=False):
     if exclusion_zone is None:
         exclusion_zone = int(np.ceil(m / config.STUMPY_EXCL_ZONE_DENOM))
 
-
-    if row_wise: #row-wise traversal in distance matrix
+    if row_wise:  # row-wise traversal in distance matrix
         if ignore_trivial:  # self-join
             result = np.array(
                 [
@@ -198,7 +198,7 @@ def stump(T_A, m, T_B=None, exclusion_zone=None, row_wise=False):
             )
         return result
 
-    else: #diagonal traversal
+    else:  # diagonal traversal
         if ignore_trivial:
             diags = np.arange(exclusion_zone + 1, n_A - m + 1)
         else:

--- a/tests/naive.py
+++ b/tests/naive.py
@@ -121,7 +121,7 @@ def mass_PI(Q, T, m, trivial_idx=None, excl_zone=0, ignore_trivial=False):
                 PL = D[i]
         if start <= IL < stop:  # pragma: no cover
             IL = -1
-    else:
+    else:  # pragma: no cover
         IL = -1
 
     if ignore_trivial and trivial_idx + 1 < D.shape[0]:

--- a/tests/naive.py
+++ b/tests/naive.py
@@ -156,7 +156,7 @@ def stamp(T_A, m, T_B=None, exclusion_zone=None):
     return result
 
 
-def stump(T_A, m, T_B=None, exclusion_zone=None):
+def stump(T_A, m, T_B=None, exclusion_zone=None, row_traversal=False):
     """
     Traverse distance matrix along the diagonals and update the matrix profile and
     matrix profile indices
@@ -181,47 +181,65 @@ def stump(T_A, m, T_B=None, exclusion_zone=None):
     if exclusion_zone is None:
         exclusion_zone = int(np.ceil(m / config.STUMPY_EXCL_ZONE_DENOM))
 
-    if ignore_trivial:
-        diags = np.arange(exclusion_zone + 1, n_A - m + 1)
-    else:
-        diags = np.arange(-(n_A - m + 1) + 1, n_B - m + 1)
 
-    P = np.full((l, 3), np.inf)
-    I = np.full((l, 3), -1, dtype=np.int64)
-
-    for k in diags:
-        if k >= 0:
-            iter_range = range(0, min(n_A - m + 1, n_B - m + 1 - k))
+    if row_traversal:
+        if ignore_trivial:  # self-join
+            result = np.array(
+                [
+                    mass_PI(Q, T_A, m, i, exclusion_zone, True)
+                    for i, Q in enumerate(core.rolling_window(T_A, m))
+                ],
+                dtype=object,
+            )
         else:
-            iter_range = range(-k, min(n_A - m + 1, n_B - m + 1 - k))
+            result = np.array(
+                [mass_PI(Q, T_B, m) for Q in core.rolling_window(T_A, m)],
+                dtype=object,
+            )
+        return result
 
-        for i in iter_range:
-            D = distance_matrix[i, i + k]
-            if D < P[i, 0]:
-                P[i, 0] = D
-                I[i, 0] = i + k
+    else: #diagonal traversal
+        if ignore_trivial:
+            diags = np.arange(exclusion_zone + 1, n_A - m + 1)
+        else:
+            diags = np.arange(-(n_A - m + 1) + 1, n_B - m + 1)
 
-            if ignore_trivial:  # Self-joins only
-                if D < P[i + k, 0]:
-                    P[i + k, 0] = D
-                    I[i + k, 0] = i
+        P = np.full((l, 3), np.inf)
+        I = np.full((l, 3), -1, dtype=np.int64)
 
-                if i < i + k:
-                    # Left matrix profile and left matrix profile index
-                    if D < P[i + k, 1]:
-                        P[i + k, 1] = D
-                        I[i + k, 1] = i
+        for k in diags:
+            if k >= 0:
+                iter_range = range(0, min(n_A - m + 1, n_B - m + 1 - k))
+            else:
+                iter_range = range(-k, min(n_A - m + 1, n_B - m + 1 - k))
 
-                    if D < P[i, 2]:
-                        # right matrix profile and right matrix profile index
-                        P[i, 2] = D
-                        I[i, 2] = i + k
+            for i in iter_range:
+                D = distance_matrix[i, i + k]
+                if D < P[i, 0]:
+                    P[i, 0] = D
+                    I[i, 0] = i + k
 
-    result = np.empty((l, 4), dtype=object)
-    result[:, 0] = P[:, 0]
-    result[:, 1:4] = I[:, :]
+                if ignore_trivial:  # Self-joins only
+                    if D < P[i + k, 0]:
+                        P[i + k, 0] = D
+                        I[i + k, 0] = i
 
-    return result
+                    if i < i + k:
+                        # Left matrix profile and left matrix profile index
+                        if D < P[i + k, 1]:
+                            P[i + k, 1] = D
+                            I[i + k, 1] = i
+
+                        if D < P[i, 2]:
+                            # right matrix profile and right matrix profile index
+                            P[i, 2] = D
+                            I[i, 2] = i + k
+
+        result = np.empty((l, 4), dtype=object)
+        result[:, 0] = P[:, 0]
+        result[:, 1:4] = I[:, :]
+
+        return result
 
 
 def aamp(T_A, m, T_B=None, exclusion_zone=None, p=2.0):

--- a/tests/naive.py
+++ b/tests/naive.py
@@ -138,7 +138,7 @@ def mass_PI(Q, T, m, trivial_idx=None, excl_zone=0, ignore_trivial=False):
 
     return P, I, IL, IR
 
-
+# just for reference
 def stamp(T_A, m, T_B=None, exclusion_zone=None):
     if T_B is None:  # self-join
         result = np.array(
@@ -156,7 +156,7 @@ def stamp(T_A, m, T_B=None, exclusion_zone=None):
     return result
 
 
-def stump(T_A, m, T_B=None, exclusion_zone=None, row_traversal=False):
+def stump(T_A, m, T_B=None, exclusion_zone=None, row_wise=False):
     """
     Traverse distance matrix along the diagonals and update the matrix profile and
     matrix profile indices
@@ -182,7 +182,7 @@ def stump(T_A, m, T_B=None, exclusion_zone=None, row_traversal=False):
         exclusion_zone = int(np.ceil(m / config.STUMPY_EXCL_ZONE_DENOM))
 
 
-    if row_traversal:
+    if row_wise: #row-wise traversal in distance matrix
         if ignore_trivial:  # self-join
             result = np.array(
                 [

--- a/tests/naive.py
+++ b/tests/naive.py
@@ -201,8 +201,6 @@ def stump(T_A, m, T_B=None, exclusion_zone=None, row_wise=False):
             I[i, 0] = idx
 
             # self-join: left matrix profile
-            IL = -1
-            IR = -1
             if ignore_trivial and i > 0:
                 IL = np.argmin(D[:i])
                 if D[IL] == np.inf:

--- a/tests/naive.py
+++ b/tests/naive.py
@@ -158,8 +158,11 @@ def stamp(T_A, m, T_B=None, exclusion_zone=None):  # pragma: no cover
 
 def stump(T_A, m, T_B=None, exclusion_zone=None, row_wise=False):
     """
-    Traverse distance matrix along the diagonals and update the matrix profile and
+    Traverse distance matrix and update the matrix profile and
     matrix profile indices
+    
+    If `row_wise=False`, then it is a diagonal traversal.
+    If `row_wise=True`, then it is a row-wise traversal.
     """
     if T_B is None:  # self-join:
         ignore_trivial = True

--- a/tests/naive.py
+++ b/tests/naive.py
@@ -184,7 +184,6 @@ def stump(T_A, m, T_B=None, exclusion_zone=None, row_wise=False):
     P = np.full((l, 3), np.inf)
     I = np.full((l, 3), -1, dtype=np.int64)
 
-    result = np.empty((l, 4), dtype=object)
     if row_wise:  # row-wise traversal in distance matrix
         if ignore_trivial:  # self-join
             for i in range(l):
@@ -213,9 +212,6 @@ def stump(T_A, m, T_B=None, exclusion_zone=None, row_wise=False):
                 if D[IR] == np.inf:
                     IR = -1
                 I[i, 2] = IR
-
-        result[:, 0] = P[:, 0]
-        result[:, 1:4] = I[:, :]
 
     else:  # diagonal traversal
         if ignore_trivial:
@@ -251,8 +247,9 @@ def stump(T_A, m, T_B=None, exclusion_zone=None, row_wise=False):
                             P[i, 2] = D
                             I[i, 2] = i + k
 
-        result[:, 0] = P[:, 0]
-        result[:, 1:4] = I[:, :]
+    result = np.empty((l, 4), dtype=object)
+    result[:, 0] = P[:, 0]
+    result[:, 1:4] = I[:, :]
 
     return result
 

--- a/tests/naive.py
+++ b/tests/naive.py
@@ -116,7 +116,7 @@ def mass_PI(Q, T, m, trivial_idx=None, excl_zone=0, ignore_trivial=False):
         PL = np.inf
         IL = -1
         for i in range(trivial_idx):
-            if D[i] < PL:
+            if D[i] < PL:  # pragma: no cover
                 IL = i
                 PL = D[i]
         if start <= IL < stop:  # pragma: no cover
@@ -133,13 +133,13 @@ def mass_PI(Q, T, m, trivial_idx=None, excl_zone=0, ignore_trivial=False):
                 PR = D[i]
         if start <= IR < stop:  # pragma: no cover
             IR = -1
-    else:
+    else:  # pragma: no cover
         IR = -1
 
     return P, I, IL, IR
 
 
-def stamp(T_A, m, T_B=None, exclusion_zone=None):
+def stamp(T_A, m, T_B=None, exclusion_zone=None):  # pragma: no cover
     if T_B is None:  # self-join
         result = np.array(
             [

--- a/tests/naive.py
+++ b/tests/naive.py
@@ -182,20 +182,43 @@ def stump(T_A, m, T_B=None, exclusion_zone=None, row_wise=False):
     if exclusion_zone is None:
         exclusion_zone = int(np.ceil(m / config.STUMPY_EXCL_ZONE_DENOM))
 
+    P = np.full((l, 3), np.inf)
+    I = np.full((l, 3), -1, dtype=np.int64)
+
     if row_wise:  # row-wise traversal in distance matrix
         if ignore_trivial:  # self-join
-            result = np.array(
-                [
-                    mass_PI(Q, T_A, m, i, exclusion_zone, True)
-                    for i, Q in enumerate(core.rolling_window(T_A, m))
-                ],
-                dtype=object,
-            )
-        else:
-            result = np.array(
-                [mass_PI(Q, T_B, m) for Q in core.rolling_window(T_A, m)],
-                dtype=object,
-            )
+            for i in range(l):
+                apply_exclusion_zone(distance_matrix[i], i, exclusion_zone, np.inf)
+
+        for i, D in enumerate(distance_matrix):
+            # self-join / AB-join: matrix proifle and indices
+            idx = np.argmin(D)
+            P[i, 0] = D[idx]
+            if P[i, 0] == np.inf:
+                idx = -1
+            I[i, 0] = idx
+
+            #self-join: left matrix profile
+            IL = -1
+            IR = -1
+            if ignore_trivial and i > 0:
+                IL = np.argmin(D[:i])
+                if D[IL] == np.inf:
+                    IL = -1
+
+            #self-join: right matrix profile
+            if ignore_trivial and i < D.shape[0]:
+                IR = i + np.argmin(D[i:]) #shift argmin by `i` to get true index
+                if D[IR] == np.inf:
+                    IR = -1
+
+                I[i, 1] = IL
+                I[i, 2] = IR
+
+        result = np.empty((l, 4), dtype=object)
+        result[:, 0] = P[:, 0]
+        result[:, 1:4] = I[:, :]
+
         return result
 
     else:  # diagonal traversal
@@ -203,9 +226,6 @@ def stump(T_A, m, T_B=None, exclusion_zone=None, row_wise=False):
             diags = np.arange(exclusion_zone + 1, n_A - m + 1)
         else:
             diags = np.arange(-(n_A - m + 1) + 1, n_B - m + 1)
-
-        P = np.full((l, 3), np.inf)
-        I = np.full((l, 3), -1, dtype=np.int64)
 
         for k in diags:
             if k >= 0:

--- a/tests/test_gpu_stump.py
+++ b/tests/test_gpu_stump.py
@@ -44,7 +44,7 @@ def test_gpu_stump_int_input():
 def test_gpu_stump_self_join(T_A, T_B):
     m = 3
     zone = int(np.ceil(m / 4))
-    ref_mp = naive.stamp(T_B, m, exclusion_zone=zone)
+    ref_mp = naive.stump(T_B, m, exclusion_zone=zone, row_wise=True)
     comp_mp = gpu_stump(T_B, m, ignore_trivial=True)
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
@@ -61,7 +61,7 @@ def test_gpu_stump_self_join(T_A, T_B):
 def test_gpu_stump_self_join_larger_window(T_A, T_B, m):
     if len(T_B) > m:
         zone = int(np.ceil(m / 4))
-        ref_mp = naive.stamp(T_B, m, exclusion_zone=zone)
+        ref_mp = naive.stump(T_B, m, exclusion_zone=zone, row_wise=True)
         comp_mp = gpu_stump(T_B, m, ignore_trivial=True)
         naive.replace_inf(ref_mp)
         naive.replace_inf(comp_mp)
@@ -81,7 +81,7 @@ def test_gpu_stump_self_join_larger_window(T_A, T_B, m):
 @pytest.mark.parametrize("T_A, T_B", test_data)
 def test_gpu_stump_A_B_join(T_A, T_B):
     m = 3
-    ref_mp = naive.stamp(T_B, m, T_B=T_A)
+    ref_mp = naive.stump(T_B, m, T_B=T_A, row_wise=True)
     comp_mp = gpu_stump(T_B, m, T_A, ignore_trivial=False)
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
@@ -99,7 +99,7 @@ def test_parallel_gpu_stump_self_join(T_A, T_B):
     if len(T_B) > 10:
         m = 3
         zone = int(np.ceil(m / 4))
-        ref_mp = naive.stamp(T_B, m, exclusion_zone=zone)
+        ref_mp = naive.stump(T_B, m, exclusion_zone=zone, row_wise=True)
         comp_mp = gpu_stump(
             T_B,
             m,
@@ -126,7 +126,7 @@ def test_parallel_gpu_stump_A_B_join(T_A, T_B):
     device_ids = [device.id for device in cuda.list_devices()]
     if len(T_B) > 10:
         m = 3
-        ref_mp = naive.stamp(T_B, m, T_B=T_A)
+        ref_mp = naive.stump(T_B, m, T_B=T_A, row_wise=True)
         comp_mp = gpu_stump(
             T_B,
             m,
@@ -154,7 +154,7 @@ def test_gpu_stump_constant_subsequence_self_join():
     T_A = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64)))
     m = 3
     zone = int(np.ceil(m / 4))
-    ref_mp = naive.stamp(T_A, m, exclusion_zone=zone)
+    ref_mp = naive.stump(T_A, m, exclusion_zone=zone, row_wise=True)
     comp_mp = gpu_stump(T_A, m, ignore_trivial=True)
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
@@ -170,7 +170,7 @@ def test_gpu_stump_one_constant_subsequence_A_B_join():
     T_A = np.random.rand(20)
     T_B = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64)))
     m = 3
-    ref_mp = naive.stamp(T_B, m, T_B=T_A)
+    ref_mp = naive.stump(T_B, m, T_B=T_A, row_wise=True)
     comp_mp = gpu_stump(T_B, m, T_A, ignore_trivial=False)
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
@@ -181,7 +181,7 @@ def test_gpu_stump_one_constant_subsequence_A_B_join():
     # npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
     # Swap inputs
-    ref_mp = naive.stamp(T_A, m, T_B=T_B)
+    ref_mp = naive.stump(T_A, m, T_B=T_B, row_wise=True)
     comp_mp = gpu_stump(T_A, m, T_B, ignore_trivial=False)
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
@@ -197,7 +197,7 @@ def test_gpu_stump_two_constant_subsequences_A_B_join():
     T_A = np.array([0, 0, 0, 0, 0, 1], dtype=np.float64)
     T_B = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64)))
     m = 3
-    ref_mp = naive.stamp(T_B, m, T_B=T_A)
+    ref_mp = naive.stump(T_B, m, T_B=T_A, row_wise=True)
     comp_mp = gpu_stump(T_B, m, T_A, ignore_trivial=False)
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
@@ -208,7 +208,7 @@ def test_gpu_stump_two_constant_subsequences_A_B_join():
     # npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
     # Swap inputs
-    ref_mp = naive.stamp(T_A, m, T_B=T_B)
+    ref_mp = naive.stump(T_A, m, T_B=T_B, row_wise=True)
     comp_mp = gpu_stump(T_A, m, T_B, ignore_trivial=False)
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
@@ -227,7 +227,7 @@ def test_gpu_stump_identical_subsequence_self_join():
     T_A[11 : 11 + identical.shape[0]] = identical
     m = 3
     zone = int(np.ceil(m / 4))
-    ref_mp = naive.stamp(T_A, m, exclusion_zone=zone)
+    ref_mp = naive.stump(T_A, m, exclusion_zone=zone, row_wise=True)
     comp_mp = gpu_stump(T_A, m, ignore_trivial=True)
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
@@ -250,7 +250,7 @@ def test_gpu_stump_identical_subsequence_A_B_join():
     T_A[1 : 1 + identical.shape[0]] = identical
     T_B[11 : 11 + identical.shape[0]] = identical
     m = 3
-    ref_mp = naive.stamp(T_B, m, T_B=T_A)
+    ref_mp = naive.stump(T_B, m, T_B=T_A, row_wise=True)
     comp_mp = gpu_stump(T_B, m, T_A, ignore_trivial=False)
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
@@ -265,7 +265,7 @@ def test_gpu_stump_identical_subsequence_A_B_join():
     # )  # ignore indices
 
     # Swap inputs
-    ref_mp = naive.stamp(T_A, m, T_B=T_B)
+    ref_mp = naive.stump(T_A, m, T_B=T_B, row_wise=True)
     comp_mp = gpu_stump(T_A, m, T_B, ignore_trivial=False)
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
@@ -294,7 +294,7 @@ def test_gpu_stump_nan_inf_self_join(T_A, T_B, substitute_B, substitution_locati
         T_B_sub[substitution_location_B] = substitute_B
 
         zone = int(np.ceil(m / 4))
-        ref_mp = naive.stamp(T_B_sub, m, exclusion_zone=zone)
+        ref_mp = naive.stump(T_B_sub, m, exclusion_zone=zone, row_wise=True)
         comp_mp = gpu_stump(T_B_sub, m, ignore_trivial=True)
         naive.replace_inf(ref_mp)
         naive.replace_inf(comp_mp)
@@ -325,7 +325,7 @@ def test_gpu_stump_nan_inf_A_B_join(
             T_A_sub[substitution_location_A] = substitute_A
             T_B_sub[substitution_location_B] = substitute_B
 
-            ref_mp = naive.stamp(T_B_sub, m, T_B=T_A_sub)
+            ref_mp = naive.stump(T_B_sub, m, T_B=T_A_sub, row_wise=True)
             comp_mp = gpu_stump(T_B_sub, m, T_A_sub, ignore_trivial=False)
             naive.replace_inf(ref_mp)
             naive.replace_inf(comp_mp)
@@ -344,7 +344,7 @@ def test_gpu_stump_nan_zero_mean_self_join():
     m = 3
 
     zone = int(np.ceil(m / 4))
-    ref_mp = naive.stamp(T, m, exclusion_zone=zone)
+    ref_mp = naive.stump(T, m, exclusion_zone=zone, row_wise=True)
     comp_mp = gpu_stump(T, m, ignore_trivial=True)
 
     naive.replace_inf(ref_mp)

--- a/tests/test_mstump.py
+++ b/tests/test_mstump.py
@@ -197,7 +197,7 @@ def test_naive_mstump():
 
     zone = int(np.ceil(m / 4))
 
-    ref_mp = naive.stamp(T[0], m, exclusion_zone=zone)
+    ref_mp = naive.stump(T[0], m, exclusion_zone=zone, row_wise=True)
     ref_P = ref_mp[np.newaxis, :, 0]
     ref_I = ref_mp[np.newaxis, :, 1]
 

--- a/tests/test_scrump.py
+++ b/tests/test_scrump.py
@@ -240,7 +240,7 @@ def test_scrump_self_join_full(T_A, T_B):
     m = 3
     zone = int(np.ceil(m / 4))
 
-    ref_mp = naive.stamp(T_B, m, exclusion_zone=zone)
+    ref_mp = naive.stump(T_B, m, exclusion_zone=zone, row_wise=True)
     ref_P = ref_mp[:, 0]
     ref_I = ref_mp[:, 1]
     ref_left_I = ref_mp[:, 2]
@@ -278,7 +278,7 @@ def test_scrump_A_B_join_full(T_A, T_B):
 
     m = 3
 
-    ref_mp = naive.stamp(T_A, m, T_B=T_B)
+    ref_mp = naive.stump(T_A, m, T_B=T_B, row_wise=True)
     ref_P = ref_mp[:, 0]
     ref_I = ref_mp[:, 1]
     ref_left_I = ref_mp[:, 2]
@@ -316,7 +316,7 @@ def test_scrump_A_B_join_full_swap(T_A, T_B):
 
     m = 3
 
-    ref_mp = naive.stamp(T_B, m, T_B=T_A)
+    ref_mp = naive.stump(T_B, m, T_B=T_A, row_wise=True)
     ref_P = ref_mp[:, 0]
     ref_I = ref_mp[:, 1]
     ref_left_I = ref_mp[:, 2]
@@ -344,7 +344,7 @@ def test_scrump_self_join_full_larger_window(T_A, T_B, m):
     if len(T_B) > m:
         zone = int(np.ceil(m / 4))
 
-        ref_mp = naive.stamp(T_B, m, exclusion_zone=zone)
+        ref_mp = naive.stump(T_B, m, exclusion_zone=zone, row_wise=True)
         ref_P = ref_mp[:, 0]
         ref_I = ref_mp[:, 1]
         ref_left_I = ref_mp[:, 2]
@@ -458,7 +458,7 @@ def test_scrump_plus_plus_self_join_full(T_A, T_B):
     m = 3
     zone = int(np.ceil(m / 4))
 
-    ref_mp = naive.stamp(T_B, m, exclusion_zone=zone)
+    ref_mp = naive.stump(T_B, m, exclusion_zone=zone, row_wise=True)
     ref_P = ref_mp[:, 0]
     ref_I = ref_mp[:, 1]
     ref_left_I = ref_mp[:, 2]
@@ -487,7 +487,7 @@ def test_scrump_plus_plus_A_B_join_full(T_A, T_B):
     m = 3
     zone = int(np.ceil(m / 4))
 
-    ref_mp = naive.stamp(T_A, m, T_B=T_B)
+    ref_mp = naive.stump(T_A, m, T_B=T_B, row_wise=True)
     ref_P = ref_mp[:, 0]
     ref_I = ref_mp[:, 1]
     ref_left_I = ref_mp[:, 2]
@@ -516,7 +516,7 @@ def test_scrump_plus_plus_A_B_join_full_swap(T_A, T_B):
     m = 3
     zone = int(np.ceil(m / 4))
 
-    ref_mp = naive.stamp(T_B, m, T_B=T_A)
+    ref_mp = naive.stump(T_B, m, T_B=T_A, row_wise=True)
     ref_P = ref_mp[:, 0]
     ref_I = ref_mp[:, 1]
     ref_left_I = ref_mp[:, 2]

--- a/tests/test_stamp.py
+++ b/tests/test_stamp.py
@@ -59,7 +59,7 @@ def test_stamp_int_input():
 def test_stamp_self_join(T_A, T_B):
     m = 3
     zone = int(np.ceil(m / 2))
-    ref_mp = naive.stamp(T_B, m, exclusion_zone=zone)
+    ref_mp = naive.stump(T_B, m, exclusion_zone=zone, row_wise=True)
     comp_mp = stamp.stamp(T_B, T_B, m, ignore_trivial=True)
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
@@ -69,7 +69,7 @@ def test_stamp_self_join(T_A, T_B):
 @pytest.mark.parametrize("T_A, T_B", test_data)
 def test_stamp_A_B_join(T_A, T_B):
     m = 3
-    ref_mp = naive.stamp(T_A, m, T_B=T_B)
+    ref_mp = naive.stump(T_A, m, T_B=T_B, row_wise=True)
     comp_mp = stamp.stamp(T_A, T_B, m)
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
@@ -89,7 +89,7 @@ def test_stamp_nan_inf_self_join(T_A, T_B, substitute_B, substitution_locations)
         T_B_sub[substitution_location_B] = substitute_B
 
         zone = int(np.ceil(m / 2))
-        ref_mp = naive.stamp(T_B_sub, m, exclusion_zone=zone)
+        ref_mp = naive.stump(T_B_sub, m, exclusion_zone=zone, row_wise=True)
         comp_mp = stamp.stamp(T_B_sub, T_B_sub, m, ignore_trivial=True)
         naive.replace_inf(ref_mp)
         naive.replace_inf(comp_mp)
@@ -115,7 +115,7 @@ def test_stamp_nan_inf_A_B_join(
             T_A_sub[substitution_location_A] = substitute_A
             T_B_sub[substitution_location_B] = substitute_B
 
-            ref_mp = naive.stamp(T_A_sub, m, T_B=T_B_sub)
+            ref_mp = naive.stump(T_A_sub, m, T_B=T_B_sub, row_wise=True)
             comp_mp = stamp.stamp(T_A_sub, T_B_sub, m)
             naive.replace_inf(ref_mp)
             naive.replace_inf(comp_mp)
@@ -127,7 +127,7 @@ def test_stamp_nan_zero_mean_self_join():
     m = 3
 
     zone = int(np.ceil(m / 2))
-    ref_mp = naive.stamp(T, m, exclusion_zone=zone)
+    ref_mp = naive.stump(T, m, exclusion_zone=zone, row_wise=True)
     comp_mp = stamp.stamp(T, T, m, ignore_trivial=True)
 
     naive.replace_inf(ref_mp)

--- a/tests/test_stomp.py
+++ b/tests/test_stomp.py
@@ -30,7 +30,7 @@ def test_stomp_int_input():
 def test_stomp_self_join(T_A, T_B):
     m = 3
     zone = int(np.ceil(m / 4))
-    ref_mp = naive.stamp(T_B, m, exclusion_zone=zone)
+    ref_mp = naive.stump(T_B, m, exclusion_zone=zone, row_wise=True)
     comp_mp = stomp._stomp(T_B, m, ignore_trivial=True)
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
@@ -42,7 +42,7 @@ def test_stomp_self_join(T_A, T_B):
 def test_stump_self_join_larger_window(T_A, T_B, m):
     if len(T_B) > m:
         zone = int(np.ceil(m / 4))
-        ref_mp = naive.stamp(T_B, m, exclusion_zone=zone)
+        ref_mp = naive.stump(T_B, m, exclusion_zone=zone, row_wise=True)
         comp_mp = stomp._stomp(T_B, m, ignore_trivial=True)
         naive.replace_inf(ref_mp)
         naive.replace_inf(comp_mp)
@@ -53,7 +53,7 @@ def test_stump_self_join_larger_window(T_A, T_B, m):
 @pytest.mark.parametrize("T_A, T_B", test_data)
 def test_stomp_A_B_join(T_A, T_B):
     m = 3
-    ref_mp = naive.stamp(T_A, m, T_B=T_B)
+    ref_mp = naive.stump(T_A, m, T_B=T_B, row_wise=True)
     comp_mp = stomp._stomp(T_A, m, T_B, ignore_trivial=False)
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
@@ -73,7 +73,7 @@ def test_stomp_nan_inf_self_join(T_A, T_B, substitute_B, substitution_locations)
         T_B_sub[substitution_location_B] = substitute_B
 
         zone = int(np.ceil(m / 4))
-        ref_mp = naive.stamp(T_B_sub, m, exclusion_zone=zone)
+        ref_mp = naive.stump(T_B_sub, m, exclusion_zone=zone, row_wise=True)
         comp_mp = stomp._stomp(T_B_sub, m, ignore_trivial=True)
         naive.replace_inf(ref_mp)
         naive.replace_inf(comp_mp)
@@ -99,7 +99,7 @@ def test_stomp_nan_inf_A_B_join(
             T_A_sub[substitution_location_A] = substitute_A
             T_B_sub[substitution_location_B] = substitute_B
 
-            ref_mp = naive.stamp(T_A_sub, m, T_B=T_B_sub)
+            ref_mp = naive.stump(T_A_sub, m, T_B=T_B_sub, row_wise=True)
             comp_mp = stomp._stomp(T_A_sub, m, T_B_sub, ignore_trivial=False)
             naive.replace_inf(ref_mp)
             naive.replace_inf(comp_mp)
@@ -111,7 +111,7 @@ def test_stomp_nan_zero_mean_self_join():
     m = 3
 
     zone = int(np.ceil(m / 4))
-    ref_mp = naive.stamp(T, m, exclusion_zone=zone)
+    ref_mp = naive.stump(T, m, exclusion_zone=zone, row_wise=True)
     comp_mp = stomp._stomp(T, m, ignore_trivial=True)
 
     naive.replace_inf(ref_mp)

--- a/tests/test_stump.py
+++ b/tests/test_stump.py
@@ -74,7 +74,7 @@ def test_stump_one_constant_subsequence_A_B_join():
     T_A = np.random.rand(20)
     T_B = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64)))
     m = 3
-    ref_mp = naive.stamp(T_A, m, T_B=T_B)
+    ref_mp = naive.stump(T_A, m, T_B=T_B, row_wise=True)
     comp_mp = stump(T_A, m, T_B, ignore_trivial=False)
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
@@ -85,7 +85,7 @@ def test_stump_one_constant_subsequence_A_B_join():
     npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
     # Swap inputs
-    ref_mp = naive.stamp(T_B, m, T_B=T_A)
+    ref_mp = naive.stump(T_B, m, T_B=T_A, row_wise=True)
     comp_mp = stump(T_B, m, T_A, ignore_trivial=False)
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
@@ -98,7 +98,7 @@ def test_stump_two_constant_subsequences_A_B_join():
     )
     T_B = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64)))
     m = 3
-    ref_mp = naive.stamp(T_A, m, T_B=T_B)
+    ref_mp = naive.stump(T_A, m, T_B=T_B, row_wise=True)
     comp_mp = stump(T_A, m, T_B, ignore_trivial=False)
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
@@ -109,7 +109,7 @@ def test_stump_two_constant_subsequences_A_B_join():
     npt.assert_almost_equal(ref_mp[:, 0], comp_mp[:, 0])  # ignore indices
 
     # Swap inputs
-    ref_mp = naive.stamp(T_B, m, T_B=T_A)
+    ref_mp = naive.stump(T_B, m, T_B=T_A, row_wise=True)
     comp_mp = stump(T_B, m, T_A, ignore_trivial=False)
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
@@ -127,7 +127,7 @@ def test_stump_identical_subsequence_self_join():
     T_A[11 : 11 + identical.shape[0]] = identical
     m = 3
     zone = int(np.ceil(m / 4))
-    ref_mp = naive.stamp(T_A, m, exclusion_zone=zone)
+    ref_mp = naive.stump(T_A, m, exclusion_zone=zone, row_wise=True)
     comp_mp = stump(T_A, m, ignore_trivial=True)
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
@@ -149,7 +149,7 @@ def test_stump_identical_subsequence_A_B_join():
     T_A[1 : 1 + identical.shape[0]] = identical
     T_B[11 : 11 + identical.shape[0]] = identical
     m = 3
-    ref_mp = naive.stamp(T_A, m, T_B=T_B)
+    ref_mp = naive.stump(T_A, m, T_B=T_B, row_wise=True)
     comp_mp = stump(T_A, m, T_B, ignore_trivial=False)
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
@@ -164,7 +164,7 @@ def test_stump_identical_subsequence_A_B_join():
     )  # ignore indices
 
     # Swap inputs
-    ref_mp = naive.stamp(T_B, m, T_B=T_A)
+    ref_mp = naive.stump(T_B, m, T_B=T_A, row_wise=True)
     comp_mp = stump(T_B, m, T_A, ignore_trivial=False)
     naive.replace_inf(ref_mp)
     naive.replace_inf(comp_mp)
@@ -186,7 +186,7 @@ def test_stump_nan_inf_self_join(T_A, T_B, substitute_B, substitution_locations)
         T_B_sub[substitution_location_B] = substitute_B
 
         zone = int(np.ceil(m / 4))
-        ref_mp = naive.stamp(T_B_sub, m, exclusion_zone=zone)
+        ref_mp = naive.stump(T_B_sub, m, exclusion_zone=zone, row_wise=True)
         comp_mp = stump(T_B_sub, m, ignore_trivial=True)
         naive.replace_inf(ref_mp)
         naive.replace_inf(comp_mp)
@@ -216,7 +216,7 @@ def test_stump_nan_inf_A_B_join(
             T_A_sub[substitution_location_A] = substitute_A
             T_B_sub[substitution_location_B] = substitute_B
 
-            ref_mp = naive.stamp(T_A_sub, m, T_B=T_B_sub)
+            ref_mp = naive.stump(T_A_sub, m, T_B=T_B_sub, row_wise=True)
             comp_mp = stump(T_A_sub, m, T_B_sub, ignore_trivial=False)
             naive.replace_inf(ref_mp)
             naive.replace_inf(comp_mp)
@@ -234,7 +234,7 @@ def test_stump_nan_zero_mean_self_join():
     m = 3
 
     zone = int(np.ceil(m / 4))
-    ref_mp = naive.stamp(T, m, exclusion_zone=zone)
+    ref_mp = naive.stump(T, m, exclusion_zone=zone, row_wise=True)
     comp_mp = stump(T, m, ignore_trivial=True)
 
     naive.replace_inf(ref_mp)

--- a/tests/test_stumpi.py
+++ b/tests/test_stumpi.py
@@ -32,7 +32,7 @@ def test_stumpi_self_join():
     comp_left_P = stream.left_P_
     comp_left_I = stream.left_I_
 
-    ref_mp = naive.stamp(stream.T_, m, exclusion_zone=zone)
+    ref_mp = naive.stump(stream.T_, m, exclusion_zone=zone, row_wise=True)
     ref_P = ref_mp[:, 0]
     ref_I = ref_mp[:, 1]
     ref_left_P = np.empty(ref_P.shape)
@@ -210,7 +210,7 @@ def test_stumpi_init_nan_inf_self_join(substitute, substitution_locations):
         comp_I = stream.I_
 
         stream.T_[substitution_location] = substitute
-        ref_mp = naive.stamp(stream.T_, m, exclusion_zone=zone)
+        ref_mp = naive.stump(stream.T_, m, exclusion_zone=zone, row_wise=True)
         ref_P = ref_mp[:, 0]
         ref_I = ref_mp[:, 1]
 
@@ -385,7 +385,7 @@ def test_stumpi_stream_nan_inf_self_join(substitute, substitution_locations):
         comp_I = stream.I_
 
         stream.T_[30:][substitution_location] = substitute
-        ref_mp = naive.stamp(stream.T_, m, exclusion_zone=zone)
+        ref_mp = naive.stump(stream.T_, m, exclusion_zone=zone, row_wise=True)
         ref_P = ref_mp[:, 0]
         ref_I = ref_mp[:, 1]
 
@@ -546,7 +546,7 @@ def test_stumpi_constant_subsequence_self_join():
     comp_P = stream.P_
     # comp_I = stream.I_
 
-    ref_mp = naive.stamp(stream.T_, m, exclusion_zone=zone)
+    ref_mp = naive.stump(stream.T_, m, exclusion_zone=zone, row_wise=True)
     ref_P = ref_mp[:, 0]
     # ref_I = ref_mp[:, 1]
 
@@ -701,7 +701,7 @@ def test_stumpi_identical_subsequence_self_join():
     comp_P = stream.P_
     # comp_I = stream.I_
 
-    ref_mp = naive.stamp(stream.T_, m, exclusion_zone=zone)
+    ref_mp = naive.stump(stream.T_, m, exclusion_zone=zone, row_wise=True)
     ref_P = ref_mp[:, 0]
     # ref_I = ref_mp[:, 1]
 


### PR DESCRIPTION
This PR addresses issue #598. I added parameter `row_wise` to `naive.stump` and, then, instead of calling `mass_PI`, I simply traverse the matrix and update matrix profile and indices.

* Btw, at first, I used the name `row_traversal` for the new parameter. But  then, I thought your proposed name (i.e. `row_wise`) is good!
