### PR TITLE
[WIP] Fix #708

### DIFF
--- a/njit_fastmath.py
+++ b/njit_fastmath.py
@@ -1,0 +1,69 @@
+
+import pathlib
+
+from utils import check_callees, check_functions
+
+stumpy_path = pathlib.Path(__file__).parent / "stumpy"
+filepaths = sorted(f for f in pathlib.Path(stumpy_path).iterdir() if f.is_file())
+
+all_functions = {}
+callees = {}
+
+ignore = ["__init__.py", "__pycache__"]
+for filepath in filepaths:
+    name = filepath.name
+    if name not in ignore and str(filepath).endswith(".py"):
+        callees[name] = check_callees(filepath)
+
+        func_names, is_njit, fastmath_values = check_functions(filepath)
+        all_functions[name] = {
+            "func_names": func_names,
+            "is_njit": is_njit,
+            "fastmath_values": fastmath_values,
+        }
+
+
+stumpy_functions = set()
+for fname, func_data in all_functions.items():
+    prefix = fname.replace(".py", "")
+    stumpy_functions.update([prefix + '.' + x for x  in func_data["func_names"]])
+stumpy_functions = list(stumpy_functions)
+stumpy_functions_no_prefix = [x.split('.')[1] for x in stumpy_functions]
+
+
+# create  a dictionary where keys are function names in stumpy_functions, and the value
+# is a tuple, where the first element says whether the function is decorated with njit
+# and the second element is the list of callees
+
+callers_callees = {}
+for func_name in stumpy_functions:
+    callers_callees[func_name] = None
+    
+    prefix, func = func_name.split('.')
+    fname = prefix + '.py'
+
+    idx = all_functions[fname]["func_names"].index(func)
+    is_njit = all_functions[fname]["is_njit"][idx]
+    fastmath_val = all_functions[fname]["fastmath_values"][idx]
+
+    callees_functions = callees[fname][func]
+    
+    pruned_callees_functions = []
+    for callee in callees_functions:
+        if callee in all_functions[fname]["func_names"]:
+            pruned_callees_functions.append(prefix + '.' + callee)
+        elif callee in stumpy_functions:
+            idx = stumpy_functions_no_prefix.index(callee)
+            pruned_callees_functions.append(stumpy_functions[idx])
+        else:
+            continue
+
+    callers_callees[func_name] = (is_njit, fastmath_val, pruned_callees_functions)
+
+
+
+
+for k, v in callers_callees.items():
+    print('---------------------------------')
+    print('> func_name: ', k)
+    print('metadata: ', v)

--- a/njit_fastmath.py
+++ b/njit_fastmath.py
@@ -62,7 +62,7 @@ for func_name in stumpy_functions:
 
 # Create callees_callers dictionary using callers_callees dictionary
 callees_callers = {}
-for func_name, func_metadata in  callers_callees.items():
+for func_name, func_metadata in callers_callees.items():
     callees_callers[func_name] = [func_metadata[0], func_metadata[1], []]
 
 
@@ -74,5 +74,3 @@ for func_name, func_metadata in callers_callees.items():
 for func_name, func_metadata in callees_callers.items():
     callees_callers[func_name][2] = set(callees_callers[func_name][2])
     callees_callers[func_name] = tuple(callees_callers[func_name])
-
-

--- a/njit_fastmath.py
+++ b/njit_fastmath.py
@@ -6,71 +6,67 @@ stumpy_path = pathlib.Path(__file__).parent / "stumpy"
 filepaths = sorted(f for f in pathlib.Path(stumpy_path).iterdir() if f.is_file())
 
 all_functions = {}
-callees = {}
 
 ignore = ["__init__.py", "__pycache__"]
 for filepath in filepaths:
-    name = filepath.name
-    if name not in ignore and str(filepath).endswith(".py"):
-        callees[name] = check_callees(filepath)
+    file_name = filepath.name
+    if file_name not in ignore and str(filepath).endswith(".py"):
+        prefix = file_name.replace(".py", "")
 
         func_names, is_njit, fastmath_values = check_functions(filepath)
