### PR TITLE
Fix algo to avoid miscalculation in AB-join

### DIFF
--- a/stumpy/scraamp.py
+++ b/stumpy/scraamp.py
@@ -134,7 +134,7 @@ def _compute_PI(
                 if p_norm < P_NORM[thread_idx, i + k]:
                     P_NORM[thread_idx, i + k] = p_norm
                     I[thread_idx, i + k] = j + k
-                if p_norm < P_NORM[thread_idx, j + k]:
+                if excl_zone is not None and p_norm < P_NORM[thread_idx, j + k]:
                     P_NORM[thread_idx, j + k] = p_norm
                     I[thread_idx, j + k] = i + k
             p_norm_j = p_norm_j_prime
@@ -155,7 +155,7 @@ def _compute_PI(
                 if p_norm < P_NORM[thread_idx, i - k]:
                     P_NORM[thread_idx, i - k] = p_norm
                     I[thread_idx, i - k] = j - k
-                if p_norm < P_NORM[thread_idx, j - k]:
+                if excl_zone is not None and p_norm < P_NORM[thread_idx, j - k]:
                     P_NORM[thread_idx, j - k] = p_norm
                     I[thread_idx, j - k] = i - k
 

--- a/tests/naive.py
+++ b/tests/naive.py
@@ -1530,7 +1530,7 @@ def prescraamp(T_A, m, T_B, s, exclusion_zone=None, p=2.0):
                 if d < P[i + k]:
                     P[i + k] = d
                     I[i + k] = j + k
-                if d < P[j + k]:
+                if exclusion_zone is not None and d < P[j + k]:
                     P[j + k] = d
                     I[j + k] = i + k
 
@@ -1539,7 +1539,7 @@ def prescraamp(T_A, m, T_B, s, exclusion_zone=None, p=2.0):
                 if d < P[i - k]:
                     P[i - k] = d
                     I[i - k] = j - k
-                if d < P[j - k]:
+                if exclusion_zone is not None and d < P[j - k]:
                     P[j - k] = d
                     I[j - k] = i - k
 


### PR DESCRIPTION
This PR fixes #644 for non-normalized method (this is a follow up to PR #645)