### PR TITLE
Add isconstant param to stumpi

### DIFF
--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -126,7 +126,6 @@ def non_normalized(non_norm, exclude=None, replace=None):
             "p",
             "T_A_subseq_isconstant",
             "T_B_subseq_isconstant",
-            "T_subseq_isconstant_func",
         ]
 
     @functools.wraps(non_norm)

--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -121,7 +121,13 @@ def non_normalized(non_norm, exclude=None, replace=None):
         The desired z-normalized/non-normalized function (or class)
     """
     if exclude is None:
-        exclude = ["normalize", "p", "T_A_subseq_isconstant", "T_B_subseq_isconstant"]
+        exclude = [
+            "normalize",
+            "p",
+            "T_A_subseq_isconstant",
+            "T_B_subseq_isconstant",
+            "T_subseq_isconstant_func",
+        ]
 
     @functools.wraps(non_norm)
     def outer_wrapper(norm):

--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -105,7 +105,8 @@ def non_normalized(non_norm, exclude=None, replace=None):
     exclude : list, default None
         A list of function (or class) parameter names to exclude when comparing the
         function (or class) signatures. When `exlcude is None`, this parameter is
-        automatically set to `exclude = ["normalize", "p"]` by default.
+        automatically set to `exclude = ["normalize", "p", "T_A_subseq_isconstant",
+        T_B_subseq_isconstant]` by default.
 
     replace : dict, default None
         A dictionary of function (or class) parameter key-value pairs. Each key that

--- a/stumpy/stumpi.py
+++ b/stumpy/stumpi.py
@@ -111,7 +111,6 @@ class stumpi:
     array([-1,  0,  1,  2])
     """
 
-
     def __init__(
         self,
         T,
@@ -120,7 +119,7 @@ class stumpi:
         normalize=True,
         p=2.0,
         k=1,
-        mp=None
+        mp=None,
         T_subseq_isconstant_func=None,
     ):
         """
@@ -195,7 +194,12 @@ class stumpi:
         )
 
         if mp is None:
-            mp = stump(self._T, self._m, k=self._k, T_A_subseq_isconstant=self._T_subseq_isconstant)
+            mp = stump(
+                self._T,
+                self._m,
+                k=self._k,
+                T_A_subseq_isconstant=self._T_subseq_isconstant,
+            )
         else:
             mp = mp.copy()
 
@@ -209,7 +213,6 @@ class stumpi:
             )
             raise ValueError(msg)
 
->>>>>>> main
         self._P = mp[:, : self._k].astype(np.float64)
         self._I = mp[:, self._k : 2 * self._k].astype(np.int64)
 

--- a/stumpy/stumpi.py
+++ b/stumpy/stumpi.py
@@ -8,7 +8,13 @@ from . import config, core, stump
 from .aampi import aampi
 
 
-@core.non_normalized(aampi)
+@core.non_normalized(
+    aampi,
+    exclude=[
+        "normalize",
+        "T_subseq_isconstant_func",
+    ],
+)
 class stumpi:
     """
     Compute an incremental z-normalized matrix profile for streaming data

--- a/tests/naive.py
+++ b/tests/naive.py
@@ -914,7 +914,7 @@ class stumpi_egress(object):
         self._m = m
         self._k = k
         if T_subseq_isconstant_func is None:
