### PR TITLE
Fixed #1116 Avoid Import Fastmath Functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,3 +112,5 @@ tbb = ">=2019.5"
 tests = "./test.sh"
 coverage = "./test.sh coverage"
 docs = "cd docs && ./setup.sh"
+black = 'black --exclude=".*\.ipynb" --extend-exclude=".venv|.pixi" --diff ./'
+isort = 'isort --profile black --skip .venv --skip .pixi ./'


### PR DESCRIPTION
See https://github.com/stumpy-dev/stumpy/issues/1116
# Pull Request Checklist

Below is a simple checklist but please do not hesitate to ask for assistance!

- [ ] Fork, clone, and checkout the newest version of the code
- [ ] Create a new branch
- [ ] Make necessary code changes
- [ ] Install `black` (i.e., `python -m pip install black` or `conda install -c conda-forge black`)
- [ ] Install `flake8` (i.e., `python -m pip install flake8` or `conda install -c conda-forge flake8`)
- [ ] Install `pytest-cov` (i.e., `python -m pip install pytest-cov` or `conda install -c conda-forge pytest-cov`)
- [ ] Run `black --exclude=".*\.ipynb" --extend-exclude=".venv" --diff ./` in the root stumpy directory
- [ ] Run `flake8 --extend-exclude=.venv ./` in the root stumpy directory
- [ ] Run `./setup.sh dev && ./test.sh` in the root stumpy directory
- [ ] Reference a Github issue (and create one if one doesn't already exist)
