### PR TITLE
[#957] Fixed updated README.md to correctly state that STUMPY support…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -325,7 +325,7 @@ Tests are written in the ``tests`` directory and processed using `PyTest <https:
 Python Version
 --------------
 
-STUMPY supports `Python 3.7+ <https://python3statement.org/>`__ and, due to the use of unicode variable names/identifiers, is not compatible with Python 2.x. Given the small dependencies, STUMPY may work on older versions of Python but this is beyond the scope of our support and we strongly recommend that you upgrade to the most recent version of Python.
+STUMPY supports `Python 3.8+ <https://python3statement.org/>`__ and, due to the use of unicode variable names/identifiers, is not compatible with Python 2.x. Given the small dependencies, STUMPY may work on older versions of Python but this is beyond the scope of our support and we strongly recommend that you upgrade to the most recent version of Python.
 
 ------------
 Getting Help

--- a/pypi.sh
+++ b/pypi.sh
@@ -5,11 +5,12 @@
 # 3. Update README with new features/functions/tutorials
 # 4. Determine minimum versions and dependencies with ./min.py
 # 5. Bump minimum versions and dependencies
-#    a) setup.py
+#    a) pyproject.toml
 #    b) requirements.txt
 #    c) environment.yml
 #    d) .github/worflows/github-actions.yml
 #    e) recipes/meta.yaml in conda-feedstock
+#    f) README.md
 # 6. Commit all above changes as the latest version number and push
 #
 # For conda-forge


### PR DESCRIPTION
See #957 

…s Python 3.8+ updated pypi.sh to reference step a) pyproject.toml instead of the decomissioned setup.py and ultimately scanned the full repository for any listings of outdated references to STUMPY supporting Python 3.7 (I was unable to find any)

# Pull Request Checklist

Below is a simple checklist but please do not hesitate to ask for assistance!

- [x] Fork, clone, and checkout the newest version of the code
- [x] Create a new branch
- [x] Make necessary code changes
- [x] Install `black` (i.e., `python -m pip install black` or `conda install -c conda-forge black`)
- [x] Install `flake8` (i.e., `python -m pip install flake8` or `conda install -c conda-forge flake8`)
- [x] Install `pytest-cov` (i.e., `python -m pip install pytest-cov` or `conda install -c conda-forge pytest-cov`)
- [x] Run `black .` in the root stumpy directory
- [x] Run `flake8 .` in the root stumpy directory
- [x] Run `./setup.sh && ./test.sh` in the root stumpy directory
- [x] Reference a Github issue (and create one if one doesn't already exist)
