### PR TITLE
Fixed #722: Replaced instances of overwriting config variables with unittest.mock.patch

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,6 +4,7 @@ import pandas as pd
 from scipy.spatial.distance import cdist
 from stumpy import core, config
 import pytest
+from unittest.mock import patch
 import os
 import math
 
@@ -288,12 +289,11 @@ def test_compute_mean_std(Q, T):
 def test_compute_mean_std_chunked(Q, T):
     m = Q.shape[0]
 
-    config.STUMPY_MEAN_STD_NUM_CHUNKS = 2
-    ref_μ_Q, ref_σ_Q = naive.compute_mean_std(Q, m)
-    ref_M_T, ref_Σ_T = naive.compute_mean_std(T, m)
-    comp_μ_Q, comp_σ_Q = core.compute_mean_std(Q, m)
-    comp_M_T, comp_Σ_T = core.compute_mean_std(T, m)
-    config.STUMPY_MEAN_STD_NUM_CHUNKS = 1
+    with patch("config.STUMPY_MEAN_STD_NUM_CHUNKS", 2):
+        ref_μ_Q, ref_σ_Q = naive.compute_mean_std(Q, m)
+        ref_M_T, ref_Σ_T = naive.compute_mean_std(T, m)
+        comp_μ_Q, comp_σ_Q = core.compute_mean_std(Q, m)
+        comp_M_T, comp_Σ_T = core.compute_mean_std(T, m)
 
     npt.assert_almost_equal(ref_μ_Q, comp_μ_Q)
     npt.assert_almost_equal(ref_σ_Q, comp_σ_Q)
@@ -305,12 +305,11 @@ def test_compute_mean_std_chunked(Q, T):
 def test_compute_mean_std_chunked_many(Q, T):
     m = Q.shape[0]
 
-    config.STUMPY_MEAN_STD_NUM_CHUNKS = 128
-    ref_μ_Q, ref_σ_Q = naive.compute_mean_std(Q, m)
-    ref_M_T, ref_Σ_T = naive.compute_mean_std(T, m)
-    comp_μ_Q, comp_σ_Q = core.compute_mean_std(Q, m)
-    comp_M_T, comp_Σ_T = core.compute_mean_std(T, m)
-    config.STUMPY_MEAN_STD_NUM_CHUNKS = 1
+    with patch("config.STUMPY_MEAN_STD_NUM_CHUNKS", 128):
+        ref_μ_Q, ref_σ_Q = naive.compute_mean_std(Q, m)
+        ref_M_T, ref_Σ_T = naive.compute_mean_std(T, m)
+        comp_μ_Q, comp_σ_Q = core.compute_mean_std(Q, m)
+        comp_M_T, comp_Σ_T = core.compute_mean_std(T, m)
 
     npt.assert_almost_equal(ref_μ_Q, comp_μ_Q)
     npt.assert_almost_equal(ref_σ_Q, comp_σ_Q)
@@ -343,12 +342,11 @@ def test_compute_mean_std_multidimensional_chunked(Q, T):
     Q = np.array([Q, np.random.uniform(-1000, 1000, [Q.shape[0]])])
     T = np.array([T, T, np.random.uniform(-1000, 1000, [T.shape[0]])])
 
-    config.STUMPY_MEAN_STD_NUM_CHUNKS = 2
-    ref_μ_Q, ref_σ_Q = naive_compute_mean_std_multidimensional(Q, m)
-    ref_M_T, ref_Σ_T = naive_compute_mean_std_multidimensional(T, m)
-    comp_μ_Q, comp_σ_Q = core.compute_mean_std(Q, m)
-    comp_M_T, comp_Σ_T = core.compute_mean_std(T, m)
-    config.STUMPY_MEAN_STD_NUM_CHUNKS = 1
+    with patch("config.STUMPY_MEAN_STD_NUM_CHUNKS", 2):
+        ref_μ_Q, ref_σ_Q = naive_compute_mean_std_multidimensional(Q, m)
+        ref_M_T, ref_Σ_T = naive_compute_mean_std_multidimensional(T, m)
+        comp_μ_Q, comp_σ_Q = core.compute_mean_std(Q, m)
+        comp_M_T, comp_Σ_T = core.compute_mean_std(T, m)
 
     npt.assert_almost_equal(ref_μ_Q, comp_μ_Q)
     npt.assert_almost_equal(ref_σ_Q, comp_σ_Q)
