### PR TITLE
Fixed #654 Refactor match 

### DIFF
--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -2583,3 +2583,94 @@ def _check_P(P, threshold=1e-6):
     if are_distances_too_small(P, threshold=threshold):  # pragma: no cover
         logger.warning(f"A large number of values in `P` are smaller than {threshold}.")
         logger.warning("For a self-join, try setting `ignore_trivial=True`.")
+
+
+def _find_matches(
+    D, excl_zone, max_distance=None, max_matches=None, query_idx=None, atol=1e-8
+):
+    """
+    Find all matches of a query `Q` whose distance profile with `T` is `D`.
+
+    Parameters
+    ----------
+    D : numpy.ndarray
+        The distance profile of `Q` with `T`. It is a 1D numpy array of size
+        `len(T)-len(Q)+1`, where `D[i]` is the distance between query `Q` and
+        `T[i : i + len(Q)]`.
+
+    excl_zone : int
+        Size of the exclusion zone. That is, after finding the next-best-match
+        located at index `idx`, we ignore subsequences with start index in range
+        (idx -  excl_zone, idx + excl_zone + 1).
+
+    max_distance : float or function, default None
+        Maximum distance between `Q` and a subsequence `S` for `S` to be considered a
+        match.
+        If a function, then it has to be a function of one argument `D`, which will be
+        the distance profile of `Q` with `T` (a 1D numpy array of size `n-m+1`).
+        If None, this defaults to
+        `np.nanmax([np.nanmean(D) - 2 * np.nanstd(D), np.nanmin(D)])` (i.e. at
+        least the closest match will be returned).
+
+    max_matches : int, default None
+        The maximum amount of similar occurrences to be returned. The resulting
+        occurrences are sorted by distance, so a value of `10` means that the
+        indices of the most similar `10` subsequences is returned. If `None`, then all
+        occurrences are returned.
+
+    query_idx : int, default None
+        This is the index position along the time series, `T`, where the query
+        subsequence, `Q`, is located.
+        `query_idx` should only be used when the matrix profile is a self-join and
+        should be set to `None` for matrix profiles computed from AB-joins.
+        If `query_idx` is set to a specific integer value, then this will help ensure
+        that the self-match will be returned first.
+
+    atol : float, default 1e-8
+        The absolute tolerance parameter. This value will be added to `max_distance`
+        when comparing distances between subsequences.
+
+    Returns
+    -------
+    out : numpy.ndarray
+        The first column consists of values selected from `D`. These are the distances
+        of subsequences of `T` whose distances to `Q` are less than or equal to
+        `max_distance`, sorted by distance (lowest to highest). The second column
+        consists of the corresponding indices in `D`. These are in fact the start index
+        of susequences in `T` selected as the match of `Q`.
+
+    """
+    if max_distance is None:
+
+        def max_distance(D):
+            D_copy = D.copy().astype(np.float64)
+            D_copy[np.isinf(D_copy)] = np.nan
+            return np.nanmax(
+                [np.nanmean(D_copy) - 2.0 * np.nanstd(D_copy), np.nanmin(D_copy)]
+            )
+
+    if not isinstance(max_distance, float):
+        max_distance = max_distance(D)
+
+    if max_matches is None:  # pragma: no cover
+        max_matches = np.inf
+
+    if query_idx is not None:
+        candidate_idx = query_idx
+    else:
+        candidate_idx = np.argmin(D)
+
+    matches = []
+    for _ in range(len(D)):
+        if (
+            D[candidate_idx] > atol + max_distance
+            or ~np.isfinite(D[candidate_idx])
+            or len(matches) >= max_matches
+        ):
+            break
+
+        matches.append([D[candidate_idx], candidate_idx])
+        apply_exclusion_zone(D, candidate_idx, excl_zone, np.inf)
+        candidate_idx = np.argmin(D)
+
+    return np.array(matches, dtype=object)

