### PR TITLE
Fixed #1119 Pandas to NumPy array read-only error

### DIFF
--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -2117,8 +2117,9 @@ def _preprocess(T, copy=True):
         Time series or sequence
 
     copy : bool, default True
-        A boolean value that indicates whether the process should be done on
-        input `T` (False) or its copy (True).
+        A boolean value that indicates whether the process should be performed on
+        input array `T` (False) or its copy (True). If `T` is a dataframe, then the
+        data is always copied into a brand new array.
 
     Returns
     -------
@@ -2173,8 +2174,9 @@ def preprocess(
         Window size
 
     copy : bool, default True
-        A boolean value that indicates whether the process should be done on
-        input `T` (False) or its copy (True).
+        A boolean value that indicates whether the process should be performed on
+        input array `T` (False) or its copy (True). If `T` is a dataframe, then the
+        data is always copied into a brand new array.
 
     M_T : numpy.ndarray, default None
         Rolling mean
@@ -2236,8 +2238,9 @@ def preprocess_non_normalized(T, m, copy=True):
         Window size
 
     copy : bool, default True
-        A boolean value that indicates whether the process should be done on
-        input `T` (False) or its copy (True).
+        A boolean value that indicates whether the process should be performed on
+        input array `T` (False) or its copy (True). If `T` is a dataframe, then the
+        data is always copied into a brand new array.
 
     Returns
     -------
@@ -2296,8 +2299,9 @@ def preprocess_diagonal(
         corresponding value set to False in this boolean array.
 
     copy : bool, default True
-        A boolean value that indicates whether the process should be done on
-        input `T` (False) or its copy (True).
+        A boolean value that indicates whether the process should be performed on
+        input array `T` (False) or its copy (True). If `T` is a dataframe, then the
+        data is always copied into a brand new array.
 
     Returns
     -------


### PR DESCRIPTION
# Pull Request Checklist

Below is a simple checklist but please do not hesitate to ask for assistance!

- [ ] Fork, clone, and checkout the newest version of the code
- [ ] Create a new branch
- [ ] Make necessary code changes
- [ ] Install `black` (i.e., `python -m pip install black` or `conda install -c conda-forge black`)
- [ ] Install `flake8` (i.e., `python -m pip install flake8` or `conda install -c conda-forge flake8`)
- [ ] Install `pytest-cov` (i.e., `python -m pip install pytest-cov` or `conda install -c conda-forge pytest-cov`)
- [ ] Run `black --exclude=".*\.ipynb" --extend-exclude=".venv" --diff ./` in the root stumpy directory
- [ ] Run `flake8 --extend-exclude=.venv ./` in the root stumpy directory
- [ ] Run `./setup.sh dev && ./test.sh` in the root stumpy directory
- [ ] Reference a Github issue (and create one if one doesn't already exist)
