### PR TITLE
Add function `process_isconstant`

### DIFF
--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -4248,8 +4248,8 @@ def process_isconstant(T, m, T_subseq_isconstant, T_subseq_isfinite=None):
     if isinstance(T_subseq_isconstant, list):
         if T.ndim != 2:  # pragma: no cover
             msg = (
-                "When `T_subseq_isconstant` is provided as a list, the `T` "
-                + f"must be a 2D array. Got {T.ndim} dimension instead."
+                "When `T_subseq_isconstant` is provided as a list, `T` "
+                + f"must be a 2D array. Found {T.ndim} dimension instead."
             )
             raise ValueError(msg)
 

--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -4246,8 +4246,12 @@ def process_isconstant(T, m, T_subseq_isconstant, T_subseq_isfinite=None):
         Rolling window isconstant
     """
     if isinstance(T_subseq_isconstant, list):
-        ndim = T.ndim
-        T = np.atleast_2d(T)
+        if T.ndim != 2:
+            msg = (
+                "When `T_subseq_isconstant` is provided as a list, the `T` "
+                + f"must be a 2D array. Got {T.ndim} dimension instead."
+            )
+            raise ValueError(msg)
 
         if len(T_subseq_isconstant) != T.shape[0]:
             msg = (
@@ -4262,9 +4266,6 @@ def process_isconstant(T, m, T_subseq_isconstant, T_subseq_isfinite=None):
                 for i in range(T.shape[0])
             ]
         )
-
-        if ndim == 1:
-            T_subseq_isconstant = T_subseq_isconstant.flatten()
 
     T_subseq_isconstant = rolling_isconstant(T, m, T_subseq_isconstant)
     T_subseq_isconstant[...] = fix_isconstant_isfinite_conflicts(

--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -4210,13 +4210,15 @@ def _mpdist(
 
 def process_isconstant(T, m, T_subseq_isconstant, T_subseq_isfinite=None):
     """
-    Compute the rolling isconstant for 1-D and 2-D arrays.
-    This is accomplished by comparing the min and max within each window and
-    assigning `True` when the min and max are equal and `False` otherwise. If
-    a subsequence contains at least one NaN, then the subsequence is not constant.
+    This is a convenience wrapper around the `rolling_isconstant` and
+    `fix_isconstant_isfinite_conflicts`.
 
-    If `T_subseq_isconstant` is provided as boolean array, its element will be set
-    to False if their corresponding value in `T_subseq_isfinite` is False.
+    It computes the rolling isconstant for 1-D and 2-D arrays. This is accomplished by
+    comparing the min and max within each window and assigning `True` when the min and
+    max are equal and `False` otherwise. If a subsequence contains at least one NaN,
+    then the subsequence is not constant. If `T_subseq_isconstant` is provided as
+    boolean array, its element will be set to False if their corresponding value in
+    `T_subseq_isfinite` is False.
 
     Parameters
     ----------

--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -4246,14 +4246,14 @@ def process_isconstant(T, m, T_subseq_isconstant, T_subseq_isfinite=None):
         Rolling window isconstant
     """
     if isinstance(T_subseq_isconstant, list):
-        if T.ndim != 2:
+        if T.ndim != 2:  # pragma: no cover
             msg = (
                 "When `T_subseq_isconstant` is provided as a list, the `T` "
                 + f"must be a 2D array. Got {T.ndim} dimension instead."
             )
             raise ValueError(msg)
 
-        if len(T_subseq_isconstant) != T.shape[0]:
+        if len(T_subseq_isconstant) != T.shape[0]:  # pragma: no cover
             msg = (
                 "The lenght of the list `T_subseq_isconstant` must be "
                 + "equal to the number of time series in `T`."

--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -2803,7 +2803,7 @@ def _idx_to_mp(
             warnings.warn(msg)
 
     if normalize:
-        T_subseq_isconstant = rolling_isconstant(T, m, T_subseq_isconstant)
+        T_subseq_isconstant = process_isconstant(T, m, T_subseq_isconstant)
 
     T_isfinite = np.isfinite(T)
     T_subseq_isfinite = np.all(rolling_window(T_isfinite, m), axis=1)

--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -4266,8 +4266,9 @@ def process_isconstant(T, m, T_subseq_isconstant, T_subseq_isfinite=None):
                 for i in range(T.shape[0])
             ]
         )
+    else:
+        T_subseq_isconstant = rolling_isconstant(T, m, T_subseq_isconstant)
 
-    T_subseq_isconstant = rolling_isconstant(T, m, T_subseq_isconstant)
     T_subseq_isconstant[...] = fix_isconstant_isfinite_conflicts(
         T, m, T_subseq_isconstant, T_subseq_isfinite
     )

--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -4210,7 +4210,7 @@ def _mpdist(
 
 def process_isconstant(T, m, T_subseq_isconstant, T_subseq_isfinite=None):
     """