--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -2640,6 +2640,7 @@ def _find_matches(
         of susequences in `T` selected as the match of `Q`.
 
     """
+    D = D.copy()
     if max_distance is None:
 
         def max_distance(D):
@@ -2652,7 +2653,7 @@ def _find_matches(
     if not isinstance(max_distance, float):
         max_distance = max_distance(D)
 
-    if max_matches is None:  # pragma: no cover
+    if max_matches is None:
         max_matches = np.inf
 
     if query_idx is not None:

--- a/tests/naive.py
+++ b/tests/naive.py
@@ -1757,3 +1757,25 @@ def _total_diagonal_ndists(tile_lower_diag, tile_upper_diag, tile_height, tile_w
         )
 
     return total_ndists
+
+
+def find_matches(D, excl_zone, max_distance, max_matches=None):
+    if max_matches is None:
+        max_matches = len(D)
+
+    matches = []
+    for i in range(D.size):
+        dist = D[i]
+        if dist <= max_distance:
+            matches.append(i)
+
+    # Removes indices that are inside the exclusion zone of some occurrence with
+    # a smaller distance to the query
+    matches.sort(key=lambda x: D[x])
+    result = []
+    while len(matches) > 0:
+        idx = matches[0]
+        result.append([D[idx], idx])
+        matches = [x for x in matches if x < idx - excl_zone or x > idx + excl_zone]
+
+    return np.array(result[:max_matches], dtype=object)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1064,3 +1064,25 @@ def test_select_P_ABBA_val_inf():
 def test_check_P():
     with pytest.raises(ValueError):
         core._check_P(np.random.rand(10).reshape(2, 5))
+
+
+def test_find_matches_all():
+    # max_matches: None, i.e. find all matches
+    max_distance = np.inf
+    D = np.random.rand(64)
+    for excl_zone in range(3):
+        ref = naive.find_matches(D, excl_zone, max_distance, max_matches=None)
+        comp = core._find_matches(D, excl_zone, max_distance, max_matches=None)
+
+        npt.assert_almost_equal(ref, comp)
+
+
+def test_find_matches_maxmatch():
+    max_distance = np.inf
+    D = np.random.rand(64)
+    for excl_zone in range(3):
+        max_matches = np.random.randint(0, 100)
+        ref = naive.find_matches(D, excl_zone, max_distance, max_matches)
+        comp = core._find_matches(D, excl_zone, max_distance, max_matches)
+
+        npt.assert_almost_equal(ref, comp)

--- a/tests/test_motifs.py
+++ b/tests/test_motifs.py
@@ -7,11 +7,11 @@ from stumpy import core, motifs, match
 import naive
 
 
-def naive_match(Q, T, excl_zone, max_distance):
+def naive_match(Q, T, excl_zone, max_distance, max_matches=None):
     m = Q.shape[0]
     D = naive.distance_profile(Q, T, m)
 
-    return naive.find_matches(D, excl_zone, max_distance)
+    return naive.find_matches(D, excl_zone, max_distance, max_matches)
 
 
 test_data = [

--- a/tests/test_motifs.py
+++ b/tests/test_motifs.py
@@ -11,22 +11,7 @@ def naive_match(Q, T, excl_zone, max_distance):
     m = Q.shape[0]
     D = naive.distance_profile(Q, T, m)
 
-    matches = []
-    for i in range(D.size):
-        dist = D[i]
-        if dist <= max_distance:
-            matches.append(i)
-
-    # Removes indices that are inside the exclusion zone of some occurrence with
-    # a smaller distance to the query
-    matches.sort(key=lambda x: D[x])
-    result = []
-    while len(matches) > 0:
-        o = matches[0]
-        result.append([D[o], o])
-        matches = [x for x in matches if x < o - excl_zone or x > o + excl_zone]
-
-    return np.array(result, dtype=object)
+    return naive.find_matches(D, excl_zone, max_distance)
 
 
 test_data = [


### PR DESCRIPTION
This PR addresses issue #654.

What I have done so far:
* Refactor `stumpy/motifs.py: match` and `stumpy/aamp_motifs.py: aamp_match`
* Add new function `_find_matches()` to `stumpy/core.py`
* Add naive implementation of  `_find_matches()`(in fact, it is mostly adapted from the existing naive version of `match` in `test_motif.py`)
* Add two test functions to `stumpy/test_core.py`
* Improve naive  implementation to consider `max_matches`

----

So, some of the test functions in `test_motif.py` perform test on different cases. However, now, the two new test functions are in `test_core.py`. Is that okay? In those test functions, I considered only two cases for the newly added function as I believed the other cases are already covered by test functions in `test_motif.py`. Please let me know how  you feel about it.