@@ -363,12 +361,11 @@ def test_compute_mean_std_multidimensional_chunked_many(Q, T):
     Q = np.array([Q, np.random.uniform(-1000, 1000, [Q.shape[0]])])
     T = np.array([T, T, np.random.uniform(-1000, 1000, [T.shape[0]])])
 
-    config.STUMPY_MEAN_STD_NUM_CHUNKS = 128
-    ref_μ_Q, ref_σ_Q = naive_compute_mean_std_multidimensional(Q, m)
-    ref_M_T, ref_Σ_T = naive_compute_mean_std_multidimensional(T, m)
-    comp_μ_Q, comp_σ_Q = core.compute_mean_std(Q, m)
-    comp_M_T, comp_Σ_T = core.compute_mean_std(T, m)
-    config.STUMPY_MEAN_STD_NUM_CHUNKS = 1
+    with patch("config.STUMPY_MEAN_STD_NUM_CHUNKS", 128):
+        ref_μ_Q, ref_σ_Q = naive_compute_mean_std_multidimensional(Q, m)
+        ref_M_T, ref_Σ_T = naive_compute_mean_std_multidimensional(T, m)
+        comp_μ_Q, comp_σ_Q = core.compute_mean_std(Q, m)
+        comp_M_T, comp_Σ_T = core.compute_mean_std(T, m)
 
     npt.assert_almost_equal(ref_μ_Q, comp_μ_Q)
     npt.assert_almost_equal(ref_σ_Q, comp_σ_Q)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -289,7 +289,7 @@ def test_compute_mean_std(Q, T):
 def test_compute_mean_std_chunked(Q, T):
     m = Q.shape[0]
 
-    with patch("config.STUMPY_MEAN_STD_NUM_CHUNKS", 2):
+    with patch("stumpy.config.STUMPY_MEAN_STD_NUM_CHUNKS", 2):
         ref_μ_Q, ref_σ_Q = naive.compute_mean_std(Q, m)
         ref_M_T, ref_Σ_T = naive.compute_mean_std(T, m)
         comp_μ_Q, comp_σ_Q = core.compute_mean_std(Q, m)
@@ -305,7 +305,7 @@ def test_compute_mean_std_chunked(Q, T):
 def test_compute_mean_std_chunked_many(Q, T):
     m = Q.shape[0]
 
-    with patch("config.STUMPY_MEAN_STD_NUM_CHUNKS", 128):
+    with patch("stumpy.config.STUMPY_MEAN_STD_NUM_CHUNKS", 128):
         ref_μ_Q, ref_σ_Q = naive.compute_mean_std(Q, m)
         ref_M_T, ref_Σ_T = naive.compute_mean_std(T, m)
         comp_μ_Q, comp_σ_Q = core.compute_mean_std(Q, m)
@@ -342,7 +342,7 @@ def test_compute_mean_std_multidimensional_chunked(Q, T):
     Q = np.array([Q, np.random.uniform(-1000, 1000, [Q.shape[0]])])
     T = np.array([T, T, np.random.uniform(-1000, 1000, [T.shape[0]])])
 
-    with patch("config.STUMPY_MEAN_STD_NUM_CHUNKS", 2):
+    with patch("stumpy.config.STUMPY_MEAN_STD_NUM_CHUNKS", 2):
         ref_μ_Q, ref_σ_Q = naive_compute_mean_std_multidimensional(Q, m)
         ref_M_T, ref_Σ_T = naive_compute_mean_std_multidimensional(T, m)
         comp_μ_Q, comp_σ_Q = core.compute_mean_std(Q, m)
@@ -361,7 +361,7 @@ def test_compute_mean_std_multidimensional_chunked_many(Q, T):
     Q = np.array([Q, np.random.uniform(-1000, 1000, [Q.shape[0]])])
     T = np.array([T, T, np.random.uniform(-1000, 1000, [T.shape[0]])])
 
-    with patch("config.STUMPY_MEAN_STD_NUM_CHUNKS", 128):
+    with patch("stumpy.config.STUMPY_MEAN_STD_NUM_CHUNKS", 128):
         ref_μ_Q, ref_σ_Q = naive_compute_mean_std_multidimensional(Q, m)
         ref_M_T, ref_Σ_T = naive_compute_mean_std_multidimensional(T, m)
         comp_μ_Q, comp_σ_Q = core.compute_mean_std(Q, m)

