### PR TITLE
Fix typos

### DIFF
--- a/stumpy/aamp_stimp.py
+++ b/stumpy/aamp_stimp.py
@@ -67,7 +67,7 @@ class _aamp_stimp:
 
     m_stop : int, default None
         The stopping (or maximum) subsequence window size for which a matrix profile
-        may be computed. When `m_stop = Non`, this is set to the maximum allowable
+        may be computed. When `m_stop = None`, this is set to the maximum allowable
         subsequence window size
 
     m_step : int, default 1
@@ -380,7 +380,7 @@ class aamp_stimp(_aamp_stimp):
 
     m_stop : int, default None
         The stopping (or maximum) subsequence window size for which a matrix profile
-        may be computed. When `m_stop = Non`, this is set to the maximum allowable
+        may be computed. When `m_stop = None`, this is set to the maximum allowable
         subsequence window size
 
     m_step : int, default 1
@@ -506,7 +506,7 @@ class aamp_stimped(_aamp_stimp):
 
     m_stop : int, default None
         The stopping (or maximum) subsequence window size for which a matrix profile
-        may be computed. When `m_stop = Non`, this is set to the maximum allowable
+        may be computed. When `m_stop = None`, this is set to the maximum allowable
         subsequence window size
 
     m_step : int, default 1

--- a/stumpy/gpu_aamp_stimp.py
+++ b/stumpy/gpu_aamp_stimp.py
@@ -23,7 +23,7 @@ class gpu_aamp_stimp(_aamp_stimp):
 
     m_stop : int, default None
         The stopping (or maximum) subsequence window size for which a matrix profile
-        may be computed. When `m_stop = Non`, this is set to the maximum allowable
+        may be computed. When `m_stop = None`, this is set to the maximum allowable
         subsequence window size
 
     m_step : int, default 1

--- a/stumpy/gpu_stimp.py
+++ b/stumpy/gpu_stimp.py
@@ -30,7 +30,7 @@ class gpu_stimp(_stimp):
 
     max_m : int, default None
         The stopping (or maximum) subsequence window size for which a matrix profile
-        may be computed. When `m_stop = Non`, this is set to the maximum allowable
+        may be computed. When `m_stop = None`, this is set to the maximum allowable
         subsequence window size
 
     step : int, default 1

--- a/stumpy/stimp.py
+++ b/stumpy/stimp.py
@@ -56,7 +56,7 @@ class _stimp:
 
     max_m : int, default None
         The stopping (or maximum) subsequence window size for which a matrix profile
-        may be computed. When `max_m = Non`, this is set to the maximum allowable
+        may be computed. When `max_m = None`, this is set to the maximum allowable
         subsequence window size
 
     step : int, default 1
@@ -397,7 +397,7 @@ class stimp(_stimp):
 
     max_m : int, default None
         The stopping (or maximum) subsequence window size for which a matrix profile
-        may be computed. When `max_m = Non`, this is set to the maximum allowable
+        may be computed. When `max_m = None`, this is set to the maximum allowable
         subsequence window size
 
     step : int, default 1
@@ -571,7 +571,7 @@ class stimped(_stimp):
 
     max_m : int, default None
         The stopping (or maximum) subsequence window size for which a matrix profile
-        may be computed. When `max_m = Non`, this is set to the maximum allowable
+        may be computed. When `max_m = None`, this is set to the maximum allowable
         subsequence window size
 
     step : int, default 1


### PR DESCRIPTION
Fixed multiple occurrences of `Non` instead of `None` in doc-strings. 