### PR TITLE
Fix #673 Fix two minor issues in motifs and aamp_motifs

### DIFF
--- a/stumpy/aamp_motifs.py
+++ b/stumpy/aamp_motifs.py
@@ -272,6 +272,17 @@ def aamp_motifs(
             [np.nanmean(P_copy) - 2.0 * np.nanstd(P_copy), np.nanmin(P_copy)]
         )
 
+    if cutoff == 0.0:  # pragma: no cover
+        suggested_cutoff = np.partition(P, 1)[1]
+        logger.warn(
+            "The `cutoff` has been set to 0.0 and may result in little/no candidate "
+            "motifs being identified."
+        )
+        logger.warn(
+            "You may consider relaxing the constraint by increasing the `cutoff` "
+            f"(e.g., cutoff={suggested_cutoff}."
+        )
+
     T, T_subseq_isfinite = core.preprocess_non_normalized(T[np.newaxis, :], m)
     P = P[np.newaxis, :].astype(np.float64)
 

--- a/stumpy/aamp_motifs.py
+++ b/stumpy/aamp_motifs.py
@@ -129,6 +129,10 @@ def _aamp_motifs(
             motif_distances.append(query_matches[:max_matches, 0])
             motif_indices.append(query_matches[:max_matches, 1])
 
+        if len(query_matches) == 0:  # pragma: no cover
+            # create fake `query_matches`
+            query_matches = np.array([[np.nan, candidate_idx]])
+
         for idx in query_matches[:, 1]:
             core.apply_exclusion_zone(P, int(idx), excl_zone, np.inf)
 

--- a/stumpy/aamp_motifs.py
+++ b/stumpy/aamp_motifs.py
@@ -284,7 +284,7 @@ def aamp_motifs(
         )
         logger.warn(
             "You may consider relaxing the constraint by increasing the `cutoff` "
-            f"(e.g., cutoff={suggested_cutoff}."
+            f"(e.g., cutoff={suggested_cutoff})."
         )
 
     T, T_subseq_isfinite = core.preprocess_non_normalized(T[np.newaxis, :], m)

--- a/stumpy/aamp_motifs.py
+++ b/stumpy/aamp_motifs.py
@@ -130,7 +130,6 @@ def _aamp_motifs(
             motif_indices.append(query_matches[:max_matches, 1])
 
         if len(query_matches) == 0:  # pragma: no cover
-            # create fake `query_matches`
             query_matches = np.array([[np.nan, candidate_idx]])
 
         for idx in query_matches[:, 1]:

--- a/stumpy/motifs.py
+++ b/stumpy/motifs.py
@@ -311,7 +311,7 @@ def motifs(
         )
         logger.warn(
             "You may consider relaxing the constraint by increasing the `cutoff` "
-            f"(e.g., cutoff={suggested_cutoff}."
+            f"(e.g., cutoff={suggested_cutoff})."
         )
 
     T, M_T, Σ_T = core.preprocess(T[np.newaxis, :], m)

--- a/stumpy/motifs.py
+++ b/stumpy/motifs.py
@@ -299,6 +299,17 @@ def motifs(
             [np.nanmean(P_copy) - 2.0 * np.nanstd(P_copy), np.nanmin(P_copy)]
         )
 
+    if cutoff == 0.0:  # pragma: no cover
+        suggested_cutoff = np.partition(P, 1)[1]
+        logger.warn(
+            "The `cutoff` has been set to 0.0 and may result in little/no candidate "
+            "motifs being identified."
+        )
+        logger.warn(
+            "You may consider relaxing the constraint by increasing the `cutoff` "
+            f"(e.g., cutoff={suggested_cutoff}."
+        )
+
     T, M_T, Σ_T = core.preprocess(T[np.newaxis, :], m)
     P = P[np.newaxis, :].astype(np.float64)
 

--- a/stumpy/motifs.py
+++ b/stumpy/motifs.py
@@ -129,6 +129,10 @@ def _motifs(
             motif_distances.append(query_matches[:max_matches, 0])
             motif_indices.append(query_matches[:max_matches, 1])
 
+        if len(query_matches) == 0:  # pragma: no cover
+            # create fake `query_matches`
+            query_matches = np.array([[np.nan, candidate_idx]])
+
         for idx in query_matches[:, 1]:
             core.apply_exclusion_zone(P, int(idx), excl_zone, np.inf)
 

--- a/stumpy/motifs.py
+++ b/stumpy/motifs.py
@@ -130,7 +130,6 @@ def _motifs(
             motif_indices.append(query_matches[:max_matches, 1])
 
         if len(query_matches) == 0:  # pragma: no cover
-            # create fake `query_matches`
             query_matches = np.array([[np.nan, candidate_idx]])
 
         for idx in query_matches[:, 1]:


### PR DESCRIPTION
This PR resolves the issues (1) and (2) discussed in #673.

Fix (1): Throwing warning when `cutoff` is set to `0.0`
Fix (2): Replace empty array with a fake 2D array to allow traversing over its second column (and avoid choosing the already selected `candidate_idx` in the next iteration)