--- a/tests/test_gpu_aamp.py
+++ b/tests/test_gpu_aamp.py
@@ -4,6 +4,7 @@ import pandas as pd
 from stumpy import gpu_aamp
 from stumpy import config
 from numba import cuda
+from unittest.mock import patch
 
 try:
     from numba.errors import NumbaPerformanceWarning
@@ -12,7 +13,7 @@ except ModuleNotFoundError:
 import pytest
 import naive
 
-config.THREADS_PER_BLOCK = 10
+TEST_THREADS_PER_BLOCK = 10
 
 if not cuda.is_available():  # pragma: no cover
     pytest.skip("Skipping Tests No GPUs Available", allow_module_level=True)
@@ -34,6 +35,7 @@ substitution_locations = [(slice(0, 0), 0, -1, slice(1, 3), [0, 3])]
 substitution_values = [np.nan, np.inf]
 
 
+@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_aamp_int_input():
     with pytest.raises(TypeError):
         gpu_aamp(np.arange(10), 5, ignore_trivial=True)
@@ -41,6 +43,7 @@ def test_gpu_aamp_int_input():
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
 @pytest.mark.parametrize("T_A, T_B", test_data)
+@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_aamp_self_join(T_A, T_B):
     m = 3
     zone = int(np.ceil(m / 4))
@@ -59,6 +62,7 @@ def test_gpu_aamp_self_join(T_A, T_B):
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
 @pytest.mark.parametrize("T_A, T_B", test_data)
 @pytest.mark.parametrize("m", window_size)
+@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_aamp_self_join_larger_window(T_A, T_B, m):
     if len(T_B) > m:
         zone = int(np.ceil(m / 4))
@@ -80,6 +84,7 @@ def test_gpu_aamp_self_join_larger_window(T_A, T_B, m):
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
 @pytest.mark.parametrize("T_A, T_B", test_data)
+@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_aamp_A_B_join(T_A, T_B):
     m = 3
     for p in [1.0, 2.0, 3.0]:
@@ -98,6 +103,7 @@ def test_gpu_aamp_A_B_join(T_A, T_B):
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
 @pytest.mark.parametrize("T_A, T_B", test_data)
+@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_parallel_gpu_aamp_self_join(T_A, T_B):
     device_ids = [device.id for device in cuda.list_devices()]
     if len(T_B) > 10:
@@ -126,6 +132,7 @@ def test_parallel_gpu_aamp_self_join(T_A, T_B):
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
 @pytest.mark.parametrize("T_A, T_B", test_data)
+@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_parallel_gpu_aamp_A_B_join(T_A, T_B):
     device_ids = [device.id for device in cuda.list_devices()]
     if len(T_B) > 10:
@@ -154,6 +161,7 @@ def test_parallel_gpu_aamp_A_B_join(T_A, T_B):
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
+@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_aamp_constant_subsequence_self_join():
     T_A = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64)))
     m = 3
@@ -170,6 +178,7 @@ def test_gpu_aamp_constant_subsequence_self_join():
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
+@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_aamp_one_constant_subsequence_A_B_join():
     T_A = np.random.rand(20)
     T_B = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64)))
@@ -197,6 +206,7 @@ def test_gpu_aamp_one_constant_subsequence_A_B_join():
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
+@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_aamp_two_constant_subsequences_A_B_join():
     T_A = np.array([0, 0, 0, 0, 0, 1], dtype=np.float64)
     T_B = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64)))
@@ -224,6 +234,7 @@ def test_gpu_aamp_two_constant_subsequences_A_B_join():
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
+@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_aamp_identical_subsequence_self_join():
     identical = np.random.rand(8)
     T_A = np.random.rand(20)
@@ -247,6 +258,7 @@ def test_gpu_aamp_identical_subsequence_self_join():
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
+@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_aamp_identical_subsequence_A_B_join():
     identical = np.random.rand(8)
     T_A = np.random.rand(20)
@@ -288,6 +300,7 @@ def test_gpu_aamp_identical_subsequence_A_B_join():
 @pytest.mark.parametrize("T_A, T_B", test_data)
 @pytest.mark.parametrize("substitute_B", substitution_values)
 @pytest.mark.parametrize("substitution_locations", substitution_locations)
+@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_aamp_nan_inf_self_join(T_A, T_B, substitute_B, substitution_locations):
     m = 3
     stop = 16
