### PR TITLE
Fix #675 Revise docstring

### DIFF
--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -1710,14 +1710,14 @@ def preprocess_diagonal(T, m):
     Preprocess a time series that is to be used when traversing the diagonals of a
     distance matrix.
 
-    Creates a copy of the time series where all NaN and inf values
-    are replaced with zero. Also computes means, `M_T` and `M_T_m_1`, for every
-    subsequence using awindow size of `m` and `m-1`, respectively, and the inverse
-    standard deviation, `Σ_T_inverse`. Every subsequence that contains at least
-    one NaN or inf value will have a `False` value in its `T_subseq_isfinite` `bool`
-    array.  Additionally, the inverse standard deviation, σ_inverse, will also be
-    computed and returned. Finally, constant subsequences (i.e., subsequences with
-    a standard deviation of zero), will have a corresponding `True` value in its
+    Creates a copy of the time series where all NaN and inf values are replaced
+    with zero. Also computes means, `M_T` and `M_T_m_1`, for every subsequence
+    using a window size of `m` and `m-1`, respectively, and the inverse standard
+    deviation, `Σ_T_inverse`. Every subsequence that contains at least one NaN or
+    inf value will have a `False` value in its `T_subseq_isfinite` `bool` array.
+    Additionally, the inverse standard deviation, σ_inverse, will also be computed
+    and returned. Finally, constant subsequences (i.e., subsequences with a standard
+    deviation of zero), will have a corresponding `True` value in its
     `T_subseq_isconstant` array.
 
     Parameters

--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -1715,12 +1715,10 @@ def preprocess_diagonal(T, m):
     subsequence using awindow size of `m` and `m-1`, respectively, and the inverse
     standard deviation, `Σ_T_inverse`. Every subsequence that contains at least
     one NaN or inf value will have a `False` value in its `T_subseq_isfinite` `bool`
-    arra and it will also have a mean of np.inf. For the standard
-    deviation these values are ignored. If all values are illegal, the
-    standard deviation will be 0 (see `core.compute_mean_std`). Additionally,
-    the inverse standard deviation, σ_inverse, will also be computed and returned.
-    Finally, constant subsequences (i.e., subsequences with a standard deviation of
-    zero), will have a corresponding `True` value in its `T_subseq_isconstant` array.
+    array.  Additionally, the inverse standard deviation, σ_inverse, will also be
+    computed and returned. Finally, constant subsequences (i.e., subsequences with
+    a standard deviation of zero), will have a corresponding `True` value in its
+    `T_subseq_isconstant` array.
 
     Parameters
     ----------


### PR DESCRIPTION
This PR fixes the issue raised in #675. I also tried to make the description of the function cleaner.

We may add something like this:
```
The calculated value for mean and std for the subsequences are calculated after replacing all nan and inf with 0.
``` 