### PR TITLE
Fix loss of precision for distance between a subseq and itself

### DIFF
--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -1265,7 +1265,7 @@ def mass_absolute(Q, T, T_subseq_isfinite=None, p=2.0, query_idx=None):
     if np.any(~np.isfinite(Q)):
         distance_profile[:] = np.inf
     else:
-        if query_idx is not None:
+        if query_idx is not None:  # pragma: no cover
             query_idx = int(query_idx)
             if not np.allclose(Q, T[query_idx : query_idx + m]):
                 msg = (
@@ -1606,7 +1606,7 @@ def mass(
     else:
         if query_idx is not None:
             query_idx = int(query_idx)
-            if not np.allclose(Q, T[query_idx : query_idx + m]):
+            if not np.allclose(Q, T[query_idx : query_idx + m]):  # pragma: no cover
                 msg = (
                     "Subsequences `Q` and `T[query_idx:query_idx+m]` are "
                     + "different but were expected to be identical. Please "

--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -1245,7 +1245,7 @@ def mass_absolute(Q, T, T_subseq_isfinite=None, p=2.0, query_idx=None):
         raise ValueError(f"`Q` is {Q.ndim}-dimensional and must be 1-dimensional. ")
 
     check_window_size(m, max_size=Q.shape[-1])
-    if query_idx is not None:
+    if query_idx is not None:  # pragma: no cover
         query_idx = int(query_idx)
         QT_query_idx_allclose = np.allclose(Q, T[query_idx : query_idx + m])
 

--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -1268,7 +1268,7 @@ def mass_absolute(Q, T, T_subseq_isfinite=None, p=2.0, query_idx=None):
         if T_subseq_isfinite is None:
             T, T_subseq_isfinite = preprocess_non_normalized(T, m)
         distance_profile[:] = _mass_absolute(Q, T, p)
-        if query_idx is not None:
+        if query_idx is not None:  # pragma: no cover
             query_idx = int(query_idx)
             distance_profile[query_idx] = 0.0
 

--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -1265,11 +1265,20 @@ def mass_absolute(Q, T, T_subseq_isfinite=None, p=2.0, query_idx=None):
     if np.any(~np.isfinite(Q)):
         distance_profile[:] = np.inf
     else:
+        if query_idx is not None:
+            query_idx = int(query_idx)
+            if not np.allclose(Q, T[query_idx : query_idx + m]):
+                msg = (
+                    "Subsequences `Q` and `T[query_idx:query_idx+m]` are "
+                    + "different but were expected to be identical. Please "
+                    + "verify that `query_idx` is correct."
+                )
+                warnings.warn(msg)
+
         if T_subseq_isfinite is None:
             T, T_subseq_isfinite = preprocess_non_normalized(T, m)
         distance_profile[:] = _mass_absolute(Q, T, p)
         if query_idx is not None:  # pragma: no cover
-            query_idx = int(query_idx)
             distance_profile[query_idx] = 0.0
 
         distance_profile[~T_subseq_isfinite] = np.inf
@@ -1595,6 +1604,16 @@ def mass(
     if np.any(~np.isfinite(Q)):
         distance_profile[:] = np.inf
     else:
+        if query_idx is not None:
+            query_idx = int(query_idx)
+            if not np.allclose(Q, T[query_idx : query_idx + m]):
+                msg = (
+                    "Subsequences `Q` and `T[query_idx:query_idx+m]` are "
+                    + "different but were expected to be identical. Please "
+                    + "verify that `query_idx` is correct."
+                )
+                warnings.warn(msg)
+
         T, M_T, Σ_T, T_subseq_isconstant = preprocess(
             T,
             m,
@@ -1625,9 +1644,7 @@ def mass(
         )
 
         if query_idx is not None:
-            query_idx = int(query_idx)
-            if np.isfinite(M_T[query_idx]) and np.isfinite(μ_Q[0]):
-                distance_profile[query_idx] = 0
+            distance_profile[query_idx] = 0
 
     return distance_profile
 

--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -1221,8 +1221,8 @@ def mass_absolute(Q, T, T_subseq_isfinite=None, p=2.0, query_idx=None):
         This is the index position along the time series, `T`, where the query
         subsequence, `Q`, is located. `query_idx` should be set to None if `Q`
         is not a subsequence of `T`. If `Q` is a subsequence of `T`, provding
-        this argument is optional. If provided, the precision of computation
-        can be slightly improved.
+        this argument is optional. If query_idx is provided, the distance between
+        Q and T[query_idx : query_idx + m] will automatically be set to zero.
 
     Returns
     -------
@@ -1542,8 +1542,9 @@ def mass(
         This is the index position along the time series, `T`, where the query
         subsequence, `Q`, is located. `query_idx` should be set to None if `Q`
         is not a subsequence of `T`. If `Q` is a subsequence of `T`, provding
-        this argument is optional. If provided, the precision of computation
-        can be slightly improved.
+        this argument is optional. If query_idx is provided, the distance
+        between Q and `T[query_idx : query_idx + m]` will automatically be set to
+        zero.
 
     Returns
     -------

--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -1196,7 +1196,7 @@ def _mass_absolute(Q, T, p=2.0):
     ).flatten()
 
 
-def mass_absolute(Q, T, T_subseq_isfinite=None, p=2.0):
+def mass_absolute(Q, T, T_subseq_isfinite=None, p=2.0, query_idx=None):
     """
     Compute the non-normalized distance profile (i.e., without z-normalization) using
     the "MASS absolute" algorithm. This is a convenience wrapper around the Numba JIT
@@ -1216,6 +1216,13 @@ def mass_absolute(Q, T, T_subseq_isfinite=None, p=2.0):
 
     p : float, default 2.0
         The p-norm to apply for computing the Minkowski distance.
+
+    query_idx : int, default None
+        This is the index position along the time series, `T`, where the query
+        subsequence, `Q`, is located. `query_idx` should be set to None if `Q`
+        is not a subsequence of `T`. If `Q` is a subsequence of `T`, provding
+        this argument is optional. If provided, the precision of computation
+        can be slightly improved.
 
     Returns
     -------
@@ -1261,6 +1268,10 @@ def mass_absolute(Q, T, T_subseq_isfinite=None, p=2.0):
         if T_subseq_isfinite is None:
             T, T_subseq_isfinite = preprocess_non_normalized(T, m)
         distance_profile[:] = _mass_absolute(Q, T, p)
+        if query_idx is not None:
+            query_idx = int(query_idx)
+            distance_profile[query_idx] = 0.0
+
         distance_profile[~T_subseq_isfinite] = np.inf
 
     return distance_profile

--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -1246,6 +1246,7 @@ def mass_absolute(Q, T, T_subseq_isfinite=None, p=2.0, query_idx=None):
     Q_isfinite = np.isfinite(Q)
 
     check_window_size(m, max_size=Q.shape[-1])
+
     if query_idx is not None:  # pragma: no cover
         query_idx = int(query_idx)
         T_isfinite_idx = np.isfinite(T[query_idx : query_idx + m])
@@ -1589,10 +1590,10 @@ def mass(
     Q_isfinite = np.isfinite(Q)
 
     check_window_size(m, max_size=Q.shape[-1])
+
     if query_idx is not None:
         query_idx = int(query_idx)
         T_isfinite_idx = np.isfinite(T[query_idx : query_idx + m])
-
         if not np.all(Q_isfinite == T_isfinite_idx) or not np.allclose(
             Q[Q_isfinite], T[query_idx : query_idx + m][T_isfinite_idx]
         ):  # pragma: no cover

--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -1243,11 +1243,21 @@ def mass_absolute(Q, T, T_subseq_isfinite=None, p=2.0, query_idx=None):
 
     if Q.ndim != 1:  # pragma: no cover
         raise ValueError(f"`Q` is {Q.ndim}-dimensional and must be 1-dimensional. ")
+    Q_isfinite = np.isfinite(Q)
 
     check_window_size(m, max_size=Q.shape[-1])
     if query_idx is not None:  # pragma: no cover
         query_idx = int(query_idx)
-        QT_query_idx_allclose = np.allclose(Q, T[query_idx : query_idx + m])
+        T_isfinite_idx = np.isfinite(T[query_idx : query_idx + m])
+        if not np.all(Q_isfinite == T_isfinite_idx) or not np.allclose(
+            Q[Q_isfinite], T[query_idx : query_idx + m][T_isfinite_idx]
+        ):
+            msg = (
+                "Subsequences `Q` and `T[query_idx:query_idx+m]` are "
+                + "different but were expected to be identical. Please "
+                + "verify that `query_idx` is correct."
+            )
+            warnings.warn(msg)
 
     T = _preprocess(T)
     n = T.shape[0]
@@ -1265,20 +1275,13 @@ def mass_absolute(Q, T, T_subseq_isfinite=None, p=2.0, query_idx=None):
         )
 
     distance_profile = np.empty(n - m + 1, dtype=np.float64)
-    if np.any(~np.isfinite(Q)):
+    if np.any(~Q_isfinite):
         distance_profile[:] = np.inf
     else:
         if T_subseq_isfinite is None:
             T, T_subseq_isfinite = preprocess_non_normalized(T, m)
         distance_profile[:] = _mass_absolute(Q, T, p)
         if query_idx is not None:  # pragma: no cover
-            if not QT_query_idx_allclose:
-                msg = (
-                    "Subsequences `Q` and `T[query_idx:query_idx+m]` are "
-                    + "different but were expected to be identical. Please "
-                    + "verify that `query_idx` is correct."
-                )
-                warnings.warn(msg)
             distance_profile[query_idx] = 0.0
 
         distance_profile[~T_subseq_isfinite] = np.inf
@@ -1582,11 +1585,22 @@ def mass(
 
     if Q.ndim != 1:  # pragma: no cover
         raise ValueError(f"Q is {Q.ndim}-dimensional and must be 1-dimensional. ")
+    Q_isfinite = np.isfinite(Q)
 
     check_window_size(m, max_size=Q.shape[-1])
     if query_idx is not None:
         query_idx = int(query_idx)
-        QT_query_idx_allclose = np.allclose(Q, T[query_idx : query_idx + m])
+        T_isfinite_idx = np.isfinite(T[query_idx : query_idx + m])
+
+        if not np.all(Q_isfinite == T_isfinite_idx) or not np.allclose(
+            Q[Q_isfinite], T[query_idx : query_idx + m][T_isfinite_idx]
+        ):  # pragma: no cover
+            msg = (
+                "Subsequences `Q` and `T[query_idx:query_idx+m]` are "
+                + "different but were expected to be identical. Please "
+                + "verify that `query_idx` is correct."
+            )
+            warnings.warn(msg)
 
     T = _preprocess(T)
     n = T.shape[0]
@@ -1604,7 +1618,7 @@ def mass(
         )
 
     distance_profile = np.empty(n - m + 1, dtype=np.float64)
-    if np.any(~np.isfinite(Q)):
+    if np.any(~Q_isfinite):
         distance_profile[:] = np.inf
     else:
         T, M_T, Σ_T, T_subseq_isconstant = preprocess(
@@ -1637,13 +1651,6 @@ def mass(
         )
 
         if query_idx is not None:
-            if not QT_query_idx_allclose:  # pragma: no cover
-                msg = (
-                    "Subsequences `Q` and `T[query_idx:query_idx+m]` are "
-                    + "different but were expected to be identical. Please "
-                    + "verify that `query_idx` is correct."
-                )
-                warnings.warn(msg)
             distance_profile[query_idx] = 0
 
     return distance_profile

--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -1460,6 +1460,7 @@ def mass(
     T_subseq_isfinite=None,
     T_subseq_isconstant=None,
     Q_subseq_isconstant=None,
+    query_idx=None,
 ):
     """
     Compute the distance profile using the MASS algorithm
@@ -1513,6 +1514,13 @@ def mass(
         by currying the user-defined function using `functools.partial`. Any
         subsequence with at least one np.nan/np.inf will automatically have its
         corresponding value set to False in this boolean array.
+
+    query_idx : int, default None
+        This is the index position along the time series, `T`, where the query
+        subsequence, `Q`, is located. `query_idx` should be set to None if `Q`
+        is not a subsequence of `T`. If `Q` is a subsequence of `T`, provding
+        this argument is optional. If provided, the precision of computation
+        can be slightly improved.
 
     Returns
     -------
@@ -1604,6 +1612,11 @@ def mass(
             Q_subseq_isconstant[0],
             T_subseq_isconstant,
         )
+
+        if query_idx is not None:
+            query_idx = int(query_idx)
+            if np.isfinite(M_T[query_idx]) and np.isfinite(μ_Q[0]):
+                distance_profile[query_idx] = 0
 
     return distance_profile
 

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -3,7 +3,7 @@ import numpy as np
 import numpy.testing as npt
 
 import stumpy
-from stumpy import config
+from stumpy import config, core
 
 
 def test_mpdist_snippets_s():
@@ -38,3 +38,20 @@ def test_mpdist_snippets_s():
     npt.assert_almost_equal(
         ref_fractions, cmp_fractions, decimal=config.STUMPY_TEST_PRECISION
     )
+
+
+def test_distace_profile():
+    # This test function raises an error when the distance profile between
+    # the query `Q = T[i: i+m]`  and `T` becomes non-zero at index `i`.
+    T = np.random.rand(64)
+    m = 3
+    T, M_T, Σ_T, T_subseq_isconstant = core.preprocess(T, m)
+
+    for i in range(len(T) - m + 1):
+        Q = T[i : i + m]
+        D_ref = naive.distance_profile(Q, T, m)
+        D_comp = core.mass(
+            Q, T, M_T=M_T, Σ_T=Σ_T, T_subseq_isconstant=T_subseq_isconstant
+        )
+
+        npt.assert_almost_equal(D_ref, D_comp)

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -51,7 +51,7 @@ def test_distace_profile():
         Q = T[i : i + m]
         D_ref = naive.distance_profile(Q, T, m)
         D_comp = core.mass(
-            Q, T, M_T=M_T, Σ_T=Σ_T, T_subseq_isconstant=T_subseq_isconstant
+            Q, T, M_T=M_T, Σ_T=Σ_T, T_subseq_isconstant=T_subseq_isconstant, query_idx=i
         )
 
         npt.assert_almost_equal(D_ref, D_comp)


### PR DESCRIPTION
According to [this error](https://github.com/TDAmeritrade/stumpy/actions/runs/4902125133/jobs/8753783558?pr=856), we can realize that there is a loss of precision in self match in core.mass. This can result in loss-of-precision in the output of `motifs`. 

We first add a test function to expose this error. 