@@ -314,6 +327,7 @@ def test_gpu_aamp_nan_inf_self_join(T_A, T_B, substitute_B, substitution_locatio
 @pytest.mark.parametrize("substitute_A", substitution_values)
 @pytest.mark.parametrize("substitute_B", substitution_values)
 @pytest.mark.parametrize("substitution_locations", substitution_locations)
+@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_aamp_nan_inf_A_B_join(
     T_A, T_B, substitute_A, substitute_B, substitution_locations
 ):
@@ -343,6 +357,7 @@ def test_gpu_aamp_nan_inf_A_B_join(
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
+@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_aamp_nan_zero_mean_self_join():
     T = np.array([-1, 0, 1, np.inf, 1, 0, -1])
     m = 3

--- a/tests/test_gpu_aamp.py
+++ b/tests/test_gpu_aamp.py
@@ -35,7 +35,7 @@ substitution_locations = [(slice(0, 0), 0, -1, slice(1, 3), [0, 3])]
 substitution_values = [np.nan, np.inf]
 
 
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_aamp_int_input():
     with pytest.raises(TypeError):
         gpu_aamp(np.arange(10), 5, ignore_trivial=True)
@@ -43,7 +43,7 @@ def test_gpu_aamp_int_input():
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
 @pytest.mark.parametrize("T_A, T_B", test_data)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_aamp_self_join(T_A, T_B):
     m = 3
     zone = int(np.ceil(m / 4))
@@ -62,7 +62,7 @@ def test_gpu_aamp_self_join(T_A, T_B):
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
 @pytest.mark.parametrize("T_A, T_B", test_data)
 @pytest.mark.parametrize("m", window_size)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_aamp_self_join_larger_window(T_A, T_B, m):
     if len(T_B) > m:
         zone = int(np.ceil(m / 4))
@@ -84,7 +84,7 @@ def test_gpu_aamp_self_join_larger_window(T_A, T_B, m):
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
 @pytest.mark.parametrize("T_A, T_B", test_data)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_aamp_A_B_join(T_A, T_B):
     m = 3
     for p in [1.0, 2.0, 3.0]:
@@ -103,7 +103,7 @@ def test_gpu_aamp_A_B_join(T_A, T_B):
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
 @pytest.mark.parametrize("T_A, T_B", test_data)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_parallel_gpu_aamp_self_join(T_A, T_B):
     device_ids = [device.id for device in cuda.list_devices()]
     if len(T_B) > 10:
@@ -132,7 +132,7 @@ def test_parallel_gpu_aamp_self_join(T_A, T_B):
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
 @pytest.mark.parametrize("T_A, T_B", test_data)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_parallel_gpu_aamp_A_B_join(T_A, T_B):
     device_ids = [device.id for device in cuda.list_devices()]
     if len(T_B) > 10:
@@ -161,7 +161,7 @@ def test_parallel_gpu_aamp_A_B_join(T_A, T_B):
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_aamp_constant_subsequence_self_join():
     T_A = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64)))
     m = 3
@@ -178,7 +178,7 @@ def test_gpu_aamp_constant_subsequence_self_join():
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_aamp_one_constant_subsequence_A_B_join():
     T_A = np.random.rand(20)
     T_B = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64)))
@@ -206,7 +206,7 @@ def test_gpu_aamp_one_constant_subsequence_A_B_join():
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_aamp_two_constant_subsequences_A_B_join():
     T_A = np.array([0, 0, 0, 0, 0, 1], dtype=np.float64)
     T_B = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64)))
@@ -234,7 +234,7 @@ def test_gpu_aamp_two_constant_subsequences_A_B_join():
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_aamp_identical_subsequence_self_join():
     identical = np.random.rand(8)
     T_A = np.random.rand(20)
@@ -258,7 +258,7 @@ def test_gpu_aamp_identical_subsequence_self_join():
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_aamp_identical_subsequence_A_B_join():
     identical = np.random.rand(8)
     T_A = np.random.rand(20)
@@ -300,7 +300,7 @@ def test_gpu_aamp_identical_subsequence_A_B_join():
 @pytest.mark.parametrize("T_A, T_B", test_data)
 @pytest.mark.parametrize("substitute_B", substitution_values)
 @pytest.mark.parametrize("substitution_locations", substitution_locations)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_aamp_nan_inf_self_join(T_A, T_B, substitute_B, substitution_locations):
     m = 3
     stop = 16
