### PR TITLE
Parallelize rolling std

### DIFF
--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -3104,8 +3104,8 @@ def _rolling_nanstd_2d(T, m):
         is the std value of T[i, j : j + m]
     """
     out = np.empty((T.shape[0], T.shape[1] - m + 1), dtype=np.float64)
-    for i in range(out.shape[0]):
-        for j in prange(out.shape[1]):
+    for i in range(T.shape[0]):
+        for j in prange(T.shape[1] - m + 1):
             out[i, j] = np.nanstd(T[i, j : j + m])
 
     return out
@@ -3116,7 +3116,7 @@ def rolling_nanstd(T, m):
     Compute the rolling standard deviation for 1D and 2D arrays while ignoring
     NaNs.
 
-    This a convenience wrapper around `_rolling_nanstd`.
+    This a convenience wrapper around `_rolling_nanstd_2d`.
 
     This essentially replaces:
 
@@ -3139,7 +3139,7 @@ def rolling_nanstd(T, m):
         raise ValueError("The input array `T` must be 1D or 2D.")
 
     out = _rolling_nanstd_2d(np.atleast_2d(T), m)
-    if T.ndim == 1:
-        return np.squeeze(out)
-    else:
+    if T.ndim == 2:
         return out
+    else:  # T.ndim is 1
+        return np.squeeze(out)

--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -659,13 +659,14 @@ def welford_nanstd(a, w=None):
     return np.sqrt(np.clip(welford_nanvar(a, w), a_min=0, a_max=None))
 
 
-def rolling_nanstd_fast(a, w):
+def rolling_nanstd_fast(a, w):  # pragma nocover
     """
     Compute the rolling standard deviation for 1-D and 2-D arrays while ignoring NaNs
     using a modified version of Welford's algorithm but is much faster than using
     `np.nanstd` with stride tricks.
 
-    This a convenience wrapper around `welford_nanstd`.
+    This a convenience wrapper around `welford_nanstd`. This is left for future
+    reference if needed.
 
     This essentially replaces:
 
@@ -3135,7 +3136,7 @@ def rolling_nanstd(T, m):
     output : numpy.ndarray
         Rolling window nanstd.
     """
-    if T.ndim > 2:
+    if T.ndim > 2:  # pragma nocover
         raise ValueError("The input array `T` must be 1D or 2D.")
 
     out = _rolling_nanstd_2d(np.atleast_2d(T), m)

--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -693,7 +693,7 @@ def rolling_nanstd(a, w, welford=False):
     NaNs.
 
     This essentially replaces:
-        `np.nanstd(rolling_window(a, w), axis=a.ndim)`
+        `np.nanstd(rolling_window(a[..., start:stop], w), axis=a.ndim)`
 
     Parameters
     ----------
@@ -731,7 +731,7 @@ def _rolling_nanmin_1d(a, w=None):
 
     This essentially replaces:
 
-        `np.nanmin(rolling_window(T[..., start:stop], m), axis=T.ndim)`
+        `np.nanmin(rolling_window(a[..., start:stop], w), axis=a.ndim)`
 
     Parameters
     ----------
@@ -761,7 +761,7 @@ def _rolling_nanmax_1d(a, w=None):
 
     This essentially replaces:
 
-        `np.nanmax(rolling_window(T[..., start:stop], m), axis=T.ndim)`
+        `np.nanmax(rolling_window(a[..., start:stop], w), axis=a.ndim)`
 
     Parameters
     ----------
@@ -793,7 +793,7 @@ def rolling_nanmin(a, w):
 
     This essentially replaces:
 
-        `np.nanmin(rolling_window(T[..., start:stop], m), axis=T.ndim)`
+        `np.nanmin(rolling_window(a[..., start:stop], w), axis=a.ndim)`
 
     Parameters
     ----------
@@ -822,7 +822,7 @@ def rolling_nanmax(a, w):
 
     This essentially replaces:
 
-        `np.nanmax(rolling_window(T[..., start:stop], m), axis=T.ndim)`
+        `np.nanmax(rolling_window(a[..., start:stop], w), axis=a.ndim)`
 
     Parameters
     ----------

--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -677,7 +677,7 @@ def _rolling_nanstd_1d(a, w):
     -------
     out : numpy.ndarray
         This 1D array has the length of `a.shape[0]-w+1`. `out[i]`
-        contains the std value of `a[i : i + w]`
+        contains the stddev value of `a[i : i + w]`
     """
     l = a.shape[0] - w + 1
     out = np.empty(l, dtype=np.float64)