-            T_subseq_isconstant_func = is_ptp_zero_1d
+            T_subseq_isconstant_func = core._rolling_isconstant
         self._T_subseq_isconstant_func = T_subseq_isconstant_func
         self._T_subseq_isconstant = rolling_isconstant(
             self._T, self._m, self._T_subseq_isconstant_func
@@ -958,17 +958,17 @@ class stumpi_egress(object):
     def update(self, t):
         self._T[:] = np.roll(self._T, -1)
         self._T_isfinite[:] = np.roll(self._T_isfinite, -1)
-        self._T_subseq_isconstant[:] = np.roll(self._T_subseq_isconstant, -1)
         if np.isfinite(t):
             self._T_isfinite[-1] = True
             self._T[-1] = t
-            self._T_subseq_isconstant[-1] = rolling_isconstant(
-                self._T[-self._m :], self._m, self._T_subseq_isconstant_func
-            )
         else:
             self._T_isfinite[-1] = False
             self._T[-1] = 0
-            self._T_subseq_isconstant[-1] = False
+
+        self._T_subseq_isconstant[:] = np.roll(self._T_subseq_isconstant, -1)
+        self._T_subseq_isconstant[-1] = rolling_isconstant(
+            self._T[-self._m :], self._m, self._T_subseq_isconstant_func
+        ) & np.all(self._T_isfinite[-self._m :])
 
         self._n_appended += 1
 

--- a/tests/naive.py
+++ b/tests/naive.py
@@ -910,7 +910,9 @@ class aampi_egress(object):
 
 
 class stumpi_egress(object):
-    def __init__(self, T, m, excl_zone=None, k=1, mp=None, T_subseq_isconstant_func=None):
+    def __init__(
+        self, T, m, excl_zone=None, k=1, mp=None, T_subseq_isconstant_func=None
+    ):
         self._T = np.asarray(T)
         self._T = self._T.copy()
         self._T_isfinite = np.isfinite(self._T)
@@ -930,7 +932,13 @@ class stumpi_egress(object):
         self._l = self._T.shape[0] - m + 1
 
         if mp is None:
-            mp = stump(self._T, self._m, exclusion_zone=self._excl_zone, k=self._k, T_A_subseq_isconstant=self._T_subseq_isconstant)
+            mp = stump(
+                self._T,
+                self._m,
+                exclusion_zone=self._excl_zone,
+                k=self._k,
+                T_A_subseq_isconstant=self._T_subseq_isconstant,
+            )
         else:
             mp = mp.copy()
 

--- a/tests/naive.py
+++ b/tests/naive.py
@@ -907,19 +907,31 @@ class aampi_egress(object):
 
 
 class stumpi_egress(object):
-    def __init__(self, T, m, excl_zone=None, k=1):
+    def __init__(self, T, m, excl_zone=None, k=1, T_subseq_isconstant_func=None):
         self._T = np.asarray(T)
         self._T = self._T.copy()
         self._T_isfinite = np.isfinite(self._T)
         self._m = m
         self._k = k
+        if T_subseq_isconstant_func is None:
+            T_subseq_isconstant_func = is_ptp_zero_1d
+        self._T_subseq_isconstant_func = T_subseq_isconstant_func
+        self._T_subseq_isconstant = rolling_isconstant(
+            self._T, self._m, self._T_subseq_isconstant_func
+        )
 
         self._excl_zone = excl_zone
         if self._excl_zone is None:
             self._excl_zone = int(np.ceil(self._m / config.STUMPY_EXCL_ZONE_DENOM))
 
         self._l = self._T.shape[0] - m + 1
-        mp = stump(T, m, exclusion_zone=self._excl_zone, k=self._k)
+        mp = stump(
+            T_A=self._T,
+            m=self._m,
+            exclusion_zone=self._excl_zone,
+            k=self._k,
+            T_A_subseq_isconstant=self._T_subseq_isconstant,
+        )
         self._P = mp[:, :k].astype(np.float64)
         self._I = mp[:, k : 2 * k].astype(np.int64)
 
@@ -928,22 +940,36 @@ class stumpi_egress(object):
 
         for idx, nn_idx in enumerate(self._left_I):
             if nn_idx >= 0:
-                D = distance_profile(
-                    self._T[idx : idx + self._m], self._T[nn_idx : nn_idx + self._m], m
-                )
-                self._left_P[idx] = D[0]
+                if self._T_subseq_isconstant[idx] and self._T_subseq_isconstant[nn_idx]:
+                    self._left_P[idx] = 0
+                elif (
+                    self._T_subseq_isconstant[idx] or self._T_subseq_isconstant[nn_idx]
+                ):
+                    self._left_P[idx] = np.sqrt(self._m)
+                else:
+                    self._left_P[idx] = distance_profile(
+                        self._T[idx : idx + self._m],
+                        self._T[nn_idx : nn_idx + self._m],
+                        m,
+                    )[0]
 
         self._n_appended = 0
 
     def update(self, t):
         self._T[:] = np.roll(self._T, -1)
         self._T_isfinite[:] = np.roll(self._T_isfinite, -1)
+        self._T_subseq_isconstant[:] = np.roll(self._T_subseq_isconstant, -1)
         if np.isfinite(t):
             self._T_isfinite[-1] = True
             self._T[-1] = t
+            self._T_subseq_isconstant[-1] = rolling_isconstant(
+                self._T[-self._m :], self._m, self._T_subseq_isconstant_func
+            )
         else:
             self._T_isfinite[-1] = False
             self._T[-1] = 0
+            self._T_subseq_isconstant[-1] = False
+
         self._n_appended += 1
 
         self._P = np.roll(self._P, -1, axis=0)
@@ -951,7 +977,12 @@ class stumpi_egress(object):
         self._left_P[:] = np.roll(self._left_P, -1)
         self._left_I[:] = np.roll(self._left_I, -1)
 
-        D = core.mass(self._T[-self._m :], self._T)
+        D = core.mass(
+            self._T[-self._m :],
+            self._T,
+            T_subseq_isconstant=self._T_subseq_isconstant,
+            Q_subseq_isconstant=self._T_subseq_isconstant[[-1]],
+        )
         T_subseq_isfinite = np.all(
             core.rolling_window(self._T_isfinite, self._m), axis=1
         )

--- a/tests/test_stumpi.py
+++ b/tests/test_stumpi.py
@@ -1,5 +1,3 @@
-import functools
-
 import naive
 import numpy as np
 import numpy.testing as npt

--- a/tests/test_stumpi.py
+++ b/tests/test_stumpi.py
@@ -1125,24 +1125,3 @@ def test_stumpi_self_join_with_isconstant():
     npt.assert_almost_equal(ref_I, comp_I)
     npt.assert_almost_equal(ref_left_P, comp_left_P)
     npt.assert_almost_equal(ref_left_I, comp_left_I)
-
-    np.random.seed(seed)
-    T = np.random.rand(30)
-    T = pd.Series(T)
-    stream = stumpi(T, m, egress=False)
-    for i in range(34):
-        t = np.random.rand()
-        stream.update(t)
-
-    comp_P = stream.P_
-    comp_I = stream.I_
-    comp_left_P = stream.left_P_
-    comp_left_I = stream.left_I_
-
-    naive.replace_inf(comp_P)
-    naive.replace_inf(comp_left_P)
-
-    npt.assert_almost_equal(ref_P, comp_P)
-    npt.assert_almost_equal(ref_I, comp_I)
-    npt.assert_almost_equal(ref_left_P, comp_left_P)
-    npt.assert_almost_equal(ref_left_I, comp_left_I)

--- a/tests/test_stumpi.py
+++ b/tests/test_stumpi.py
@@ -1302,8 +1302,8 @@ def test_stumpi_self_join_egress_with_isconstant():
         naive.replace_inf(comp_P)
         naive.replace_inf(comp_left_P)
 
-        # We are allowed to compare the matrix profile indices
-        # as both the naive and the performant version follow
+        # Comparing the matrix profile indices is allowed as
+        # both the naive and the performant versions follow
         # the same approach in updating the matrix profile (indices)
         # arrays.
         npt.assert_almost_equal(ref_P, comp_P)

--- a/tests/test_stumpi.py
+++ b/tests/test_stumpi.py
@@ -1078,6 +1078,7 @@ def test_stumpi_self_join_with_isconstant():
     stddev_threshold = np.quantile(sliding_stddev, quantile_threshold)
     isconstant_custom_func = functools.partial(
         naive.isconstant_func_stddev_threshold,
+        quantile_threshold=quantile_threshold,
         stddev_threshold=stddev_threshold,
     )
 

--- a/tests/test_stumpi.py
+++ b/tests/test_stumpi.py
@@ -1,3 +1,5 @@
+import functools
+
 import naive
 import numpy as np
 import numpy.testing as npt
@@ -1061,3 +1063,86 @@ def test_stumpi_self_join_egress_KNN():
             npt.assert_almost_equal(ref_I, comp_I)
             npt.assert_almost_equal(ref_left_P, comp_left_P)
             npt.assert_almost_equal(ref_left_I, comp_left_I)
+
+
+def test_stumpi_self_join_with_isconstant():
+    m = 3
+    zone = int(np.ceil(m / 4))
+
+    seed = np.random.randint(100000)
+    np.random.seed(seed)
+
+    T = np.random.rand(30)
+    quantile_threshold = 0.25
+    sliding_stddev = naive.rolling_nanstd(T, m)
+    stddev_threshold = np.quantile(sliding_stddev, quantile_threshold)
+    isconstant_custom_func = functools.partial(
+        naive.isconstant_func_stddev_threshold,
+        stddev_threshold=stddev_threshold,
+    )
+
+    stream = stumpi(T, m, egress=False, T_subseq_isconstant_func=isconstant_custom_func)
+    for i in range(34):
+        t = np.random.rand()
+        stream.update(t)
+
+    comp_P = stream.P_
+    comp_I = stream.I_
+    comp_left_P = stream.left_P_
+    comp_left_I = stream.left_I_
+
+    T_subseq_isconstant = naive.rolling_isconstant(stream.T_, m, isconstant_custom_func)
+    ref_mp = naive.stump(
+        T_A=stream.T_,
+        m=m,
+        exclusion_zone=zone,
+        row_wise=True,
+        T_A_subseq_isconstant=T_subseq_isconstant,
+    )
+    ref_P = ref_mp[:, 0]
+    ref_I = ref_mp[:, 1]
+    ref_left_I = ref_mp[:, 2].astype(np.int64)
+    ref_left_P = np.full_like(ref_left_I, np.inf, dtype=np.float64)
+    for i, nn_i in enumerate(ref_left_I):  # nn_i is left nn of i
+        if nn_i < 0:
+            continue
+
+        if T_subseq_isconstant[i] and T_subseq_isconstant[nn_i]:
+            D = 0
+        elif T_subseq_isconstant[i] or T_subseq_isconstant[nn_i]:
+            D = np.sqrt(m)
+        else:
+            D = core.mass(stream.T_[i : i + m], stream.T_[nn_i : nn_i + m])[0]
+
+        ref_left_P[i] = D
+
+    naive.replace_inf(ref_P)
+    naive.replace_inf(ref_left_P)
+    naive.replace_inf(comp_P)
+    naive.replace_inf(comp_left_P)
+
+    npt.assert_almost_equal(ref_P, comp_P)
+    npt.assert_almost_equal(ref_I, comp_I)
+    npt.assert_almost_equal(ref_left_P, comp_left_P)
+    npt.assert_almost_equal(ref_left_I, comp_left_I)
+
+    np.random.seed(seed)
+    T = np.random.rand(30)
+    T = pd.Series(T)
+    stream = stumpi(T, m, egress=False)
+    for i in range(34):
+        t = np.random.rand()
+        stream.update(t)
+
+    comp_P = stream.P_
+    comp_I = stream.I_
+    comp_left_P = stream.left_P_
+    comp_left_I = stream.left_I_
+
+    naive.replace_inf(comp_P)
+    naive.replace_inf(comp_left_P)
+
+    npt.assert_almost_equal(ref_P, comp_P)
+    npt.assert_almost_equal(ref_I, comp_I)
+    npt.assert_almost_equal(ref_left_P, comp_left_P)
+    npt.assert_almost_equal(ref_left_I, comp_left_I)

--- a/tests/test_stumpi.py
+++ b/tests/test_stumpi.py
@@ -1,3 +1,5 @@
+import functools
+
 import naive
 import numpy as np
 import numpy.testing as npt
@@ -1079,6 +1081,191 @@ def test_stumpi_self_join_egress_passing_mp():
     ref_left_I = ref_mp.left_I_
 
     stream = stumpi(T, m, egress=True, mp=mp)
+
+    comp_P = stream.P_.copy()
+    comp_I = stream.I_
+    comp_left_P = stream.left_P_.copy()
+    comp_left_I = stream.left_I_
+
+    naive.replace_inf(ref_P)
+    naive.replace_inf(ref_left_P)
+    naive.replace_inf(comp_P)
+    naive.replace_inf(comp_left_P)
+
+    npt.assert_almost_equal(ref_P, comp_P)
+    npt.assert_almost_equal(ref_I, comp_I)
+    npt.assert_almost_equal(ref_left_P, comp_left_P)
+    npt.assert_almost_equal(ref_left_I, comp_left_I)
+
+    for i in range(34):
+        t = np.random.rand()
+        ref_mp.update(t)
+        stream.update(t)
+
+        comp_P = stream.P_.copy()
+        comp_I = stream.I_
+        comp_left_P = stream.left_P_.copy()
+        comp_left_I = stream.left_I_
+
+        ref_P = ref_mp.P_.copy()
+        ref_I = ref_mp.I_
+        ref_left_P = ref_mp.left_P_.copy()
+        ref_left_I = ref_mp.left_I_
+
+        naive.replace_inf(ref_P)
+        naive.replace_inf(ref_left_P)
+        naive.replace_inf(comp_P)
+        naive.replace_inf(comp_left_P)
+
+        npt.assert_almost_equal(ref_P, comp_P)
+        npt.assert_almost_equal(ref_I, comp_I)
+        npt.assert_almost_equal(ref_left_P, comp_left_P)
+        npt.assert_almost_equal(ref_left_I, comp_left_I)
+
+
+def test_stumpi_self_join_with_isconstant():
+    m = 3
+    zone = int(np.ceil(m / 4))
+
+    seed = np.random.randint(100000)
+    np.random.seed(seed)
+
+    T = np.random.rand(30)
+
+    quantile_threshold = 0.5
+    sliding_stddev = naive.rolling_nanstd(T, m)
+    stddev_threshold = np.quantile(sliding_stddev, quantile_threshold)
+    isconstant_custom_func = functools.partial(
+        naive.isconstant_func_stddev_threshold,
+        stddev_threshold=stddev_threshold,
+    )
+
+    stream = stumpi(T, m, egress=False, T_subseq_isconstant_func=isconstant_custom_func)
+    for i in range(34):
+        t = np.random.rand()
+        stream.update(t)
+
+    comp_P = stream.P_
+    comp_I = stream.I_
+    comp_left_P = stream.left_P_
+    comp_left_I = stream.left_I_
+
+    ref_mp = naive.stump(
+        stream.T_,
+        m,
+        exclusion_zone=zone,
+        row_wise=True,
+        T_A_subseq_isconstant=isconstant_custom_func,
+    )
+    ref_P = ref_mp[:, 0]
+    ref_I = ref_mp[:, 1]
+    ref_left_I = ref_mp[:, 2].astype(np.int64)
+    ref_left_P = np.full(len(ref_P), np.inf, dtype=np.float64)
+    for i, j in enumerate(ref_left_I):
+        if j >= 0:
+            D = core.mass(
+                stream.T_[i : i + m],
+                stream.T_[j : j + m],
+                T_subseq_isconstant=isconstant_custom_func,
+                Q_subseq_isconstant=isconstant_custom_func,
+            )
+            ref_left_P[i] = D[0]
+
+    naive.replace_inf(ref_P)
+    naive.replace_inf(ref_left_P)
+    naive.replace_inf(comp_P)
+    naive.replace_inf(comp_left_P)
+
+    # comparing matrix profile indices are avoided as, in this case,
+    # the performant version computes matrix profile in a diagonal
+    # manner, which is different than how the naive version computes
+    # the full data (i.e. original `T` including egressed points).
+    # which is in a `row_wise==True` manner
+
+    npt.assert_almost_equal(ref_P, comp_P)
+    # npt.assert_almost_equal(ref_I, comp_I)
+    npt.assert_almost_equal(ref_left_P, comp_left_P)
+    # npt.assert_almost_equal(ref_left_I, comp_left_I)
+
+    # with passing `mp`
+    T = np.random.rand(30)
+
+    quantile_threshold = 0.5
+    sliding_stddev = naive.rolling_nanstd(T, m)
+    stddev_threshold = np.quantile(sliding_stddev, quantile_threshold)
+    isconstant_custom_func = functools.partial(
+        naive.isconstant_func_stddev_threshold,
+        stddev_threshold=stddev_threshold,
+    )
+
+    mp = naive.stump(T, m, row_wise=True, T_A_subseq_isconstant=isconstant_custom_func)
+    stream = stumpi(
+        T, m, egress=False, mp=mp, T_subseq_isconstant_func=isconstant_custom_func
+    )
+    for i in range(34):
+        t = np.random.rand()
+        stream.update(t)
+
+    comp_P = stream.P_
+    comp_I = stream.I_
+    comp_left_P = stream.left_P_
+    comp_left_I = stream.left_I_
+
+    ref_mp = naive.stump(
+        stream.T_,
+        m,
+        exclusion_zone=zone,
+        row_wise=True,
+        T_A_subseq_isconstant=isconstant_custom_func,
+    )
+    ref_P = ref_mp[:, 0]
+    ref_I = ref_mp[:, 1]
+    ref_left_I = ref_mp[:, 2].astype(np.int64)
+    ref_left_P = np.full(len(ref_P), np.inf, dtype=np.float64)
+    for i, j in enumerate(ref_left_I):
+        if j >= 0:
+            D = core.mass(
+                stream.T_[i : i + m],
+                stream.T_[j : j + m],
+                T_subseq_isconstant=isconstant_custom_func,
+                Q_subseq_isconstant=isconstant_custom_func,
+            )
+            ref_left_P[i] = D[0]
+
+    naive.replace_inf(ref_P)
+    naive.replace_inf(ref_left_P)
+    naive.replace_inf(comp_P)
+    naive.replace_inf(comp_left_P)
+
+    npt.assert_almost_equal(ref_P, comp_P)
+    npt.assert_almost_equal(ref_I, comp_I)
+    npt.assert_almost_equal(ref_left_P, comp_left_P)
+    npt.assert_almost_equal(ref_left_I, comp_left_I)
+
+
+def test_stumpi_self_join_egress_with_isconstant():
+    m = 3
+
+    seed = np.random.randint(100000)
+    np.random.seed(seed)
+    n = 30
+    T = np.random.rand(n)
+
+    quantile_threshold = 0.5
+    sliding_stddev = naive.rolling_nanstd(T, m)
+    stddev_threshold = np.quantile(sliding_stddev, quantile_threshold)
+    isconstant_custom_func = functools.partial(
+        naive.isconstant_func_stddev_threshold,
+        stddev_threshold=stddev_threshold,
+    )
+
+    ref_mp = naive.stumpi_egress(T, m, T_subseq_isconstant_func=isconstant_custom_func)
+    ref_P = ref_mp.P_.copy()
+    ref_I = ref_mp.I_
+    ref_left_P = ref_mp.left_P_.copy()
+    ref_left_I = ref_mp.left_I_
+
+    stream = stumpi(T, m, egress=True, T_subseq_isconstant_func=isconstant_custom_func)
 
     comp_P = stream.P_.copy()
     comp_I = stream.I_

--- a/tests/test_stumpi.py
+++ b/tests/test_stumpi.py
@@ -1302,6 +1302,10 @@ def test_stumpi_self_join_egress_with_isconstant():
         naive.replace_inf(comp_P)
         naive.replace_inf(comp_left_P)
 
+        # We are allowed to compare the matrix profile indices
+        # as both the naive and the performant version follow
+        # the same approach in updating the matrix profile (indices)
+        # arrays.
         npt.assert_almost_equal(ref_P, comp_P)
         npt.assert_almost_equal(ref_I, comp_I)
         npt.assert_almost_equal(ref_left_P, comp_left_P)


### PR DESCRIPTION
To resolve the issue in this PR, I think we should first address #814 (I can do it in this PR if that is okay).  Or, we can just avoid comparing matrix profile indices obtained, in uni testing, via naive and performant version.