-    This is a convenience wrapper around the `rolling_isconstant` and
+    A convenience wrapper around the `rolling_isconstant` and
     `fix_isconstant_isfinite_conflicts`.
 
     It computes the rolling isconstant for 1-D and 2-D arrays. This is accomplished by

--- a/stumpy/floss.py
+++ b/stumpy/floss.py
@@ -526,7 +526,7 @@ class floss:
         self._finite_Q = self._finite_T[-self._m :].copy()
 
         if self._normalize:
-            self._T_subseq_isconstant = core.rolling_isconstant(
+            self._T_subseq_isconstant = core.process_isconstant(
                 self._T, self._m, self._T_subseq_isconstant_func
             )
             self._M_T, self._Σ_T = core.compute_mean_std(self._T, self._m)
@@ -636,7 +636,7 @@ class floss:
         # Ingress
         if self._normalize:
             self._T_subseq_isconstant[:-1] = self._T_subseq_isconstant[1:]
-            self._Q_subseq_isconstant = core.rolling_isconstant(
+            self._Q_subseq_isconstant = core.process_isconstant(
                 self._T[-self._m :], self._m, self._T_subseq_isconstant_func
             )
             self._T_subseq_isconstant[-1] = self._Q_subseq_isconstant

--- a/stumpy/motifs.py
+++ b/stumpy/motifs.py
@@ -335,7 +335,7 @@ def motifs(
         msg += f"(e.g., cutoff={suggested_cutoff})."
         warnings.warn(msg)
 
-    T_subseq_isconstant = core.rolling_isconstant(T, m, T_subseq_isconstant)
+    T_subseq_isconstant = core.process_isconstant(T, m, T_subseq_isconstant)
     T, M_T, Σ_T, T_subseq_isconstant = core.preprocess(
         np.expand_dims(T, 0),
         m,
@@ -516,8 +516,8 @@ def match(
     m = Q.shape[-1]
     excl_zone = int(np.ceil(m / config.STUMPY_EXCL_ZONE_DENOM))
 
-    Q_subseq_isconstant = core.rolling_isconstant(Q, m, Q_subseq_isconstant)
-    T_subseq_isconstant = core.rolling_isconstant(T, m, T_subseq_isconstant)
+    Q_subseq_isconstant = core.process_isconstant(Q, m, Q_subseq_isconstant)
+    T_subseq_isconstant = core.process_isconstant(T, m, T_subseq_isconstant)
 
     if Q.ndim == 1:
         Q = np.expand_dims(Q, 0)

--- a/stumpy/snippets.py
+++ b/stumpy/snippets.py
@@ -101,7 +101,7 @@ def _get_all_profiles(
         s = min(math.ceil(percentage * m), m)
 
     right_pad = 0
-    T_subseq_isconstant = core.rolling_isconstant(T, s, mpdist_T_subseq_isconstant)
+    T_subseq_isconstant = core.process_isconstant(T, s, mpdist_T_subseq_isconstant)
     if T.shape[0] % m != 0:
         right_pad = int(m * np.ceil(T.shape[0] / m) - T.shape[0])
         pad_width = (0, right_pad)

--- a/stumpy/stumpi.py
+++ b/stumpy/stumpi.py
@@ -197,7 +197,7 @@ class stumpi:
         self._T_isfinite = np.isfinite(self._T)
         self._egress = egress
 
-        self._T_subseq_isconstant = core.rolling_isconstant(
+        self._T_subseq_isconstant = core.process_isconstant(
             self._T, self._m, self._T_subseq_isconstant_func
         )
 
@@ -324,7 +324,7 @@ class stumpi:
             σ_Q = np.nan
             Q_subseq_isconstant = False
         else:
-            Q_subseq_isconstant = core.rolling_isconstant(
+            Q_subseq_isconstant = core.process_isconstant(
                 S, self._m, self._T_subseq_isconstant_func
             )[0]
             μ_Q, σ_Q = [arr[0] for arr in core.compute_mean_std(S, self._m)]
@@ -412,7 +412,7 @@ class stumpi:
             σ_Q = np.nan
             Q_subseq_isconstant = False
         else:
-            Q_subseq_isconstant = core.rolling_isconstant(
+            Q_subseq_isconstant = core.process_isconstant(
                 S, self._m, self._T_subseq_isconstant_func
             )[0]
             μ_Q, σ_Q = [arr[0] for arr in core.compute_mean_std(S, self._m)]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1728,15 +1728,22 @@ def test_process_isconstant_2d():
 
     # case 2: with nan
     T = np.random.rand(d, n)
-    row = np.random.randint(d)
-    col = np.random.randint(n)
-    T[row, col] = np.nan
+    i, j = np.random.choice(np.arange(n - m + 1), size=2, replace=False)
+    T[-1, i : i + m] = 0.0
+    T[-1, j : j + m] = 0.0
+    T[-1, j] = np.nan
 
     T_subseq_isconstant = [
         None,
         isconstant_custom_func,
-        np.random.choice([True, False], n - m + 1, replace=True),
+        np.full(n - m + 1, 0, dtype=bool),
     ]
+    T_subseq_isconstant[-1][i] = True
+    T_subseq_isconstant[-1][j] = True
+    # Although T_subseq_isconstant[-1, j] should be set to False (since...
+    # the subquence `T[-1, j:j+m]` is not finte), it is intentially set
+    # to True to test the functionality of `process_isconstant` in handling
+    # such conflict.
 
     T_subseq_isconstant_ref = np.array(
         [naive.rolling_isconstant(T[i], m, T_subseq_isconstant[i]) for i in range(d)]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1669,3 +1669,80 @@ def test_compute_P_ABBA_with_isconstant(T_A, T_B):
     )
 
     npt.assert_almost_equal(ref_P_ABBA, comp_P_ABBA)
+
+
+def test_process_isconstant_1d():
+    isconstant_custom_func = functools.partial(
+        naive.isconstant_func_stddev_threshold, quantile_threshold=0.05
+    )
+
+    n = 64
+    m = 8
+
+    # case 1: without nan
+    T = np.random.rand(n)
+
+    T_subseq_isconstant_ref = naive.rolling_isconstant(T, m, isconstant_custom_func)
+    T_subseq_isconstant_comp = core.process_isconstant(T, m, isconstant_custom_func)
+
+    npt.assert_array_equal(T_subseq_isconstant_ref, T_subseq_isconstant_comp)
+
+    # case 2: with nan
+    T = np.random.rand(n)
+    idx = np.random.randint(n)
+    T[idx] = np.nan
+    T_subseq_isconstant = np.random.choice([True, False], n - m + 1, replace=True)
+
+    T_subseq_isfinite = core.rolling_isfinite(T, m)
+
+    T_subseq_isconstant_ref = T_subseq_isconstant & T_subseq_isfinite
+    T_subseq_isconstant_comp = core.process_isconstant(T, m, T_subseq_isconstant)
+
+    npt.assert_array_equal(T_subseq_isconstant_ref, T_subseq_isconstant_comp)
+
+
+def test_process_isconstant_2d():
+    isconstant_custom_func = functools.partial(
+        naive.isconstant_func_stddev_threshold, quantile_threshold=0.05
+    )
+
+    n = 64
+    m = 8
+    d = 3
+
+    # case 1: without nan
+    T = np.random.rand(d, n)
+    T_subseq_isconstant = [
+        None,
+        isconstant_custom_func,
+        np.random.choice([True, False], n - m + 1, replace=True),
+    ]
+
+    T_subseq_isconstant_ref = np.array(
+        [naive.rolling_isconstant(T[i], m, T_subseq_isconstant[i]) for i in range(d)]
+    )
+
+    T_subseq_isconstant_comp = core.process_isconstant(T, m, T_subseq_isconstant)
+
+    npt.assert_array_equal(T_subseq_isconstant_ref, T_subseq_isconstant_comp)
+
+    # case 2: with nan
+    T = np.random.rand(d, n)
+    row = np.random.randint(d)
+    col = np.random.randint(n)
+    T[row, col] = np.nan
+
+    T_subseq_isconstant = [
+        None,
+        isconstant_custom_func,
+        np.random.choice([True, False], n - m + 1, replace=True),
+    ]
+
+    T_subseq_isconstant_ref = np.array(
+        [naive.rolling_isconstant(T[i], m, T_subseq_isconstant[i]) for i in range(d)]
+    )
+    T_subseq_isconstant_ref = T_subseq_isconstant_ref & core.rolling_isfinite(T, m)
+
+    T_subseq_isconstant_comp = core.process_isconstant(T, m, T_subseq_isconstant)
+
+    npt.assert_array_equal(T_subseq_isconstant_ref, T_subseq_isconstant_comp)


### PR DESCRIPTION
The new function, `process_isconstant`, is added to the `stumpy.core` module to handle:
* 2D time series when `T_subseq_isconstant` is provided as a list
* To fix the conflict between `T_subseq_isconstant` and `T_subseq_isfinite`

Two notes:
(1) The function `core.rolling_isconstant` can handle 2D time series, and the parameter `T_subseq_isconstant` can still be passed as `numpy.ndarray`, `function`, or `None`. However, it does not suppoert the `list` type.

(2) I think `core.preprocess` supports 2D array. So, we may change its docstring to reflect that the param `T_subseq_isconstant` can be a list. (since this function now calls the function `process_isconstant` which can support `list` type for `T_subseq_isconstant`)

