### PR TITLE
Fixed #1014 Fix max_matches=None bug

### DIFF
--- a/stumpy/aamp_motifs.py
+++ b/stumpy/aamp_motifs.py
@@ -126,8 +126,12 @@ def _aamp_motifs(
         )
 
         if len(query_matches) > min_neighbors:
-            motif_distances.append(query_matches[:max_matches, 0])
-            motif_indices.append(query_matches[:max_matches, 1])
+            if np.isinf(max_matches):
+                motif_distances.append(query_matches[:, 0])
+                motif_indices.append(query_matches[:, 1])
+            else:
+                motif_distances.append(query_matches[:max_matches, 0])
+                motif_indices.append(query_matches[:max_matches, 1])
 
         if len(query_matches) == 0:  # pragma: no cover
             query_matches = np.array([[np.nan, candidate_idx]])

--- a/stumpy/aamp_motifs.py
+++ b/stumpy/aamp_motifs.py
@@ -126,12 +126,8 @@ def _aamp_motifs(
         )
 
         if len(query_matches) > min_neighbors:
-            if np.isinf(max_matches):
-                motif_distances.append(query_matches[:, 0])
-                motif_indices.append(query_matches[:, 1])
-            else:
-                motif_distances.append(query_matches[:max_matches, 0])
-                motif_indices.append(query_matches[:max_matches, 1])
+            motif_distances.append(query_matches[:max_matches, 0])
+            motif_indices.append(query_matches[:max_matches, 1])
 
         if len(query_matches) == 0:  # pragma: no cover
             query_matches = np.array([[np.nan, candidate_idx]])
@@ -272,7 +268,7 @@ def aamp_motifs(
     m = T.shape[-1] - P.shape[-1] + 1
     excl_zone = int(np.ceil(m / config.STUMPY_EXCL_ZONE_DENOM))
     if max_matches is None:  # pragma: no cover
-        max_matches = np.inf
+        max_matches = P.shape[-1]
     if cutoff is None:  # pragma: no cover
         P_copy = P.copy().astype(np.float64)
         P_copy[np.isinf(P_copy)] = np.nan

--- a/stumpy/motifs.py
+++ b/stumpy/motifs.py
@@ -131,12 +131,8 @@ def _motifs(
         )
 
         if len(query_matches) > min_neighbors:
-            if np.isinf(max_matches):
-                motif_distances.append(query_matches[:, 0])
-                motif_indices.append(query_matches[:, 1])
-            else:
-                motif_distances.append(query_matches[:max_matches, 0])
-                motif_indices.append(query_matches[:max_matches, 1])
+            motif_distances.append(query_matches[:max_matches, 0])
+            motif_indices.append(query_matches[:max_matches, 1])
 
         if len(query_matches) == 0:  # pragma: no cover
             query_matches = np.array([[np.nan, candidate_idx]])
@@ -338,7 +334,7 @@ def motifs(
     m = T.shape[-1] - P.shape[-1] + 1
     excl_zone = int(np.ceil(m / config.STUMPY_EXCL_ZONE_DENOM))
     if max_matches is None:  # pragma: no cover
-        max_matches = np.inf
+        max_matches = P.shape[-1]
     if cutoff is None:  # pragma: no cover
         P_copy = P.copy().astype(np.float64)
         P_copy[np.isinf(P_copy)] = np.nan

--- a/stumpy/motifs.py
+++ b/stumpy/motifs.py
@@ -131,8 +131,12 @@ def _motifs(
         )
 
         if len(query_matches) > min_neighbors:
-            motif_distances.append(query_matches[:max_matches, 0])
-            motif_indices.append(query_matches[:max_matches, 1])
+            if np.isinf(max_matches):
+                motif_distances.append(query_matches[:, 0])
+                motif_indices.append(query_matches[:, 1])
+            else:
+                motif_distances.append(query_matches[:max_matches, 0])
+                motif_indices.append(query_matches[:max_matches, 1])
 
         if len(query_matches) == 0:  # pragma: no cover
             query_matches = np.array([[np.nan, candidate_idx]])

--- a/tests/test_motifs.py
+++ b/tests/test_motifs.py
@@ -679,7 +679,7 @@ def test_motifs_with_max_matches_none():
         max_motifs=max_motifs,
     )
 
-    ref_len = len(T) / m
+    ref_len = len(T) - m + 1
 
-    npt.assert_(ref_len <= comp_distance.shape[1])
-    npt.assert_(ref_len <= comp_indices.shape[1])
+    npt.assert_(ref_len >= comp_distance.shape[1])
+    npt.assert_(ref_len >= comp_indices.shape[1])

--- a/tests/test_motifs.py
+++ b/tests/test_motifs.py
@@ -656,3 +656,30 @@ def test_motifs_with_isconstant():
 
     npt.assert_almost_equal(ref_distances, comp_distance)
     npt.assert_almost_equal(ref_indices, comp_indices)
+
+
+def test_motifs_with_max_matches_none():
+    T = np.random.rand(16)
+    m = 3
+
+    max_motifs = 1
+    max_matches = None
+    max_distance = np.inf
+    cutoff = np.inf
+
+    # performant
+    mp = naive.stump(T, m, row_wise=True)
+    comp_distance, comp_indices = motifs(
+        T,
+        mp[:, 0].astype(np.float64),
+        min_neighbors=1,
+        max_distance=max_distance,
+        cutoff=cutoff,
+        max_matches=max_matches,
+        max_motifs=max_motifs,
+    )
+
+    ref_len = len(T) / m
+
+    npt.assert_(ref_len <= comp_distance.shape[1])
+    npt.assert_(ref_len <= comp_indices.shape[1])


### PR DESCRIPTION
This fix addresses issue #1014 by not slicing the `query_matches` if `max_matches` is set to `None` for `motifs` (which in turn calls `_motifs` with `max_matches=np.inf`.

I made an initial effort to add testing, but I'm sure there are better ways to do so.

# Pull Request Checklist

- [x] Fork, clone, and checkout the newest version of the code
- [x] Create a new branch
- [x] Make necessary code changes
- [x] Install `black` (i.e., `python -m pip install black` or `conda install -c conda-forge black`)
- [x] Install `flake8` (i.e., `python -m pip install flake8` or `conda install -c conda-forge flake8`)
- [x] Install `pytest-cov` (i.e., `python -m pip install pytest-cov` or `conda install -c conda-forge pytest-cov`)
- [x] Run `black .` in the root stumpy directory
- [x] Run `flake8 .` in the root stumpy directory
- [x] Run `./setup.sh && ./test.sh` in the root stumpy directory
- [x] Reference a Github issue (and create one if one doesn't already exist)