@@ -689,11 +689,11 @@ def _rolling_nanstd_1d(a, w):
 
 def rolling_nanstd(a, w, welford=False):
     """
-    Compute the rolling standard deviation for 1D and 2D arrays while ignoring
+    Compute the rolling standard deviation over the last axis of `a` while ignoring
     NaNs.
 
     This essentially replaces:
-        `np.nanstd(rolling_window(T[..., start:stop], m), axis=T.ndim)`
+        `np.nanstd(rolling_window(a, w), axis=a.ndim)`
 
     Parameters
     ----------
@@ -714,9 +714,6 @@ def rolling_nanstd(a, w, welford=False):
     out : numpy.ndarray
         Rolling window nanstd
     """
-    if a.ndim > 2:  # pragma nocover
-        raise ValueError("The input array `a` must be 1D or 2D.")
-
     axis = a.ndim - 1  # Account for rolling
     if welford:  # pragma nocover
         return np.apply_along_axis(

--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -3083,10 +3083,10 @@ def check_ignore_trivial(T_A, T_B, ignore_trivial):
 
 
 @njit(parallel=True, fastmath={"nsz", "arcp", "contract", "afn", "reassoc"})
-def _rolling_nanstd(T, m):
+def _rolling_nanstd(T, m, out):
     """
     A Numba JIT-compiled and parallelized function for computing the std of
-    subsequences of length `m` in `T`, which is 1D or 2D numpy array.
+    subsequences of length `m` in `T`, which is 1D array.
 
     Parameters
     ----------
@@ -3096,23 +3096,15 @@ def _rolling_nanstd(T, m):
     m : int
         The rolling window size
 
+    out : numpy.ndarray
+        The variable to store the std values, with length len(T) - m + 1
+
     Returns
     -------
-    output : numpy.ndarray
-        Rolling window nanstd.
+    None
     """
-    l = T.shape[-1] - m + 1
-    if T.ndim == 1:
-        out = np.empty(l, dtype=np.float64)
-        for i in prange(l):
-            out[i] = np.nanstd(T[i : i + m])
-    else:  # T is 2D
-        out = np.empty((T.shape[0], l), dtype=np.float64)
-        for i, T_row in enumerate(T):
-            for j in prange(l):
-                out[i, j] = np.nanstd(T_row[j : j + m])
-
-    return out
+    for i in prange(len(out)):
+        out[i] = np.nanstd(T[i : i + m])
 
 
 def rolling_nanstd(T, m):
@@ -3142,4 +3134,14 @@ def rolling_nanstd(T, m):
     if T.ndim > 2:
         raise ValueError("The input array `T` must be 1D or 2D.")
 
-    return _rolling_nanstd(T, m)
+    T_2D = np.atleast_2d(T)
+    l = T_2D.shape[1] - m + 1
+
+    out = np.empty((T_2D.shape[0], l), dtype=np.float64)
+    for i, T_row in enumerate(T_2D):
+        _rolling_nanstd(T_row, m, out[i])
+
+    if T.ndim == 1:
+        return np.squeeze(out)
+    else:
+        return out

--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -662,13 +662,13 @@ def welford_nanstd(a, w=None):
 @njit(parallel=True, fastmath={"nsz", "arcp", "contract", "afn", "reassoc"})
 def _rolling_nanstd_1d(a, w):
     """
-    A Numba JIT-compiled and parallelized function for computing the std of
-    each subsequence with length `w` in `a`, which is a 1D array.
+    A Numba JIT-compiled and parallelized function for computing the rolling standard
+    deviation for 1-D array while ignoring NaN.
 
     Parameters
     ----------
     a : numpy.ndarray
-        The input 1D array
+        The input array
 
     w : int
         The rolling window size
@@ -690,10 +690,7 @@ def _rolling_nanstd_1d(a, w):
 def rolling_nanstd(a, w, welford=False):
     """
     Compute the rolling standard deviation for 1D and 2D arrays while ignoring
-    NaNs. When `welford==False` (default), the parallelization is used to compute
-    the std of each subsequence with length `w`. If `welford==True`, this function
-    uses a modified version of Welford's algorithm to speed up the computation at
-    the cost of losing precision.
+    NaNs.
 
     This essentially replaces:
         `np.nanstd(rolling_window(T[..., start:stop], m), axis=T.ndim)`
@@ -707,16 +704,15 @@ def rolling_nanstd(a, w, welford=False):
         The rolling window size
 
     welford : bool, default False
-        When False (default), the computation is parallelized and the std of
+        When False (default), the computation is parallelized and the stddev of
         each subsequence is calculated on its own. When `welford==True`, the
-        welford method is used to reduce the computing time at the cost of slight
-        loss of precision
+        welford method is used to reduce the computing time at the cost of slightly
+        reduced precision.
 
     Returns
     -------
     out : numpy.ndarray
-        Rolling window nanstd. When `a` is 1D, `out[i]` is the std of `a[i, i + w]`.
-        When `a` is 2D, `out[i, j]` is the std of `a[i, j : j + w]`.
+        Rolling window nanstd
     """
     if a.ndim > 2:  # pragma nocover
         raise ValueError("The input array `a` must be 1D or 2D.")

--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -722,7 +722,7 @@ def rolling_nanstd(a, w, welford=False):
         raise ValueError("The input array `a` must be 1D or 2D.")
 
     axis = a.ndim - 1  # Account for rolling
-    if welford:
+    if welford:  # pragma nocover
         return np.apply_along_axis(
             lambda a_row, w: welford_nanstd(a_row, w), axis=axis, arr=a, w=w
         )

--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -679,9 +679,9 @@ def _rolling_nanstd_1d(a, w):
         This 1D array has the length of `a.shape[0]-w+1`. `out[i]`
         contains the stddev value of `a[i : i + w]`
     """
-    l = a.shape[0] - w + 1
-    out = np.empty(l, dtype=np.float64)
-    for i in prange(l):
+    n = a.shape[0] - w + 1
+    out = np.empty(n, dtype=np.float64)
+    for i in prange(n):
         out[i] = np.nanstd(a[i : i + w])
 
     return out

--- a/tests/naive.py
+++ b/tests/naive.py
@@ -6,6 +6,11 @@ from scipy.stats import norm
 from stumpy import core, config
 
 
+def rolling_nanstd(a, w):
+    # a can be 1D, 2D, or more. The rolling occurs on last axis.
+    return np.nanstd(core.rolling_window(a, w), axis=a.ndim)
+
+
 def z_norm(a, axis=0, threshold=config.STUMPY_STDDEV_THRESHOLD):
     std = np.std(a, axis, keepdims=True)
     std[np.less(std, threshold, where=~np.isnan(std))] = 1.0

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -259,8 +259,8 @@ def test_rolling_std_1d():
 
 def test_rolling_std_2d():
     w = 5
-    for n_dim in range(1, 4):
-        a = np.random.rand(n_dim * 64).reshape(n_dim, 64)
+    for n_rows in range(1, 4):
+        a = np.random.rand(n_rows * 64).reshape(n_rows, 64)
         ref_std = naive.rolling_nanstd(a, w)
 
         # welford = False (default)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -243,6 +243,35 @@ def test_welford_nanstd():
     npt.assert_almost_equal(ref_var, comp_var)
 
 
+def test_rolling_std_1d():
+    a = np.random.rand(64)
+    for w in range(3, 6):
+        ref_std = naive.rolling_nanstd(a, w)
+
+        # welford = False (default)
+        comp_std = core.rolling_nanstd(a, w)
+        npt.assert_almost_equal(ref_std, comp_std)
+
+        # welford = True
+        comp_std = core.rolling_nanstd(a, w, welford=True)
+        npt.assert_almost_equal(ref_std, comp_std)
+
+
+def test_rolling_std_2d():
+    w = 5
+    for n_dim in range(1, 4):
+        a = np.random.rand(n_dim * 64).reshape(n_dim, 64)
+        ref_std = naive.rolling_nanstd(a, w)
+
+        # welford = False (default)
+        comp_std = core.rolling_nanstd(a, w)
+        npt.assert_almost_equal(ref_std, comp_std)
+
+        # welford = True
+        comp_std = core.rolling_nanstd(a, w, welford=True)
+        npt.assert_almost_equal(ref_std, comp_std)
+
+
 def test_rolling_nanmin_1d():
     T = np.random.rand(64)
     for m in range(1, 12):


### PR DESCRIPTION
Using parallelization to compute the rolling std. So, instead of using welford, we calculate the "std"  of each subsequence on its own. The time complexity of this approach is `O(n.m)`, where `n` is the length of the time series input `T` (if 1D), and `m` is the window size.