### PR TITLE
Fix loss of precision for self match in `core.mass`

### DIFF
--- a/stumpy/motifs.py
+++ b/stumpy/motifs.py
@@ -121,7 +121,7 @@ def _motifs(
             T,
             M_T=M_T,
             Σ_T=Σ_T,
-            max_matches=None,
+            max_matches=max_matches,
             max_distance=max_distance,
             atol=atol,
             query_idx=candidate_idx,

--- a/tests/test_motifs.py
+++ b/tests/test_motifs.py
@@ -170,6 +170,73 @@ def test_motifs_max_matches():
     npt.assert_almost_equal(left_profile_values, right_distance_values, decimal=4)
 
 
+def test_motifs_max_matches_max_distances_inf():
+    # This test covers the following:
+
+    # A time series contains motif A at four locations and motif B at two.
+    # If `max_moitf=3` and `max_matches=2`, and `max_distance=inf`, the
+    # result should contain three motifs, each containing top-two matches.
+    # Hence, two out of the three motifs are from A, and the other is from
+    # B.
+    T = np.array(
+        [
+            0.0,  # motif A
+            1.0,
+            0.0,
+            2.3,
+            -1.0,  # motif B
+            -1.0,
+            -2.0,
+            0.0,  # motif A
+            1.0,
+            0.0,
+            -2.0,
+            -1.0,  # motif B
+            -1.03,
+            -2.0,
+            -0.5,
+            0.0,  # motif A
+            1.0,
+            0.0,
+            2.3,
+            0.0,  # motif A
+            1.0,
+            0.0,
+        ]
+    )
+    m = 3
+    max_motifs = 3
+    max_matches = 2
+    max_distance = np.inf
+
+    left_indices = [[0, 7], [15, 19], [4, 11]]
+    left_profile_values = [
+        [0.0, 0.0],
+        [0.0, 0.0],
+        [
+            0.0,
+            naive.distance(
+                core.z_norm(T[left_indices[1][0] : left_indices[1][0] + m]),
+                core.z_norm(T[left_indices[1][1] : left_indices[1][1] + m]),
+            ),
+        ],
+    ]
+
+    # set `row_wise` to True so that we can compare the indices of motifs as well
+    mp = naive.stump(T, m, row_wise=True)
+    right_distance_values, right_indices = motifs(
+        T,
+        mp[:, 0],
+        max_motifs=max_motifs,
+        max_distance=max_distance,
+        cutoff=np.inf,
+        max_matches=max_matches,
+    )
+
+    npt.assert_almost_equal(left_profile_values, right_distance_values, decimal=4)
+    npt.assert_almost_equal(left_profile_values, right_distance_values, decimal=4)
+
+
 def test_naive_match_exclusion_zone():
     # The query appears as a perfect match at location 1 and as very close matches
     # (z-normalized distance of 0.05) at location 0, 5 and 9.

--- a/tests/test_motifs.py
+++ b/tests/test_motifs.py
@@ -112,8 +112,8 @@ def test_motifs_max_matches():
     # This test covers the following:
 
     # A time series contains motif A at four locations and motif B at two.
-    # If `max_motifs=2` the result should contain only the top two matches of motif A
-    # and the top two matches of motif B as two separate motifs.
+    # If `max_moitf=2` and `max_matches=2`, the result should contain two
+    # sets of motifs. Each motif set contains top two matches
     T = np.array(
         [
             0.0,  # motif A
@@ -141,7 +141,7 @@ def test_motifs_max_matches():
         ]
     )
     m = 3
-    max_motifs = 3
+    max_motifs = 2
 
     left_indices = [[0, 7], [4, 11]]
     left_profile_values = [

--- a/tests/test_motifs.py
+++ b/tests/test_motifs.py
@@ -137,7 +137,7 @@ def test_motifs_max_matches():
             2.3,
             2.0,  # motif A
             3.0,
-            2.02,
+            3.0,
         ]
     )
     m = 3

--- a/tests/test_motifs.py
+++ b/tests/test_motifs.py
@@ -173,9 +173,9 @@ def test_motifs_max_matches():
 def test_motifs_max_matches_max_distances_inf():
     # This test covers the following:
 
-    # A time series contains motif A at four locations and motif B at two.
-    # If `max_moitf=3` and `max_matches=2`, and `max_distance=inf`, the
-    # result should contain three motifs, each containing top-two matches.
+    # A time series contains motif A at two locations and motif B at two.
+    # If `max_moitf=2` and `max_matches=2`, and `max_distance=inf`, the
+    # result should contain two motifs, each containing top-two matches.
     # Hence, two out of the three motifs are from A, and the other is from
     # B.
     T = np.array(
@@ -195,23 +195,22 @@ def test_motifs_max_matches_max_distances_inf():
             -1.03,
             -2.0,
             -0.5,
-            0.0,  # motif A
-            1.0,
-            0.0,
+            2.0,
+            3.0,
+            2.04,
             2.3,
-            0.0,  # motif A
-            1.0,
-            0.0,
+            2.0,
+            3.0,
+            3.0,
         ]
     )
     m = 3
-    max_motifs = 3
+    max_motifs = 2
     max_matches = 2
     max_distance = np.inf
 
-    left_indices = [[0, 7], [15, 19], [4, 11]]
+    left_indices = [[0, 7], [4, 11]]
     left_profile_values = [
-        [0.0, 0.0],
         [0.0, 0.0],
         [
             0.0,
@@ -233,8 +232,8 @@ def test_motifs_max_matches_max_distances_inf():
         max_matches=max_matches,
     )
 
-    npt.assert_almost_equal(left_profile_values, right_distance_values, decimal=4)
     npt.assert_almost_equal(left_indices, right_indices)
+    npt.assert_almost_equal(left_profile_values, right_distance_values, decimal=4)
 
 
 def test_naive_match_exclusion_zone():

--- a/tests/test_motifs.py
+++ b/tests/test_motifs.py
@@ -234,7 +234,7 @@ def test_motifs_max_matches_max_distances_inf():
     )
 
     npt.assert_almost_equal(left_profile_values, right_distance_values, decimal=4)
-    npt.assert_almost_equal(left_profile_values, right_distance_values, decimal=4)
+    npt.assert_almost_equal(left_indices, right_indices)
 
 
 def test_naive_match_exclusion_zone():

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -3,7 +3,7 @@ import numpy as np
 import numpy.testing as npt
 
 import stumpy
-from stumpy import config
+from stumpy import config, core
 
 
 def test_mpdist_snippets_s():
@@ -38,3 +38,20 @@ def test_mpdist_snippets_s():
     npt.assert_almost_equal(
         ref_fractions, cmp_fractions, decimal=config.STUMPY_TEST_PRECISION
     )
+
+
+def test_distace_profile():
+    # This test function raises an error when the distance profile between
+    # the query `Q = T[i: i+m]`  and `T` becomes non-zero at index `i`.
+    T = np.random.rand(64)
+    m = 3
+    T, M_T, Σ_T, T_subseq_isconstant = core.preprocess(T, m)
+
+    for i in range(len(T) - m + 1):
+        Q = T[i : i + m]
+        D_ref = naive.distance_profile(Q, T, m)
+        D_comp = core.mass(
+            Q, T, M_T=M_T, Σ_T=Σ_T, T_subseq_isconstant=T_subseq_isconstant
+        )
+
+        npt.assert_almost_equal(D_ref, D_comp)


### PR DESCRIPTION
According to [this error](https://github.com/TDAmeritrade/stumpy/actions/runs/4902125133/jobs/8753783558?pr=856), we can realize that there is a loss of precision in self match in `core.mass`. A test function is added to expose this error.