-        all_functions[name] = {
+        func_names = [f"{prefix}.{fn}" for fn in func_names]
+
+        all_functions[file_name] = {
             "func_names": func_names,
             "is_njit": is_njit,
             "fastmath_values": fastmath_values,
         }
 
+all_stumpy_functions = set()
+for file_name, file_functions_metadata in all_functions.items():
+    all_stumpy_functions.update(file_functions_metadata["func_names"])
 
-stumpy_functions = set()
-for fname, func_data in all_functions.items():
-    prefix = fname.replace(".py", "")
-    stumpy_functions.update([prefix + "." + x for x in func_data["func_names"]])
-stumpy_functions = list(stumpy_functions)
-stumpy_functions_no_prefix = [x.split(".")[1] for x in stumpy_functions]
+all_stumpy_functions = list(all_stumpy_functions)
+all_stumpy_functions_no_prefix = [f.split(".")[-1] for f in all_stumpy_functions]
 
 
-# create  a dictionary where keys are function names in stumpy_functions, and the value
-# is a tuple, where the first element says whether the function is decorated with njit
-# and the second element is the list of callees
+# output 1: func_metadata
+func_metadata = {}
+for file_name, file_functions_metadata in all_functions.items():
+    for i, f in enumerate(file_functions_metadata["func_names"]):
+        is_njit = file_functions_metadata["is_njit"][i]
+        fastmath_value = file_functions_metadata["fastmath_values"][i]
+        func_metadata[f] = [is_njit, fastmath_value]
 
-callers_callees = {}
-for func_name in stumpy_functions:
-    callers_callees[func_name] = None
 
-    prefix, func = func_name.split(".")
-    fname = prefix + ".py"
+# output 2: func_callers
+func_callers = {}
+for f in func_metadata.keys():
+    func_callers[f] = []
 
-    idx = all_functions[fname]["func_names"].index(func)
-    is_njit = all_functions[fname]["is_njit"][idx]
-    fastmath_val = all_functions[fname]["fastmath_values"][idx]
+for filepath in filepaths:
+    file_name = filepath.name
+    if file_name in ignore or not str(filepath).endswith(".py"):
+        continue
 
-    callees_functions = callees[fname][func]
+    prefix = file_name.replace(".py", "")
+    callees = check_callees(filepath)
 
-    pruned_callees_functions = []
-    for callee in callees_functions:
-        if callee in all_functions[fname]["func_names"]:
-            pruned_callees_functions.append(prefix + "." + callee)
-        elif callee in stumpy_functions:
-            idx = stumpy_functions_no_prefix.index(callee)
-            pruned_callees_functions.append(stumpy_functions[idx])
-        else:
+    current_callers = set(callees.keys())
+    for caller, callee_set in callees.items():
+        s = list(callee_set.intersection(all_stumpy_functions_no_prefix))
+        if len(s) == 0:
             continue
 
-    callers_callees[func_name] = (is_njit, fastmath_val, pruned_callees_functions)
+        for c in s:
+            if c in current_callers:
+                c_name = prefix + "." + c
+            else:
+                idx = all_stumpy_functions_no_prefix.index(c)
+                c_name = all_stumpy_functions[idx]
+
+            func_callers[c_name].append(f"{prefix}.{caller}")
 
 
-# Create callees_callers dictionary using callers_callees dictionary
-callees_callers = {}
-for func_name, func_metadata in callers_callees.items():
-    callees_callers[func_name] = [func_metadata[0], func_metadata[1], []]
-
-
-for func_name, func_metadata in callers_callees.items():
-    for callee in func_metadata[2]:
-        callees_callers[callee][-1].append(func_name)
-
-
-for func_name, func_metadata in callees_callers.items():
-    callees_callers[func_name][2] = set(callees_callers[func_name][2])
-    callees_callers[func_name] = tuple(callees_callers[func_name])
+for f, callers in func_callers.items():
+    func_callers[f] = list(set(callers))

--- a/njit_fastmath.py
+++ b/njit_fastmath.py
@@ -1,4 +1,3 @@
-
 import pathlib
 
 from utils import check_callees, check_functions
@@ -26,9 +25,9 @@ for filepath in filepaths:
 stumpy_functions = set()
 for fname, func_data in all_functions.items():
     prefix = fname.replace(".py", "")
-    stumpy_functions.update([prefix + '.' + x for x  in func_data["func_names"]])
+    stumpy_functions.update([prefix + "." + x for x in func_data["func_names"]])
 stumpy_functions = list(stumpy_functions)
-stumpy_functions_no_prefix = [x.split('.')[1] for x in stumpy_functions]
+stumpy_functions_no_prefix = [x.split(".")[1] for x in stumpy_functions]
 
 
 # create  a dictionary where keys are function names in stumpy_functions, and the value
@@ -38,20 +37,20 @@ stumpy_functions_no_prefix = [x.split('.')[1] for x in stumpy_functions]
 callers_callees = {}
 for func_name in stumpy_functions:
     callers_callees[func_name] = None
-    
-    prefix, func = func_name.split('.')
-    fname = prefix + '.py'
+
+    prefix, func = func_name.split(".")
+    fname = prefix + ".py"
 
     idx = all_functions[fname]["func_names"].index(func)
     is_njit = all_functions[fname]["is_njit"][idx]
     fastmath_val = all_functions[fname]["fastmath_values"][idx]
 
     callees_functions = callees[fname][func]
-    
+
     pruned_callees_functions = []
     for callee in callees_functions:
         if callee in all_functions[fname]["func_names"]:
-            pruned_callees_functions.append(prefix + '.' + callee)
+            pruned_callees_functions.append(prefix + "." + callee)
         elif callee in stumpy_functions:
             idx = stumpy_functions_no_prefix.index(callee)
             pruned_callees_functions.append(stumpy_functions[idx])
@@ -59,11 +58,3 @@ for func_name in stumpy_functions:
             continue
 
     callers_callees[func_name] = (is_njit, fastmath_val, pruned_callees_functions)
-
-
-
-
-for k, v in callers_callees.items():
-    print('---------------------------------')
-    print('> func_name: ', k)
-    print('metadata: ', v)

--- a/njit_fastmath.py
+++ b/njit_fastmath.py
@@ -58,3 +58,21 @@ for func_name in stumpy_functions:
             continue
 
     callers_callees[func_name] = (is_njit, fastmath_val, pruned_callees_functions)
+
+
+# Create callees_callers dictionary using callers_callees dictionary
+callees_callers = {}
+for func_name, func_metadata in  callers_callees.items():
+    callees_callers[func_name] = [func_metadata[0], func_metadata[1], []]
+
+
+for func_name, func_metadata in callers_callees.items():
+    for callee in func_metadata[2]:
+        callees_callers[callee][-1].append(func_name)
+
+
+for func_name, func_metadata in callees_callers.items():
+    callees_callers[func_name][2] = set(callees_callers[func_name][2])
+    callees_callers[func_name] = tuple(callees_callers[func_name])
+
+

--- a/utils.py
+++ b/utils.py
@@ -92,3 +92,55 @@ def check_functions(filepath):
             fastmath_values[i] = check_fastmath(node)
 
     return func_names, is_njit, fastmath_values
+
+
+def _get_callees(node, all_functions):
+    for n in ast.iter_child_nodes(node):
+        if isinstance(n, ast.Call):
+            obj = n.func
+            if isinstance(obj, ast.Attribute):
+                name = obj.attr
+            elif isinstance(obj, ast.Subscript):
+                name = obj.value.id
+            elif isinstance(obj, ast.Name):
+                name = obj.id
+            else:
+                msg = f"The type {type(obj)} is not supported"
+                raise ValueError(msg)
+
+            all_functions.append(name)
+
+        _get_callees(n, all_functions)
+
+
+def get_all_callees(fd):
+    """
+    For a given node of type ast.FunctionDef, visit all of its child nodes,
+    and return a list of all of its callees
+    """
+    all_functions = []
+    _get_callees(fd, all_functions)
+
+    return all_functions
+
+
+def check_callees(filepath):
+    """
+    For the given `filepath`, return a dictionary with the key
+    being the function name and the value being a set of function names
+    that are called by the function
+    """
+    file_contents = ""
+    with open(filepath, encoding="utf8") as f:
+        file_contents = f.read()
+    module = ast.parse(file_contents)
+
+    function_definitions = [
+        node for node in module.body if isinstance(node, ast.FunctionDef)
+    ]
+
+    callees = {}
+    for fd in function_definitions:
+        callees[fd.name] = set(get_all_callees(fd))
+
+    return callees

--- a/utils.py
+++ b/utils.py
@@ -3,13 +3,13 @@ import ast
 
 def check_fastmath(decorator):
     """
-    For the given `decorator` node with type `ast.Call`, 
+    For the given `decorator` node with type `ast.Call`,
     return the value of the `fastmath` argument if it exists.
     Otherwise, return `None`.
     """
     fastmath_value = None
     for n in ast.iter_child_nodes(decorator):
-        if isinstance(n, ast.keyword) and n.arg == 'fastmath':
+        if isinstance(n, ast.keyword) and n.arg == "fastmath":
             if isinstance(n.value, ast.Constant):
                 fastmath_value = n.value.value
             elif isinstance(n.value, ast.Set):
@@ -21,10 +21,9 @@ def check_fastmath(decorator):
     return fastmath_value
 
 
-
 def check_njit(fd):
     """
-    For the given `fd` node with type `ast.FunctionDef`, 
+    For the given `fd` node with type `ast.FunctionDef`,
     return the node of the `njit` decorator if it exists.
     Otherwise, return `None`.
     """
@@ -38,7 +37,7 @@ def check_njit(fd):
             name = obj.attr
         elif isinstance(obj, ast.Subscript):
             name = obj.value.id
-        elif isinstance(obj, ast.Name):                
+        elif isinstance(obj, ast.Name):
             name = obj.id
         else:
             msg = f"The type {type(obj)} is not supported."
@@ -47,29 +46,29 @@ def check_njit(fd):
         if name == "njit":
             decorator_node = decorator
             break
-    
+
     return decorator_node
 
 
 def check_functions(filepath):
     """
-    For the given `filepath`, return the function names, 
-    whether the function is decorated with `@njit`, 
+    For the given `filepath`, return the function names,
+    whether the function is decorated with `@njit`,
     and the value of the `fastmath` argument if it exists
 
     Parameters
     ----------
     filepath : str
         The path to the file
-    
+
     Returns
     -------
     func_names : list
         List of function names
-    
+
     is_njit : list
         List of boolean values indicating whether the function is decorated with `@njit`
-    
+
     fastmath_value : list
         List of values of the `fastmath` argument if it exists
     """
@@ -77,19 +76,19 @@ def check_functions(filepath):
     with open(filepath, encoding="utf8") as f:
         file_contents = f.read()
     module = ast.parse(file_contents)
-    
+
     function_definitions = [
-        node for node in module.body if isinstance(node, ast.FunctionDef) 
+        node for node in module.body if isinstance(node, ast.FunctionDef)
     ]
 
     func_names = [fd.name for fd in function_definitions]
 
-    njit_nodes = [check_njit(fd) for fd in function_definitions]    
+    njit_nodes = [check_njit(fd) for fd in function_definitions]
     is_njit = [node is not None for node in njit_nodes]
 
-    fastmath_value = [None] * len(njit_nodes)
+    fastmath_values = [None] * len(njit_nodes)
     for i, node in enumerate(njit_nodes):
         if node is not None:
-            fastmath_value[i] = check_fastmath(node)
+            fastmath_values[i] = check_fastmath(node)
 
     return func_names, is_njit, fastmath_values

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,95 @@
+import ast
+
+
+def check_fastmath(decorator):
+    """
+    For the given `decorator` node with type `ast.Call`, 
+    return the value of the `fastmath` argument if it exists.
+    Otherwise, return `None`.
+    """
+    fastmath_value = None
+    for n in ast.iter_child_nodes(decorator):
+        if isinstance(n, ast.keyword) and n.arg == 'fastmath':
+            if isinstance(n.value, ast.Constant):
+                fastmath_value = n.value.value
+            elif isinstance(n.value, ast.Set):
+                fastmath_value = set(item.value for item in n.value.elts)
+            else:
+                pass
+            break
+
+    return fastmath_value
+
+
+
+def check_njit(fd):
+    """
+    For the given `fd` node with type `ast.FunctionDef`, 
+    return the node of the `njit` decorator if it exists.
+    Otherwise, return `None`.
+    """
+    decorator_node = None
+    for decorator in fd.decorator_list:
+        if not isinstance(decorator, ast.Call):
+            continue
+
+        obj = decorator.func
+        if isinstance(obj, ast.Attribute):
+            name = obj.attr
+        elif isinstance(obj, ast.Subscript):
+            name = obj.value.id
+        elif isinstance(obj, ast.Name):                
+            name = obj.id
+        else:
+            msg = f"The type {type(obj)} is not supported."
+            raise ValueError(msg)
+
+        if name == "njit":
+            decorator_node = decorator
+            break
+    
+    return decorator_node
+
+
+def check_functions(filepath):
+    """
+    For the given `filepath`, return the function names, 
+    whether the function is decorated with `@njit`, 
+    and the value of the `fastmath` argument if it exists
+
+    Parameters
+    ----------
+    filepath : str
+        The path to the file
+    
+    Returns
+    -------
+    func_names : list
+        List of function names
+    
+    is_njit : list
+        List of boolean values indicating whether the function is decorated with `@njit`
+    
+    fastmath_value : list
+        List of values of the `fastmath` argument if it exists
+    """
+    file_contents = ""
+    with open(filepath, encoding="utf8") as f:
+        file_contents = f.read()
+    module = ast.parse(file_contents)
+    
+    function_definitions = [
+        node for node in module.body if isinstance(node, ast.FunctionDef) 
+    ]
+
+    func_names = [fd.name for fd in function_definitions]
+
+    njit_nodes = [check_njit(fd) for fd in function_definitions]    
+    is_njit = [node is not None for node in njit_nodes]
+
+    fastmath_value = [None] * len(njit_nodes)
+    for i, node in enumerate(njit_nodes):
+        if node is not None:
+            fastmath_value[i] = check_fastmath(node)
+
+    return func_names, is_njit, fastmath_values


### PR DESCRIPTION
See #708. This PR should address #708 (and #1011)

Each main checkbox below has at least one indented checkbox. The main checkbox represents a callee function with `fastmath=True` and an indented checkbox represents a caller function. If the caller function itself has `fastmath=True` flag as well, a star(*) is written next to its name. In such case, the callers of this function are represented in another checkbox set. 

---

- [ ] maap._compute_multi_p_norm 
  - [ ] maap._maamp

- [ ]  core._sliding_dot_product
  - [ ] * core._p_norm_distance_profile
  - [ ] core._mass_distance_matrix
  - [ ] * scrump._compute_PI
  - [ ] tests/test_preceision.py::test_calculate_squared_distance
  - [ ] tests/test_core.py::test_njit_sliding_dot_product


- [ ]  core._p_norm_distance_profile 
  - [ ] *  scrammp._compute_PI
  - [ ] tests/test_core.py::test_p_norm_distance_profile

- [ ]  core._calculate_squared_distance_profile 
  - [ ] *  core.calculate_distance_profile
  - [ ] stomp._stomp
  - [ ] * mstump._compute_multi_D
  - [ ] *  scrump._compute_PI
  - [ ] tests/test_core.py::test_calculate_squared_distance_profile


- [ ]  core.calculate_distance_profile 
  - [ ] *  core._mass
  - [ ] stumpi._update_egress
  - [ ] stumpi._update
  - [ ] tests/test_core.py::test_calculate_distance_profile
 
- [ ] core._mass
  - [ ] core.mass
  - [ ] core._mass_distance_matrix
  - [ ] ostinato._across_series_nearest_neighbors
  - [ ] ostinato._ostinato
 

- [ ]  core._apply_exclusion_zone
  - [ ] * maap._compute_multi_p_norm
  - [ ] core.apply_exclusion_zone
  - [ ] * scraamp._compute_PI
  - [ ] * mstump._compute_multi_D
  - [ ] * scrump._compute_PI


- [ ]  stump._stump
  - [ ] stumped._dask_stumped
  - [ ] stumped._ray_stumped
  - [ ] stump.stump
  - [ ] scrump.update

- [ ]  stump._compute_diagonal
  - [ ] * stump._stump


- [ ]  * scraamp._compute_PI
  - [ ] * scraamp._prescraamp


- [ ]  scraamp._prescraamp
  - [ ] scraamp.prescraamp
  - [ ] scraamp.\__init__

- [ ]  mstump._compute_multi_D
  - [ ] mstump._mstump


- [ ]  scrump._compute_PI
  - [ ] * scrump._prescrump


- [ ]  scrump. _prescrump
  - [ ] scrump.prescrump
  - [ ] scrump.\__init__


- [ ]  aamp._compute_diagonal
  - [ ] * aamp._aamp


- [ ]  aamp._aamp
  - [ ] aamp.aamp
  - [ ] scraamp.update
  - [ ] aamped._dask_aamped
  - [ ] aamped._ray_aamped


NOTE: The functions `core._count_diagonal_ndist` and `core._total_diagonal_ndists` are ignored as their input parameters cannot have non-finite value.