### PR TITLE
Add test function for `_mpdist_vect`

### DIFF
--- a/tests/naive.py
+++ b/tests/naive.py
@@ -1308,7 +1308,15 @@ def aamp_ostinato(Ts, m, p=2.0):
     return radius, Ts_idx, subseq_idx
 
 
-def mpdist_vect(T_A, T_B, m, percentage=0.05, k=None):
+def mpdist_vect(
+    T_A,
+    T_B,
+    m,
+    percentage=0.05,
+    k=None,
+    T_A_subseq_isconstant=None,
+    T_B_subseq_isconstant=None,
+):
     n_A = T_A.shape[0]
     n_B = T_B.shape[0]
     j = n_A - m + 1  # `k` is reserved for `P_ABBA` selection
@@ -1322,9 +1330,23 @@ def mpdist_vect(T_A, T_B, m, percentage=0.05, k=None):
 
     k = min(int(k), P_ABBA.shape[0] - 1)
 
+    T_A_subseq_isconstant = rolling_isconstant(T_A, m, T_A_subseq_isconstant)
+    T_B_subseq_isconstant = rolling_isconstant(T_B, m, T_B_subseq_isconstant)
     for i in range(n_B - n_A + 1):
-        P_ABBA[:j] = stump(T_A, m, T_B[i : i + n_A])[:, 0]
-        P_ABBA[j:] = stump(T_B[i : i + n_A], m, T_A)[:, 0]
+        P_ABBA[:j] = stump(
+            T_A,
+            m,
+            T_B[i : i + n_A],
+            T_A_subseq_isconstant=T_A_subseq_isconstant,
+            T_B_subseq_isconstant=T_B_subseq_isconstant[i : i + n_A - m + 1],
+        )[:, 0]
+        P_ABBA[j:] = stump(
+            T_B[i : i + n_A],
+            m,
+            T_A,
+            T_A_subseq_isconstant=T_B_subseq_isconstant[i : i + n_A - m + 1],
+            T_B_subseq_isconstant=T_A_subseq_isconstant,
+        )[:, 0]
         P_ABBA.sort()
         MPdist_vect[i] = P_ABBA[min(k, P_ABBA.shape[0] - 1)]
 


### PR DESCRIPTION
I think we should add test function (in `tests/test_mpdist.py`) to test param "isconstant" of function `stumpy/mpdist._mpdist_vect`. To do so, we need to revise the naive function `mpdist_vect` so that it can accept param "isconstant". This can help us to add the param `isconstant` in the snippet module more easily.