@@ -327,7 +327,7 @@ def test_gpu_aamp_nan_inf_self_join(T_A, T_B, substitute_B, substitution_locatio
 @pytest.mark.parametrize("substitute_A", substitution_values)
 @pytest.mark.parametrize("substitute_B", substitution_values)
 @pytest.mark.parametrize("substitution_locations", substitution_locations)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_aamp_nan_inf_A_B_join(
     T_A, T_B, substitute_A, substitute_B, substitution_locations
 ):
@@ -357,7 +357,7 @@ def test_gpu_aamp_nan_inf_A_B_join(
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_aamp_nan_zero_mean_self_join():
     T = np.array([-1, 0, 1, np.inf, 1, 0, -1])
     m = 3

--- a/tests/test_gpu_aamp_ostinato.py
+++ b/tests/test_gpu_aamp_ostinato.py
@@ -22,7 +22,7 @@ if not cuda.is_available():  # pragma: no cover
 @pytest.mark.parametrize(
     "seed", np.random.choice(np.arange(10000), size=2, replace=False)
 )
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_random_gpu_aamp_ostinato(seed):
     m = 50
     np.random.seed(seed)
@@ -38,7 +38,7 @@ def test_random_gpu_aamp_ostinato(seed):
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
 @pytest.mark.parametrize("seed", [41, 88])
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_deterministic_gpu_aamp_ostinato(seed):
     m = 50
     np.random.seed(seed)

--- a/tests/test_gpu_aamp_ostinato.py
+++ b/tests/test_gpu_aamp_ostinato.py
@@ -1,17 +1,18 @@
 import numpy as np
 import numpy.testing as npt
 from numba import cuda
+from unittest.mock import patch
 
 try:
     from numba.errors import NumbaPerformanceWarning
 except ModuleNotFoundError:
     from numba.core.errors import NumbaPerformanceWarning
-from stumpy import gpu_aamp_ostinato, config
+from stumpy import gpu_aamp_ostinato
 import naive
 import pytest
 
 
-config.THREADS_PER_BLOCK = 10
+TEST_THREADS_PER_BLOCK = 10
 
 if not cuda.is_available():  # pragma: no cover
     pytest.skip("Skipping Tests No GPUs Available", allow_module_level=True)
@@ -21,6 +22,7 @@ if not cuda.is_available():  # pragma: no cover
 @pytest.mark.parametrize(
     "seed", np.random.choice(np.arange(10000), size=2, replace=False)
 )
+@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_random_gpu_aamp_ostinato(seed):
     m = 50
     np.random.seed(seed)
@@ -36,6 +38,7 @@ def test_random_gpu_aamp_ostinato(seed):
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
 @pytest.mark.parametrize("seed", [41, 88])
+@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_deterministic_gpu_aamp_ostinato(seed):
     m = 50
     np.random.seed(seed)

--- a/tests/test_gpu_aamp_stimp.py
+++ b/tests/test_gpu_aamp_stimp.py
@@ -1,8 +1,8 @@
 import numpy as np
 import numpy.testing as npt
 from stumpy import gpu_aamp_stimp
-from stumpy import config
 from numba import cuda
+from unittest.mock import patch
 
 try:
     from numba.errors import NumbaPerformanceWarning
@@ -11,7 +11,7 @@ except ModuleNotFoundError:
 import pytest
 import naive
 
-config.THREADS_PER_BLOCK = 10
+TEST_THREADS_PER_BLOCK = 10
 
 if not cuda.is_available():  # pragma: no cover
     pytest.skip("Skipping Tests No GPUs Available", allow_module_level=True)
@@ -25,6 +25,7 @@ T = [
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
 @pytest.mark.parametrize("T", T)
+@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_aamp_stimp(T):
     threshold = 0.2
     min_m = 3

--- a/tests/test_gpu_aamp_stimp.py
+++ b/tests/test_gpu_aamp_stimp.py
@@ -25,7 +25,7 @@ T = [
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
 @pytest.mark.parametrize("T", T)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_aamp_stimp(T):
     threshold = 0.2
     min_m = 3

--- a/tests/test_gpu_aampdist.py
+++ b/tests/test_gpu_aampdist.py
@@ -1,7 +1,8 @@
 import numpy as np
 import numpy.testing as npt
-from stumpy import gpu_aampdist, config
+from stumpy import gpu_aampdist
 from numba import cuda
+from unittest.mock import patch
 
 try:
     from numba.errors import NumbaPerformanceWarning
@@ -10,7 +11,7 @@ except ModuleNotFoundError:
 import pytest
 import naive
 
-config.THREADS_PER_BLOCK = 10
+TEST_THREADS_PER_BLOCK = 10
 
 if not cuda.is_available():  # pragma: no cover
     pytest.skip("Skipping Tests No GPUs Available", allow_module_level=True)
@@ -30,6 +31,7 @@ test_data = [
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
 @pytest.mark.parametrize("T_A, T_B", test_data)
+@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_aampdist(T_A, T_B):
     m = 3
     for p in [1.0, 2.0, 3.0]:

--- a/tests/test_gpu_aampdist.py
+++ b/tests/test_gpu_aampdist.py
@@ -31,7 +31,7 @@ test_data = [
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
 @pytest.mark.parametrize("T_A, T_B", test_data)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_aampdist(T_A, T_B):
     m = 3
     for p in [1.0, 2.0, 3.0]:

--- a/tests/test_gpu_mpdist.py
+++ b/tests/test_gpu_mpdist.py
@@ -31,7 +31,7 @@ test_data = [
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
 @pytest.mark.parametrize("T_A, T_B", test_data)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_mpdist(T_A, T_B):
     m = 3
     ref_mpdist = naive.mpdist(T_A, T_B, m)

--- a/tests/test_gpu_mpdist.py
+++ b/tests/test_gpu_mpdist.py
@@ -1,7 +1,8 @@
 import numpy as np
 import numpy.testing as npt
-from stumpy import gpu_mpdist, config
+from stumpy import gpu_mpdist
 from numba import cuda
+from unittest.mock import patch
 
 try:
     from numba.errors import NumbaPerformanceWarning
@@ -10,7 +11,7 @@ except ModuleNotFoundError:
 import pytest
 import naive
 
-config.THREADS_PER_BLOCK = 10
+TEST_THREADS_PER_BLOCK = 10
 
 if not cuda.is_available():  # pragma: no cover
     pytest.skip("Skipping Tests No GPUs Available", allow_module_level=True)
@@ -30,6 +31,7 @@ test_data = [
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
 @pytest.mark.parametrize("T_A, T_B", test_data)
+@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_mpdist(T_A, T_B):
     m = 3
     ref_mpdist = naive.mpdist(T_A, T_B, m)

--- a/tests/test_gpu_ostinato.py
+++ b/tests/test_gpu_ostinato.py
@@ -6,12 +6,13 @@ try:
     from numba.errors import NumbaPerformanceWarning
 except ModuleNotFoundError:
     from numba.core.errors import NumbaPerformanceWarning
-from stumpy import gpu_ostinato, config
+from stumpy import gpu_ostinato
 import naive
 import pytest
+from unittest.mock import patch
 
 
-config.THREADS_PER_BLOCK = 10
+TEST_THREADS_PER_BLOCK = 10
 
 if not cuda.is_available():  # pragma: no cover
     pytest.skip("Skipping Tests No GPUs Available", allow_module_level=True)
@@ -21,6 +22,7 @@ if not cuda.is_available():  # pragma: no cover
 @pytest.mark.parametrize(
     "seed", np.random.choice(np.arange(10000), size=2, replace=False)
 )
+@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_random_gpu_ostinato(seed):
     m = 50
     np.random.seed(seed)
@@ -36,6 +38,7 @@ def test_random_gpu_ostinato(seed):
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
 @pytest.mark.parametrize("seed", [79, 109])
+@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_deterministic_gpu_ostinato(seed):
     m = 50
     np.random.seed(seed)

--- a/tests/test_gpu_ostinato.py
+++ b/tests/test_gpu_ostinato.py
@@ -22,7 +22,7 @@ if not cuda.is_available():  # pragma: no cover
 @pytest.mark.parametrize(
     "seed", np.random.choice(np.arange(10000), size=2, replace=False)
 )
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_random_gpu_ostinato(seed):
     m = 50
     np.random.seed(seed)
@@ -38,7 +38,7 @@ def test_random_gpu_ostinato(seed):
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
 @pytest.mark.parametrize("seed", [79, 109])
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_deterministic_gpu_ostinato(seed):
     m = 50
     np.random.seed(seed)

--- a/tests/test_gpu_stimp.py
+++ b/tests/test_gpu_stimp.py
@@ -25,7 +25,7 @@ T = [
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
 @pytest.mark.parametrize("T", T)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_stimp(T):
     threshold = 0.2
     min_m = 3

--- a/tests/test_gpu_stimp.py
+++ b/tests/test_gpu_stimp.py
@@ -1,8 +1,8 @@
 import numpy as np
 import numpy.testing as npt
 from stumpy import gpu_stimp
-from stumpy import config
 from numba import cuda
+from unittest.mock import patch
 
 try:
     from numba.errors import NumbaPerformanceWarning
@@ -11,7 +11,7 @@ except ModuleNotFoundError:
 import pytest
 import naive
 
-config.THREADS_PER_BLOCK = 10
+TEST_THREADS_PER_BLOCK = 10
 
 if not cuda.is_available():  # pragma: no cover
     pytest.skip("Skipping Tests No GPUs Available", allow_module_level=True)
@@ -25,6 +25,7 @@ T = [
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
 @pytest.mark.parametrize("T", T)
+@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_stimp(T):
     threshold = 0.2
     min_m = 3

--- a/tests/test_gpu_stump.py
+++ b/tests/test_gpu_stump.py
@@ -53,7 +53,6 @@ def test_gpu_stump_int_input():
 
 
 @cuda.jit("(f8[:, :], f8[:], i8[:], i8, b1, i8[:])")
-@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def _gpu_searchsorted_kernel(a, v, bfs, nlevel, is_left, idx):
     # A wrapper kernel for calling device function _gpu_searchsorted_left/right.
     i = cuda.grid(1)

--- a/tests/test_gpu_stump.py
+++ b/tests/test_gpu_stump.py
@@ -46,14 +46,14 @@ substitution_locations = [(slice(0, 0), 0, -1, slice(1, 3), [0, 3])]
 substitution_values = [np.nan, np.inf]
 
 
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_stump_int_input():
     with pytest.raises(TypeError):
         gpu_stump(np.arange(10), 5, ignore_trivial=True)
 
 
 @cuda.jit("(f8[:, :], f8[:], i8[:], i8, b1, i8[:])")
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def _gpu_searchsorted_kernel(a, v, bfs, nlevel, is_left, idx):
     # A wrapper kernel for calling device function _gpu_searchsorted_left/right.
     i = cuda.grid(1)
@@ -65,7 +65,7 @@ def _gpu_searchsorted_kernel(a, v, bfs, nlevel, is_left, idx):
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_searchsorted():
     n = 3 * config.STUMPY_THREADS_PER_BLOCK + 1
     V = np.empty(n, dtype=np.float64)
@@ -112,7 +112,7 @@ def test_gpu_searchsorted():
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
 @pytest.mark.parametrize("T_A, T_B", test_data)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_stump_self_join(T_A, T_B):
     m = 3
     zone = int(np.ceil(m / 4))
@@ -130,7 +130,7 @@ def test_gpu_stump_self_join(T_A, T_B):
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
 @pytest.mark.parametrize("T_A, T_B", test_data)
 @pytest.mark.parametrize("m", window_size)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_stump_self_join_larger_window(T_A, T_B, m):
     if len(T_B) > m:
         zone = int(np.ceil(m / 4))
@@ -152,7 +152,7 @@ def test_gpu_stump_self_join_larger_window(T_A, T_B, m):
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
 @pytest.mark.parametrize("T_A, T_B", test_data)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_stump_A_B_join(T_A, T_B):
     m = 3
     ref_mp = naive.stump(T_B, m, T_B=T_A, row_wise=True)
@@ -168,7 +168,7 @@ def test_gpu_stump_A_B_join(T_A, T_B):
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
 @pytest.mark.parametrize("T_A, T_B", test_data)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_parallel_gpu_stump_self_join(T_A, T_B):
     device_ids = [device.id for device in cuda.list_devices()]
     if len(T_B) > 10:
@@ -197,7 +197,7 @@ def test_parallel_gpu_stump_self_join(T_A, T_B):
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
 @pytest.mark.parametrize("T_A, T_B", test_data)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_parallel_gpu_stump_A_B_join(T_A, T_B):
     device_ids = [device.id for device in cuda.list_devices()]
     if len(T_B) > 10:
@@ -226,7 +226,7 @@ def test_parallel_gpu_stump_A_B_join(T_A, T_B):
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_stump_constant_subsequence_self_join():
     T_A = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64)))
     m = 3
@@ -243,7 +243,7 @@ def test_gpu_stump_constant_subsequence_self_join():
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_stump_one_constant_subsequence_A_B_join():
     T_A = np.random.rand(20)
     T_B = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64)))
@@ -271,7 +271,7 @@ def test_gpu_stump_one_constant_subsequence_A_B_join():
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_stump_two_constant_subsequences_A_B_join():
     T_A = np.array([0, 0, 0, 0, 0, 1], dtype=np.float64)
     T_B = np.concatenate((np.zeros(20, dtype=np.float64), np.ones(5, dtype=np.float64)))
@@ -299,7 +299,7 @@ def test_gpu_stump_two_constant_subsequences_A_B_join():
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_stump_identical_subsequence_self_join():
     identical = np.random.rand(8)
     T_A = np.random.rand(20)
@@ -323,7 +323,7 @@ def test_gpu_stump_identical_subsequence_self_join():
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_stump_identical_subsequence_A_B_join():
     identical = np.random.rand(8)
     T_A = np.random.rand(20)
@@ -365,7 +365,7 @@ def test_gpu_stump_identical_subsequence_A_B_join():
 @pytest.mark.parametrize("T_A, T_B", test_data)
 @pytest.mark.parametrize("substitute_B", substitution_values)
 @pytest.mark.parametrize("substitution_locations", substitution_locations)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_stump_nan_inf_self_join(T_A, T_B, substitute_B, substitution_locations):
     m = 3
     stop = 16
@@ -392,7 +392,7 @@ def test_gpu_stump_nan_inf_self_join(T_A, T_B, substitute_B, substitution_locati
 @pytest.mark.parametrize("substitute_A", substitution_values)
 @pytest.mark.parametrize("substitute_B", substitution_values)
 @pytest.mark.parametrize("substitution_locations", substitution_locations)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_stump_nan_inf_A_B_join(
     T_A, T_B, substitute_A, substitute_B, substitution_locations
 ):
@@ -422,7 +422,7 @@ def test_gpu_stump_nan_inf_A_B_join(
 
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_stump_nan_zero_mean_self_join():
     T = np.array([-1, 0, 1, np.inf, 1, 0, -1])
     m = 3
@@ -438,7 +438,7 @@ def test_gpu_stump_nan_zero_mean_self_join():
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
 @pytest.mark.parametrize("T_A, T_B", test_data)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_stump_self_join_KNN(T_A, T_B):
     m = 3
     zone = int(np.ceil(m / 4))
@@ -456,7 +456,7 @@ def test_gpu_stump_self_join_KNN(T_A, T_B):
 
 @pytest.mark.filterwarnings("ignore", category=NumbaPerformanceWarning)
 @pytest.mark.parametrize("T_A, T_B", test_data)
-@patch("stumpy.config.THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
+@patch("stumpy.config.STUMPY_THREADS_PER_BLOCK", TEST_THREADS_PER_BLOCK)
 def test_gpu_stump_A_B_join_KNN(T_A, T_B):
     m = 3
     for k in range(2, 4):


### PR DESCRIPTION
# Summary

Most instances where `config` variables are overwritten for testing have been replaced with the `unittest.mock.patch` module.

@seanlaw there are actually a few instances in some of the GPU tests where `config.THREADS_PER_BLOCK` is set globally, I didn't touch those files since the `config` variable was changed globally. Let me know if those should be replaced with `unittest.mock.patch` as well.

# Pull Request Checklist

- [x] Fork, clone, and checkout the newest version of the code
- [x] Create a new branch
- [x] Make necessary code changes
- [x] Install `black` (i.e., `python -m pip install black` or `conda install -c conda-forge black`)
- [x] Install `flake8` (i.e., `python -m pip install flake8` or `conda install -c conda-forge flake8`)
- [x] Install `pytest-cov` (i.e., `python -m pip install pytest-cov` or `conda install -c conda-forge pytest-cov`)
- [x] Run `black .` in the root stumpy directory
- [x] Run `flake8 .` in the root stumpy directory
- [ ] Run `./setup.sh && ./test.sh` in the root stumpy directory (I'll let the pipelines take care of this)
- [x] Reference a Github issue (and create one if one doesn't already exist)