### PR TITLE
Fix dask/distributed regression

### DIFF
--- a/stumpy/aamped.py
+++ b/stumpy/aamped.py
@@ -150,16 +150,6 @@ def aamped(dask_client, T_A, m, T_B=None, ignore_trivial=True, p=2.0):
     out[:, 0] = profile[:, 0]
     out[:, 1:4] = indices
 
-    # Delete data from Dask cluster
-    dask_client.cancel(T_A_future)
-    dask_client.cancel(T_B_future)
-    dask_client.cancel(T_A_subseq_isfinite_future)
-    dask_client.cancel(T_B_subseq_isfinite_future)
-    for diags_future in diags_futures:
-        dask_client.cancel(diags_future)
-    for future in futures:
-        dask_client.cancel(future)
-
     threshold = 10e-6
     if core.are_distances_too_small(out[:, 0], threshold=threshold):  # pragma: no cover
         logger.warning(f"A large number of values are smaller than {threshold}.")

--- a/stumpy/maamped.py
+++ b/stumpy/maamped.py
@@ -167,15 +167,4 @@ def maamped(dask_client, T, m, include=None, discords=False, p=2.0):
         stop = min(k, start + step)
         P[:, start + 1 : stop], I[:, start + 1 : stop] = results[i]
 
-    # Delete data from Dask cluster
-    dask_client.cancel(T_A_future)
-    dask_client.cancel(T_A_subseq_isfinite_future)
-    dask_client.cancel(T_B_subseq_isfinite_future)
-    for p_norm_future in p_norm_futures:
-        dask_client.cancel(p_norm_future)
-    for p_norm_first_future in p_norm_first_futures:
-        dask_client.cancel(p_norm_first_future)
-    for future in futures:
-        dask_client.cancel(future)
-
     return P, I

--- a/stumpy/mstumped.py
+++ b/stumpy/mstumped.py
@@ -186,17 +186,4 @@ def mstumped(dask_client, T, m, include=None, discords=False, normalize=True):
         stop = min(k, start + step)
         P[:, start + 1 : stop], I[:, start + 1 : stop] = results[i]
 
-    # Delete data from Dask cluster
-    dask_client.cancel(T_A_future)
-    dask_client.cancel(M_T_future)
-    dask_client.cancel(Σ_T_future)
-    dask_client.cancel(μ_Q_future)
-    dask_client.cancel(σ_Q_future)
-    for QT_future in QT_futures:
-        dask_client.cancel(QT_future)
-    for QT_first_future in QT_first_futures:
-        dask_client.cancel(QT_first_future)
-    for future in futures:
-        dask_client.cancel(future)
-
     return P, I

--- a/stumpy/stumped.py
+++ b/stumpy/stumped.py
@@ -263,24 +263,6 @@ def stumped(dask_client, T_A, m, T_B=None, ignore_trivial=True, normalize=True, 
     out[:, 0] = profile[:, 0]
     out[:, 1:4] = indices
 
-    # Delete data from Dask cluster
-    dask_client.cancel(T_A_future)
-    dask_client.cancel(T_B_future)
-    dask_client.cancel(M_T_future)
-    dask_client.cancel(μ_Q_future)
-    dask_client.cancel(Σ_T_inverse_future)
-    dask_client.cancel(σ_Q_inverse_future)
-    dask_client.cancel(M_T_m_1_future)
-    dask_client.cancel(μ_Q_m_1_future)
-    dask_client.cancel(T_A_subseq_isfinite_future)
-    dask_client.cancel(T_B_subseq_isfinite_future)
-    dask_client.cancel(T_A_subseq_isconstant_future)
-    dask_client.cancel(T_B_subseq_isconstant_future)
-    for diags_future in diags_futures:
-        dask_client.cancel(diags_future)
-    for future in futures:
-        dask_client.cancel(future)
-
     threshold = 10e-6
     if core.are_distances_too_small(out[:, 0], threshold=threshold):  # pragma: no cover
         logger.warning(f"A large number of values are smaller than {threshold}.")


### PR DESCRIPTION
Closes https://github.com/TDAmeritrade/stumpy/issues/615

The comment suggests that these cancellations are required to delete data from the dask cluster but this is not necessary for a couple of reasons

- Cancellation itself is not necessary unless you want to abort an actively running graph, e.g. if you wanted to stop all submitted futures before they finished. We reach this code path only if all completed successfully 
- What you are looking for is likely rather `del future` or `future.release()` which tells the scheduler that the future is no longer required and it deletes it
- The explicit release of the data is not even required. We're already at the end of the function and as soon as we exit the local context, the futures are garbage collected and dask dereferences the futures automatically and releases the data.