### PR TITLE
[Failed] Fixed #1112 Migrate to New NumPy Random Number Generator (RNG) API

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -9,7 +9,8 @@ import json
 import numpy as np
 import pytest
 
-pytest.RNG = np.random.default_rng()
+bit_gen = np.random.PCG64()
+pytest.RNG = np.random.Generator(bit_gen)
 # pytest.RNG.bit_generator.state = {
 #     Set RNG state here
 # }

--- a/conftest.py
+++ b/conftest.py
@@ -46,12 +46,7 @@ def _get_rng_state():
 def _set_rng_state(state):
     """
     Store existing RNG state and set RNG state
-
-    If no state is provided, a hardcoded, safe state will be used
     """
-    if state is None:
-        state = pytest.SEED_ZERO.copy()
-
     pytest.LAST_RNG_STATE = pytest.RNG.bit_generator.state.copy()
     pytest.RNG.bit_generator.state = state
 

--- a/conftest.py
+++ b/conftest.py
@@ -4,3 +4,21 @@
 # to fix eventual module import errors that can arise, for example when
 # running tests from inside VS code.
 # See https://stackoverflow.com/a/34520971
+import json
+
+import numpy as np
+import pytest
+
+pytest.RNG = np.random.default_rng()
+# pytest.RNG.bit_generator.state = {
+#     Set RNG state here
+# }
+
+
+def pytest_configure(config):
+    """
+    Called after command line options have been parsed
+    and all plugins and initial conftest files been loaded.
+    """
+    state = json.dumps(pytest.RNG.bit_generator.state, indent=4)
+    print(f"conftest.py: pytest.RNG.bit_generator.state = {state}")

--- a/conftest.py
+++ b/conftest.py
@@ -14,6 +14,18 @@ pytest.RNG = np.random.default_rng()
 #     Set RNG state here
 # }
 
+pytest.LAST_RNG_STATE = None
+pytest.FIXED_RNG_STATE = {
+    # DO NOT CHANGE/ALTER!!
+    "bit_generator": "PCG64",
+    "state": {
+        "state": 195349167630453735115769518810051464980,
+        "inc": 247589055400886363559049235690497450585,
+    },
+    "has_uint32": 0,
+    "uinteger": 0,
+}
+
 
 def pytest_configure(config):
     """
@@ -22,3 +34,44 @@ def pytest_configure(config):
     """
     state = json.dumps(pytest.RNG.bit_generator.state, indent=4)
     print(f"conftest.py: pytest.RNG.bit_generator.state = {state}")
+
+
+def _get_rng_state():
+    """
+    Get a copy of the current RNG state
+    """
+    return pytest.RNG.bit_generator.state.copy()
+
+
+def _set_rng_state(state):
+    """
+    Store existing RNG state and set RNG state
+
+    If no state is provided, a hardcoded, safe state will be used
+    """
+    if state is None:
+        state = pytest.SEED_ZERO.copy()
+
+    pytest.LAST_RNG_STATE = pytest.RNG.bit_generator.state.copy()
+    pytest.RNG.bit_generator.state = state
+
+
+def _reset_rng_state():
+    """
+    Restore the RNG state to the last recorded RNG state
+    """
+    pytest.RNG.bit_generator.state = pytest.LAST_RNG_STATE.copy()
+    pytest.LAST_RNG_STATE = None
+
+
+def _fix_rng_state():
+    """
+    Set the RNG state to a fixed, hardcoded, safe state
+    """
+    _set_rng_state(pytest.FIXED_RNG_STATE)
+
+
+pytest.get_rng_state = _get_rng_state
+pytest.set_rng_state = _set_rng_state
+pytest.fix_rng_state = _fix_rng_state
+pytest.unfix_rng_state = _reset_rng_state

--- a/test.sh
+++ b/test.sh
@@ -175,7 +175,7 @@ set_ray_coveragerc()
 show_coverage_report()
 {
     set_ray_coveragerc
-    coverage report --show-missing --fail-under=100 --skip-covered --omit=fastmath.py,docstring.py,versions.py $fcoveragerc
+    coverage report --show-missing --fail-under=100 --skip-covered --omit=fastmath.py,docstring.py,versions.py,conftest.py $fcoveragerc
     check_errs $?
 }
 

--- a/test.sh
+++ b/test.sh
@@ -83,7 +83,7 @@ check_flake()
 check_print()
 {
     if [[ $print_mode == "verbose" ]]; then
-        if [[ `grep print --exclude="conftext.py" */*.py | wc -l` -gt "0" ]]; then
+        if [[ `grep print */*.py | wc -l` -gt "0" ]]; then
             echo "Error: print statement found in code"
             grep print */*.py
             exit 1

--- a/test.sh
+++ b/test.sh
@@ -83,7 +83,7 @@ check_flake()
 check_print()
 {
     if [[ $print_mode == "verbose" ]]; then
-        if [[ `grep print */*.py | wc -l` -gt "0" ]]; then
+        if [[ `grep print --exclude="conftext.py" */*.py | wc -l` -gt "0" ]]; then
             echo "Error: print statement found in code"
             grep print */*.py
             exit 1

--- a/tests/test_aamp_mmotifs.py
+++ b/tests/test_aamp_mmotifs.py
@@ -51,17 +51,15 @@ test_data = [
 
 
 def test_aamp_mmotifs_default_parameters():
-    motif_distances_ref = np.array(
-        [[0.0, 0.06315749, 0.25275899, 0.34087884, 0.3452315]]
-    )
-    motif_indices_ref = np.array([[19, 77, 63, 52, 71]])
-    motif_subspaces_ref = [np.array([2])]
+    motif_distances_ref = np.array([[0.0, 0.10660435, 0.27927693]])
+    motif_indices_ref = np.array([[19, 41, 34]])
+    motif_subspaces_ref = [np.array([1])]
     motif_mdls_ref = [
-        np.array([411.60964047, 423.69925001, 449.11032383, 476.95855027, 506.62406252])
+        np.array([411.60964047, 433.21928095, 429.77443751, 457.74925683, 477.80793557])
     ]
 
-    np.random.seed(0)
-    T = np.random.rand(500).reshape(5, 100)
+    pytest.fix_rng_state()
+    T = pytest.RNG.random(size=(5, 100))
 
     m = 5
     excl_zone = int(np.ceil(m / config.STUMPY_EXCL_ZONE_DENOM))
@@ -77,6 +75,8 @@ def test_aamp_mmotifs_default_parameters():
     npt.assert_array_almost_equal(motif_indices_ref, motif_indices_cmp)
     npt.assert_array_almost_equal(motif_subspaces_ref, motif_subspaces_cmp)
     npt.assert_array_almost_equal(motif_mdls_ref, motif_mdls_cmp)
+
+    pytest.unfix_rng_state()
 
 
 @pytest.mark.parametrize("T", test_data)

--- a/tests/test_aamp_motifs.py
+++ b/tests/test_aamp_motifs.py
@@ -73,10 +73,10 @@ def test_aamp_motifs_two_motifs():
     # fails, which is caused since one of the motifs is not repeated perfectly in T.
     pytest.fix_rng_state()
 
-    # The time series is random noise with two motifs for m=10:
+    # The time series is random noise with two motifs for m=20:
     # * (almost) identical step functions at indices 10, 110 and 210
     # * identical linear slopes at indices 70 and 170
-    T = pytest.RNG.normal(size=300)
+    T = pytest.RNG.random(size=300)
     m = 20
 
     T[10:30] = 1
@@ -90,14 +90,14 @@ def test_aamp_motifs_two_motifs():
     T[210:230] = 1
     T[212:228] = 2
     T[220] = 1.9
-    # naive.distance(naive.z_norm(T[10:30]), naive.z_norm(T[110:130])) = 0.47
-    # naive.distance(naive.z_norm(T[10:30]), naive.z_norm(T[210:230])) = 0.24
-    # naive.distance(naive.z_norm(T[110:130]), naive.z_norm(T[210:230])) = 0.72
+    # naive.distance(T[10:30], T[110:130]) == 16.65
+    # naive.distance(T[10:30], T[210:230]) == 0.1
+    # naive.distance(T[110:130], T[210:230]) == 16.68
     # Hence T[10:30] is the motif representative for this motif
 
     T[70:90] = np.arange(m) * 0.1
     T[170:190] = np.arange(m) * 0.1
-    # naive.distance(naive.z_norm(T[70:90]), naive.z_norm(T[170:190])) = 0.0
+    # naive.distance(T[70:90], T[170:190]) = 0.0
 
     max_motifs = 2
 

--- a/tests/test_aamp_motifs.py
+++ b/tests/test_aamp_motifs.py
@@ -15,7 +15,7 @@ test_data = [
         np.array([0.0, 1.0, 2.0]),
         np.array([0.1, 1.0, 2.0, 3.0, -1.0, 0.1, 1.0, 2.0, -0.5]),
     ),
-    (np.random.uniform(-1000, 1000, [8]), np.random.uniform(-1000, 1000, [64])),
+    (pytest.RNG.uniform(-1000, 1000, [8]), pytest.RNG.uniform(-1000, 1000, [64])),
 ]
 
 
@@ -71,12 +71,12 @@ def test_aamp_motifs_one_motif():
 def test_aamp_motifs_two_motifs():
     # Fix seed, because in some case motifs can be off by an index resulting in test
     # fails, which is caused since one of the motifs is not repeated perfectly in T.
-    np.random.seed(1234)
+    pytest.fix_rng_state()
 
     # The time series is random noise with two motifs for m=10:
     # * (almost) identical step functions at indices 10, 110 and 210
     # * identical linear slopes at indices 70 and 170
-    T = np.random.normal(size=300)
+    T = pytest.RNG.normal(size=300)
     m = 20
 
     T[10:30] = 1
@@ -125,7 +125,7 @@ def test_aamp_motifs_two_motifs():
     npt.assert_almost_equal(left_profile_values, right_distance_values, decimal=6)
 
     # Reset seed
-    np.random.seed(None)
+    pytest.unfix_rng_state()
 
 
 def test_aamp_naive_match_exact():

--- a/tests/test_aamp_ostinato.py
+++ b/tests/test_aamp_ostinato.py
@@ -20,65 +20,46 @@ def dask_cluster():
     cluster.close()
 
 
-@pytest.mark.parametrize(
-    "seed", np.random.choice(np.arange(10000), size=25, replace=False)
-)
-def test_random_ostinato(seed):
-    m = 50
-    np.random.seed(seed)
-    Ts = [np.random.rand(n) for n in [64, 128, 256]]
-
-    ref_radius, ref_Ts_idx, ref_subseq_idx = naive.aamp_ostinato(Ts, m)
-    comp_radius, comp_Ts_idx, comp_subseq_idx = aamp_ostinato(Ts, m)
-
-    npt.assert_almost_equal(ref_radius, comp_radius)
-    npt.assert_almost_equal(ref_Ts_idx, comp_Ts_idx)
-    npt.assert_almost_equal(ref_subseq_idx, comp_subseq_idx)
-
-
-@pytest.mark.parametrize("seed", [41, 88, 290, 292, 310, 328, 538, 556, 563, 570])
-def test_deterministic_ostinato(seed):
-    m = 50
-    np.random.seed(seed)
-    Ts = [np.random.rand(n) for n in [64, 128, 256]]
-
-    for p in [1.0, 2.0, 3.0]:
-        ref_radius, ref_Ts_idx, ref_subseq_idx = naive.aamp_ostinato(Ts, m, p=p)
-        comp_radius, comp_Ts_idx, comp_subseq_idx = aamp_ostinato(Ts, m, p=p)
-
-        npt.assert_almost_equal(ref_radius, comp_radius)
-        npt.assert_almost_equal(ref_Ts_idx, comp_Ts_idx)
-        npt.assert_almost_equal(ref_subseq_idx, comp_subseq_idx)
-
-
-@pytest.mark.parametrize(
-    "seed", np.random.choice(np.arange(10000), size=25, replace=False)
-)
-def test_random_ostinatoed(seed, dask_cluster):
-    with Client(dask_cluster) as dask_client:
+def test_random_ostinato():
+    for _ in range(25):
         m = 50
-        np.random.seed(seed)
-        Ts = [np.random.rand(n) for n in [64, 128, 256]]
+        Ts = [pytest.RNG.random(n) for n in [64, 128, 256]]
 
         ref_radius, ref_Ts_idx, ref_subseq_idx = naive.aamp_ostinato(Ts, m)
-        comp_radius, comp_Ts_idx, comp_subseq_idx = aamp_ostinatoed(dask_client, Ts, m)
+        comp_radius, comp_Ts_idx, comp_subseq_idx = aamp_ostinato(Ts, m)
 
         npt.assert_almost_equal(ref_radius, comp_radius)
         npt.assert_almost_equal(ref_Ts_idx, comp_Ts_idx)
         npt.assert_almost_equal(ref_subseq_idx, comp_subseq_idx)
 
 
-@pytest.mark.parametrize("seed", [41, 88, 290, 292, 310, 328, 538, 556, 563, 570])
-def test_deterministic_ostinatoed(seed, dask_cluster):
-    with Client(dask_cluster) as dask_client:
+def test_deterministic_ostinato():
+    pytest.fix_rng_state()
+
+    for _ in range(10):
         m = 50
-        np.random.seed(seed)
-        Ts = [np.random.rand(n) for n in [64, 128, 256]]
+        Ts = [pytest.RNG.random(n) for n in [64, 128, 256]]
 
         for p in [1.0, 2.0, 3.0]:
             ref_radius, ref_Ts_idx, ref_subseq_idx = naive.aamp_ostinato(Ts, m, p=p)
+            comp_radius, comp_Ts_idx, comp_subseq_idx = aamp_ostinato(Ts, m, p=p)
+
+            npt.assert_almost_equal(ref_radius, comp_radius)
+            npt.assert_almost_equal(ref_Ts_idx, comp_Ts_idx)
+            npt.assert_almost_equal(ref_subseq_idx, comp_subseq_idx)
+
+    pytest.unfix_rng_state()
+
+
+def test_random_ostinatoed(dask_cluster):
+    with Client(dask_cluster) as dask_client:
+        for _ in range(25):
+            m = 50
+            Ts = [pytest.RNG.random(n) for n in [64, 128, 256]]
+
+            ref_radius, ref_Ts_idx, ref_subseq_idx = naive.aamp_ostinato(Ts, m)
             comp_radius, comp_Ts_idx, comp_subseq_idx = aamp_ostinatoed(
-                dask_client, Ts, m, p=p
+                dask_client, Ts, m
             )
 
             npt.assert_almost_equal(ref_radius, comp_radius)
@@ -86,12 +67,34 @@ def test_deterministic_ostinatoed(seed, dask_cluster):
             npt.assert_almost_equal(ref_subseq_idx, comp_subseq_idx)
 
 
+@pytest.mark.parametrize("seed", [41, 88, 290, 292, 310, 328, 538, 556, 563, 570])
+def test_deterministic_ostinatoed(seed, dask_cluster):
+    pytest.fix_rng_state()
+
+    with Client(dask_cluster) as dask_client:
+        for _ in range(10):
+            m = 50
+            Ts = [pytest.RNG.random(n) for n in [64, 128, 256]]
+
+            for p in [1.0, 2.0, 3.0]:
+                ref_radius, ref_Ts_idx, ref_subseq_idx = naive.aamp_ostinato(Ts, m, p=p)
+                comp_radius, comp_Ts_idx, comp_subseq_idx = aamp_ostinatoed(
+                    dask_client, Ts, m, p=p
+                )
+
+                npt.assert_almost_equal(ref_radius, comp_radius)
+                npt.assert_almost_equal(ref_Ts_idx, comp_Ts_idx)
+                npt.assert_almost_equal(ref_subseq_idx, comp_subseq_idx)
+
+    pytest.unfix_rng_state()
+
+
 def test_input_not_overwritten_ostinato():
     # aamp_ostinato preprocesses its input, a list of time series,
     # by replacing nan value with 0 in each time series.
     # This test ensures that the original input is not overwritten
     m = 50
-    Ts = [np.random.rand(n) for n in [64, 128, 256]]
+    Ts = [pytest.RNG.random(n) for n in [64, 128, 256]]
     for T in Ts:
         T[0] = np.nan
 
@@ -107,7 +110,7 @@ def test_input_not_overwritten_ostinato():
 def test_extract_several_consensus_ostinato():
     # This test is to further ensure that the function `aamp_ostinato`
     # does not tamper with the original data.
-    Ts = [np.random.rand(n) for n in [256, 512, 1024]]
+    Ts = [pytest.RNG.random(n) for n in [256, 512, 1024]]
     Ts_ref = [T.copy() for T in Ts]
     Ts_comp = [T.copy() for T in Ts]
 
@@ -145,7 +148,7 @@ def test_input_not_overwritten_ostinatoed(dask_cluster):
     # This test ensures that the original input is not overwritten
     with Client(dask_cluster) as dask_client:
         m = 50
-        Ts = [np.random.rand(n) for n in [64, 128, 256]]
+        Ts = [pytest.RNG.random(n) for n in [64, 128, 256]]
         for T in Ts:
             T[0] = np.nan
 
@@ -163,7 +166,7 @@ def test_input_not_overwritten_ostinatoed(dask_cluster):
 def test_extract_several_consensus_ostinatoed(dask_cluster):
     # This test is to further ensure that the function `ostinatoed`
     # does not tamper with the original data.
-    Ts = [np.random.rand(n) for n in [256, 512, 1024]]
+    Ts = [pytest.RNG.random(n) for n in [256, 512, 1024]]
     Ts_ref = [T.copy() for T in Ts]
     Ts_comp = [T.copy() for T in Ts]
 

--- a/tests/test_aamp_ostinato.py
+++ b/tests/test_aamp_ostinato.py
@@ -67,8 +67,7 @@ def test_random_ostinatoed(dask_cluster):
             npt.assert_almost_equal(ref_subseq_idx, comp_subseq_idx)
 
 
-@pytest.mark.parametrize("seed", [41, 88, 290, 292, 310, 328, 538, 556, 563, 570])
-def test_deterministic_ostinatoed(seed, dask_cluster):
+def test_deterministic_ostinatoed(dask_cluster):
     pytest.fix_rng_state()
 
     with Client(dask_cluster) as dask_client:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1906,7 +1906,7 @@ def test_update_incremental_PI_egressTrue_MemoryCheck():
     # a new data point is appended. However, the updated matrix profile index for the
     # middle subsequence `s` should still refer to  the first subsequence in
     # the historical data.
-
+    pytest.fix_rng_state()
     T = pytest.RNG.random(64)
     m = 3
     excl_zone = int(np.ceil(m / config.STUMPY_EXCL_ZONE_DENOM))
@@ -1964,6 +1964,8 @@ def test_update_incremental_PI_egressTrue_MemoryCheck():
 
         npt.assert_almost_equal(P_ref, P_comp)
         npt.assert_almost_equal(I_ref, I_comp)
+
+    pytest.unfix_rng_state()
 
 
 def test_check_self_join():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -149,7 +149,7 @@ test_data = [
         np.array([9, 8100, -60], dtype=np.float64),
         np.array([584, -11, 23, 79, 1001], dtype=np.float64),
     ),
-    (np.random.uniform(-1000, 1000, [8]), np.random.uniform(-1000, 1000, [64])),
+    (pytest.RNG.uniform(-1000, 1000, size=8), pytest.RNG.uniform(-1000, 1000, size=64)),
 ]
 
 n = list(range(1, 50))
@@ -158,11 +158,11 @@ n = list(range(1, 50))
 def test_check_bad_dtype():
     for dtype in [np.int32, np.int64, np.float32]:
         with pytest.raises(TypeError):
-            core.check_dtype(np.random.rand(10).astype(dtype))
+            core.check_dtype(pytest.RNG.random(10).astype(dtype))
 
 
 def test_check_dtype_float64():
-    assert core.check_dtype(np.random.rand(10))
+    assert core.check_dtype(pytest.RNG.random(10))
 
 
 def test_get_max_window_size():
@@ -196,7 +196,7 @@ def test_check_max_window_size():
 def test_check_window_size_excl_zone():
     # To ensure warning is raised if there is at least one subsequence
     # that has no non-trivial neighbor
-    T = np.random.rand(10)
+    T = pytest.RNG.random(10)
     m = 7
 
     # For `len(T) == 10` and `m == 7`, the `excl_zone` is ceil(m / 4) = 2.
@@ -223,7 +223,7 @@ def test_sliding_dot_product(Q, T):
 
 
 def test_welford_nanvar():
-    T = np.random.rand(64)
+    T = pytest.RNG.random(64)
     m = 10
 
     ref_var = np.nanvar(T)
@@ -245,7 +245,7 @@ def test_welford_nanvar_catastrophic_cancellation():
 
 
 def test_welford_nanvar_nan():
-    T = np.random.rand(64)
+    T = pytest.RNG.random(64)
     m = 10
 
     T[1] = np.nan
@@ -262,7 +262,7 @@ def test_welford_nanvar_nan():
 
 
 def test_welford_nanstd():
-    T = np.random.rand(64)
+    T = pytest.RNG.random(64)
     m = 10
 
     ref_var = np.nanstd(T)
@@ -275,7 +275,7 @@ def test_welford_nanstd():
 
 
 def test_rolling_std_1d():
-    a = np.random.rand(64)
+    a = pytest.RNG.random(64)
     for w in range(3, 6):
         ref_std = naive.rolling_nanstd(a, w)
 
@@ -291,7 +291,7 @@ def test_rolling_std_1d():
 def test_rolling_std_2d():
     w = 5
     for n_rows in range(1, 4):
-        a = np.random.rand(n_rows * 64).reshape(n_rows, 64)
+        a = pytest.RNG.random(size=(n_rows, 64))
         ref_std = naive.rolling_nanstd(a, w)
 
         # welford = False (default)
@@ -304,7 +304,7 @@ def test_rolling_std_2d():
 
 
 def test_rolling_nanmin_1d():
-    T = np.random.rand(64)
+    T = pytest.RNG.random(64)
     for m in range(1, 12):
         ref_min = np.nanmin(T)
         comp_min = core._rolling_nanmin_1d(T)
@@ -316,7 +316,7 @@ def test_rolling_nanmin_1d():
 
 
 def test_rolling_nanmin():
-    T = np.random.rand(64)
+    T = pytest.RNG.random(64)
     for m in range(1, 12):
         ref_min = np.nanmin(core.rolling_window(T, m), axis=1)
         comp_min = core.rolling_nanmin(T, m)
@@ -328,7 +328,7 @@ def test_rolling_nanmin():
 
 
 def test_rolling_nanmax_1d():
-    T = np.random.rand(64)
+    T = pytest.RNG.random(64)
     for m in range(1, 12):
         ref_max = np.nanmax(T)
         comp_max = core._rolling_nanmax_1d(T)
@@ -340,7 +340,7 @@ def test_rolling_nanmax_1d():
 
 
 def test_rolling_nanmax():
-    T = np.random.rand(64)
+    T = pytest.RNG.random(64)
     for m in range(1, 12):
         ref_max = np.nanmax(core.rolling_window(T, m), axis=1)
         comp_max = core.rolling_nanmax(T, m)
@@ -402,8 +402,8 @@ def test_compute_mean_std_chunked_many(Q, T):
 def test_compute_mean_std_multidimensional(Q, T):
     m = Q.shape[0]
 
-    Q = np.array([Q, np.random.uniform(-1000, 1000, [Q.shape[0]])])
-    T = np.array([T, T, np.random.uniform(-1000, 1000, [T.shape[0]])])
+    Q = np.array([Q, pytest.RNG.uniform(-1000, 1000, size=Q.shape[0])])
+    T = np.array([T, T, pytest.RNG.uniform(-1000, 1000, size=T.shape[0])])
 
     ref_μ_Q, ref_σ_Q = naive_compute_mean_std_multidimensional(Q, m)
     ref_M_T, ref_Σ_T = naive_compute_mean_std_multidimensional(T, m)
@@ -420,8 +420,8 @@ def test_compute_mean_std_multidimensional(Q, T):
 def test_compute_mean_std_multidimensional_chunked(Q, T):
     m = Q.shape[0]
 
-    Q = np.array([Q, np.random.uniform(-1000, 1000, [Q.shape[0]])])
-    T = np.array([T, T, np.random.uniform(-1000, 1000, [T.shape[0]])])
+    Q = np.array([Q, pytest.RNG.uniform(-1000, 1000, size=Q.shape[0])])
+    T = np.array([T, T, pytest.RNG.uniform(-1000, 1000, size=T.shape[0])])
 
     with patch("stumpy.config.STUMPY_MEAN_STD_NUM_CHUNKS", 2):
         ref_μ_Q, ref_σ_Q = naive_compute_mean_std_multidimensional(Q, m)
@@ -439,8 +439,8 @@ def test_compute_mean_std_multidimensional_chunked(Q, T):
 def test_compute_mean_std_multidimensional_chunked_many(Q, T):
     m = Q.shape[0]
 
-    Q = np.array([Q, np.random.uniform(-1000, 1000, [Q.shape[0]])])
-    T = np.array([T, T, np.random.uniform(-1000, 1000, [T.shape[0]])])
+    Q = np.array([Q, pytest.RNG.uniform(-1000, 1000, size=Q.shape[0])])
+    T = np.array([T, T, pytest.RNG.uniform(-1000, 1000, size=T.shape[0])])
 
     with patch("stumpy.config.STUMPY_MEAN_STD_NUM_CHUNKS", 128):
         ref_μ_Q, ref_σ_Q = naive_compute_mean_std_multidimensional(Q, m)
@@ -933,7 +933,7 @@ def test_preprocess_diagonal():
 
 
 def test_replace_distance():
-    right = np.random.rand(30).reshape(5, 6)
+    right = pytest.RNG.random(size=(5, 6))
     left = right.copy()
     np.fill_diagonal(right, config.STUMPY_MAX_DISTANCE - 1e-9)
     np.fill_diagonal(left, np.inf)
@@ -941,7 +941,7 @@ def test_replace_distance():
 
 
 def test_array_to_temp_file():
-    left = np.random.rand()
+    left = pytest.RNG.random()
     fname = core.array_to_temp_file(left)
     right = np.load(fname, allow_pickle=False)
     os.remove(fname)
@@ -953,7 +953,7 @@ def test_count_diagonal_ndist():
     for n_A in range(10, 15):
         for n_B in range(10, 15):
             for m in range(3, 6):
-                diags = np.random.permutation(
+                diags = pytest.RNG.permutation(
                     range(-(n_A - m + 1) + 1, n_B - m + 1)
                 ).astype(np.int64)
                 ones_matrix = np.ones((n_A - m + 1, n_B - m + 1), dtype=np.int64)
@@ -1122,12 +1122,12 @@ def test_get_mask_slices():
 def test_idx_to_mp():
     n = 64
     m = 5
-    T = np.random.rand(n)
+    T = pytest.RNG.random(n)
     # T[1] = np.nan
     # T[8] = np.inf
     # T[:] = 1.0
     l = n - m + 1
-    I = np.random.randint(0, l, l)
+    I = pytest.RNG.integers(0, l, l)
 
     # `normalize == True` and `T_subseq_isconstant` is None (default)
     ref_mp = naive_idx_to_mp(I, T, m)
@@ -1135,7 +1135,7 @@ def test_idx_to_mp():
     npt.assert_almost_equal(ref_mp, cmp_mp)
 
     # `normalize == True` and `T_subseq_isconstant` is provided
-    T_subseq_isconstant = np.random.choice([True, False], l, replace=True)
+    T_subseq_isconstant = pytest.RNG.choice([True, False], l, replace=True)
     ref_mp = naive_idx_to_mp(I, T, m, T_subseq_isconstant=T_subseq_isconstant)
     cmp_mp = core._idx_to_mp(I, T, m, T_subseq_isconstant=T_subseq_isconstant)
     npt.assert_almost_equal(ref_mp, cmp_mp)
@@ -1186,7 +1186,7 @@ def test_bfs_indices_fill_value(n):
 
 
 def test_select_P_ABBA_val_inf():
-    P_ABBA = np.random.rand(10)
+    P_ABBA = pytest.RNG.random(10)
     k = 2
     P_ABBA[k:] = np.inf
     p_abba = P_ABBA.copy()
@@ -1202,13 +1202,13 @@ def test_merge_topk_PI_without_overlap():
     # is no overlap between row IA[i] and row IB[i].
     n = 50
     for k in range(1, 6):
-        PA = np.random.rand(n * k).reshape(n, k)
+        PA = pytest.RNG.random(size=(n, k))
         PA[:, :] = np.sort(PA, axis=1)  # sorting each row separately
 
-        PB = np.random.rand(n * k).reshape(n, k)
-        col_idx = np.random.randint(0, k, size=n)
+        PB = pytest.RNG.random(size=(n, k))
+        col_idx = pytest.RNG.integers(0, k, size=n)
         for i in range(n):  # creating ties between values of PA and PB
-            val = np.random.choice(PA[i], size=1, replace=False)
+            val = pytest.RNG.choice(PA[i], size=1, replace=False)
             PB[i, col_idx[i]] = val.item()
         PB[:, :] = np.sort(PB, axis=1)  # sorting each row separately
 
@@ -1235,17 +1235,17 @@ def test_merge_topk_PI_with_overlap():
     for k in range(1, 6):
         # note: we do not have overlap issue when k is 1. The `k=1` is considered
         # for the sake of consistency with the `without-overlap` test function.
-        PA = np.random.rand(n * k).reshape(n, k)
-        PB = np.random.rand(n * k).reshape(n, k)
+        PA = pytest.RNG.random(size=(n, k))
+        PB = pytest.RNG.random(size=(n, k))
 
         IA = np.arange(n * k).reshape(n, k)
         IB = IA + n * k
 
-        num_overlaps = np.random.randint(1, k + 1, size=n)
+        num_overlaps = pytest.RNG.integers(1, k + 1, size=n)
         for i in range(n):
             # create overlaps
-            col_IDX = np.random.choice(np.arange(k), num_overlaps[i], replace=False)
-            imprecision = np.random.uniform(low=-1e-06, high=1e-06, size=len(col_IDX))
+            col_IDX = pytest.RNG.choice(np.arange(k), num_overlaps[i], replace=False)
+            imprecision = pytest.RNG.uniform(low=-1e-06, high=1e-06, size=len(col_IDX))
             PB[i, col_IDX] = PA[i, col_IDX] + imprecision
             IB[i, col_IDX] = IA[i, col_IDX]
 
@@ -1274,15 +1274,15 @@ def test_merge_topk_PI_with_overlap():
 def test_merge_topk_PI_with_1D_input():
     # including some overlaps randomly
     n = 50
-    PA = np.random.rand(n)
-    PB = np.random.rand(n)
+    PA = pytest.RNG.random(n)
+    PB = pytest.RNG.random(n)
 
     IA = np.arange(n)
     IB = IA + n
 
-    n_overlaps = np.random.randint(1, n + 1)
-    IDX_rows_with_overlaps = np.random.choice(np.arange(n), n_overlaps, replace=False)
-    imprecision = np.random.uniform(low=-1e-06, high=1e-06, size=n_overlaps)
+    n_overlaps = pytest.RNG.integers(1, n + 1)
+    IDX_rows_with_overlaps = pytest.RNG.choice(np.arange(n), n_overlaps, replace=False)
+    imprecision = pytest.RNG.uniform(low=-1e-06, high=1e-06, size=n_overlaps)
     PB[IDX_rows_with_overlaps] = PA[IDX_rows_with_overlaps] + imprecision
     IB[IDX_rows_with_overlaps] = IA[IDX_rows_with_overlaps]
 
@@ -1327,13 +1327,13 @@ def test_merge_topk_ρI_without_overlap():
     # is no overlap between row IA[i] and row IB[i].
     n = 50
     for k in range(1, 6):
-        ρA = np.random.rand(n * k).reshape(n, k)
+        ρA = pytest.RNG.random(size=(n, k))
         ρA[:, :] = np.sort(ρA, axis=1)  # sorting each row separately
 
-        ρB = np.random.rand(n * k).reshape(n, k)
-        col_idx = np.random.randint(0, k, size=n)
+        ρB = pytest.RNG.random(size=(n, k))
+        col_idx = pytest.RNG.integers(0, k, size=n)
         for i in range(n):  # creating ties between values of PA and PB
-            val = np.random.choice(ρA[i], size=1, replace=False)
+            val = pytest.RNG.choice(ρA[i], size=1, replace=False)
             ρB[i, col_idx[i]] = val.item()
         ρB[:, :] = np.sort(ρB, axis=1)  # sorting each row separately
 
@@ -1360,17 +1360,17 @@ def test_merge_topk_ρI_with_overlap():
     for k in range(1, 6):
         # note: we do not have overlap issue when k is 1. The `k=1` is considered
         # for the sake of consistency with the `without-overlap` test function.
-        ρA = np.random.rand(n * k).reshape(n, k)
-        ρB = np.random.rand(n * k).reshape(n, k)
+        ρA = pytest.RNG.random(size=(n, k))
+        ρB = pytest.RNG.random(size=(n, k))
 
         IA = np.arange(n * k).reshape(n, k)
         IB = IA + n * k
 
-        num_overlaps = np.random.randint(1, k + 1, size=n)
+        num_overlaps = pytest.RNG.integers(1, k + 1, size=n)
         for i in range(n):
             # create overlaps
-            col_IDX = np.random.choice(np.arange(k), num_overlaps[i], replace=False)
-            imprecision = np.random.uniform(low=-1e-06, high=1e-06, size=len(col_IDX))
+            col_IDX = pytest.RNG.choice(np.arange(k), num_overlaps[i], replace=False)
+            imprecision = pytest.RNG.uniform(low=-1e-06, high=1e-06, size=len(col_IDX))
             ρB[i, col_IDX] = ρA[i, col_IDX] + imprecision
             IB[i, col_IDX] = IA[i, col_IDX]
 
@@ -1399,15 +1399,15 @@ def test_merge_topk_ρI_with_overlap():
 def test_merge_topk_ρI_with_1D_input():
     # including some overlaps randomly
     n = 50
-    ρA = np.random.rand(n)
-    ρB = np.random.rand(n)
+    ρA = pytest.RNG.random(n)
+    ρB = pytest.RNG.random(n)
 
     IA = np.arange(n)
     IB = IA + n
 
-    n_overlaps = np.random.randint(1, n + 1)
-    IDX_rows_with_overlaps = np.random.choice(np.arange(n), n_overlaps, replace=False)
-    imprecision = np.random.uniform(low=-1e-06, high=1e-06, size=n_overlaps)
+    n_overlaps = pytest.RNG.integers(1, n + 1)
+    IDX_rows_with_overlaps = pytest.RNG.choice(np.arange(n), n_overlaps, replace=False)
+    imprecision = pytest.RNG.uniform(low=-1e-06, high=1e-06, size=n_overlaps)
     ρB[IDX_rows_with_overlaps] = ρA[IDX_rows_with_overlaps] + imprecision
     IB[IDX_rows_with_overlaps] = IA[IDX_rows_with_overlaps]
 
@@ -1449,12 +1449,12 @@ def test_merge_topk_ρI_with_1D_input_hardcoded():
 
 def test_shift_insert_at_index():
     for k in range(1, 6):
-        a = np.random.rand(k)
+        a = pytest.RNG.random(k)
         ref = np.empty(k, dtype=np.float64)
         comp = np.empty(k, dtype=np.float64)
 
         indices = np.arange(k + 1)
-        values = np.random.rand(k + 1)
+        values = pytest.RNG.random(k + 1)
 
         # test shift = "right"
         for idx, v in zip(indices, values):
@@ -1483,13 +1483,13 @@ def test_shift_insert_at_index():
 
 def test_check_P():
     with pytest.raises(ValueError):
-        core._check_P(np.random.rand(10).reshape(2, 5))
+        core._check_P(pytest.RNG.random(size=(2, 5)))
 
 
 def test_find_matches_all():
     # max_matches: None, i.e. find all matches
     max_distance = np.inf
-    D = np.random.rand(64)
+    D = pytest.RNG.random(64)
     for excl_zone in range(3):
         ref = naive.find_matches(D, excl_zone, max_distance, max_matches=None)
         comp = core._find_matches(D, excl_zone, max_distance, max_matches=None)
@@ -1499,9 +1499,9 @@ def test_find_matches_all():
 
 def test_find_matches_maxmatch():
     max_distance = np.inf
-    D = np.random.rand(64)
+    D = pytest.RNG.random(64)
     for excl_zone in range(3):
-        max_matches = np.random.randint(0, 100)
+        max_matches = pytest.RNG.integers(0, 100)
         ref = naive.find_matches(D, excl_zone, max_distance, max_matches)
         comp = core._find_matches(D, excl_zone, max_distance, max_matches)
 
@@ -1524,11 +1524,11 @@ def test_gpu_searchsorted():
         device_bfs = cuda.to_device(core._bfs_indices(k, fill_value=-1))
         nlevel = np.floor(np.log2(k) + 1).astype(np.int64)
 
-        A = np.sort(np.random.rand(n, k), axis=1)
+        A = np.sort(pytest.RNG.random(n, k), axis=1)
         device_A = cuda.to_device(A)
 
-        V[:] = np.random.rand(n)
-        for i, idx in enumerate(np.random.choice(np.arange(n), size=k, replace=False)):
+        V[:] = pytest.RNG.random(n)
+        for i, idx in enumerate(pytest.RNG.choice(np.arange(n), size=k, replace=False)):
             V[idx] = A[idx, i]  # create ties
         device_V = cuda.to_device(V)
 
@@ -1563,7 +1563,7 @@ def test_client_to_func():
 
 
 def test_apply_include():
-    D = np.random.uniform(-1000, 1000, [10, 20]).astype(np.float64)
+    D = pytest.RNG.uniform(-1000, 1000, [10, 20]).astype(np.float64)
     ref_D = np.empty(D.shape)
     comp_D = np.empty(D.shape)
     for width in range(D.shape[0]):
@@ -1698,7 +1698,7 @@ def test_process_isconstant_1d():
     m = 8
 
     # case 1: without nan
-    T = np.random.rand(n)
+    T = pytest.RNG.random(n)
 
     T_subseq_isconstant_ref = naive.rolling_isconstant(T, m, isconstant_custom_func)
     T_subseq_isconstant_comp = core.process_isconstant(T, m, isconstant_custom_func)
@@ -1706,10 +1706,10 @@ def test_process_isconstant_1d():
     npt.assert_array_equal(T_subseq_isconstant_ref, T_subseq_isconstant_comp)
 
     # case 2: with nan
-    T = np.random.rand(n)
-    idx = np.random.randint(n)
+    T = pytest.RNG.random(n)
+    idx = pytest.RNG.integers(n)
     T[idx] = np.nan
-    T_subseq_isconstant = np.random.choice([True, False], n - m + 1, replace=True)
+    T_subseq_isconstant = pytest.RNG.choice([True, False], n - m + 1, replace=True)
 
     T_subseq_isfinite = core.rolling_isfinite(T, m)
 
@@ -1729,11 +1729,11 @@ def test_process_isconstant_2d():
     d = 3
 
     # case 1: without nan
-    T = np.random.rand(d, n)
+    T = pytest.RNG.random(size=(d, n))
     T_subseq_isconstant = [
         None,
         isconstant_custom_func,
-        np.random.choice([True, False], n - m + 1, replace=True),
+        pytest.RNG.choice([True, False], n - m + 1, replace=True),
     ]
 
     T_subseq_isconstant_ref = np.array(
@@ -1745,8 +1745,8 @@ def test_process_isconstant_2d():
     npt.assert_array_equal(T_subseq_isconstant_ref, T_subseq_isconstant_comp)
 
     # case 2: with nan
-    T = np.random.rand(d, n)
-    i, j = np.random.choice(np.arange(n - m + 1), size=2, replace=False)
+    T = pytest.RNG.random(size=(d, n))
+    i, j = pytest.RNG.choice(np.arange(n - m + 1), size=2, replace=False)
     T[-1, i : i + m] = 0.0
     T[-1, j : j + m] = 0.0
     T[-1, j] = np.nan
@@ -1779,7 +1779,7 @@ def test_process_isconstant_1d_default():
     m = 8
 
     # case 1: without nan
-    T = np.random.rand(n)
+    T = pytest.RNG.random(n)
     T[:m] = 0.5  # constant subsequence
 
     T_subseq_isconstant_ref = naive.rolling_isconstant(T, m, a_subseq_isconstant=None)
@@ -1788,7 +1788,7 @@ def test_process_isconstant_1d_default():
     npt.assert_array_equal(T_subseq_isconstant_ref, T_subseq_isconstant_comp)
 
     # case 2: with nan
-    T = np.random.rand(n)
+    T = pytest.RNG.random(n)
     T[:m] = 0.5  # constant subsequence
     T[-m:] = np.nan  # non-finite subsequence
 
@@ -1802,8 +1802,8 @@ def test_update_incremental_PI_egressFalse():
     # This tests the function `core._update_incremental_PI`
     # when `egress` is False, meaning new data point is being
     # appended to the historical data.
-    T = np.random.rand(64)
-    t = np.random.rand()  # new datapoint
+    T = pytest.RNG.random(64)
+    t = pytest.RNG.random()  # new datapoint
     T_new = np.append(T, t)
 
     m = 3
@@ -1844,8 +1844,8 @@ def test_update_incremental_PI_egressFalse():
 
 
 def test_update_incremental_PI_egressTrue():
-    T = np.random.rand(64)
-    t = np.random.rand()  # new data point
+    T = pytest.RNG.random(64)
+    t = pytest.RNG.random()  # new data point
     m = 3
     excl_zone = int(np.ceil(m / config.STUMPY_EXCL_ZONE_DENOM))
 
@@ -1906,19 +1906,17 @@ def test_update_incremental_PI_egressTrue_MemoryCheck():
     # a new data point is appended. However, the updated matrix profile index for the
     # middle subsequence `s` should still refer to  the first subsequence in
     # the historical data.
-    seed = 0
-    np.random.seed(seed)
 
-    T = np.random.rand(64)
+    T = pytest.RNG.random(64)
     m = 3
     excl_zone = int(np.ceil(m / config.STUMPY_EXCL_ZONE_DENOM))
 
-    s = np.random.rand(m)
+    s = pytest.RNG.random(m)
     T[:m] = s
     T[30 : 30 + m] = s
     T[-m:] = s
 
-    t = np.random.rand()  # new data point
+    t = pytest.RNG.random()  # new data point
     T_with_t = np.append(T, t)
 
     # In egress=True mode, a new data point, t, is being appended

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1524,7 +1524,7 @@ def test_gpu_searchsorted():
         device_bfs = cuda.to_device(core._bfs_indices(k, fill_value=-1))
         nlevel = np.floor(np.log2(k) + 1).astype(np.int64)
 
-        A = np.sort(pytest.RNG.random(n, k), axis=1)
+        A = np.sort(pytest.RNG.random(size=(n, k)), axis=1)
         device_A = cuda.to_device(A)
 
         V[:] = pytest.RNG.random(n)


### PR DESCRIPTION
See #1112 

# Pull Request Checklist

Below is a simple checklist but please do not hesitate to ask for assistance!

- [x] Fork, clone, and checkout the newest version of the code
- [x] Create a new branch
- [x] Make necessary code changes
- [x] Install `black` (i.e., `python -m pip install black` or `conda install -c conda-forge black`)
- [x] Install `flake8` (i.e., `python -m pip install flake8` or `conda install -c conda-forge flake8`)
- [x] Install `pytest-cov` (i.e., `python -m pip install pytest-cov` or `conda install -c conda-forge pytest-cov`)
- [x] Run `black --exclude=".*\.ipynb" --extend-exclude=".venv" --diff ./` in the root stumpy directory
- [x] Run `flake8 --extend-exclude=.venv ./` in the root stumpy directory
- [x] Run `./setup.sh dev && ./test.sh` in the root stumpy directory
- [x] Reference a Github issue (and create one if one doesn't already exist)

# To Do List
1. Search for `np.random`
2. Replace `np.random.rand(x)` with `pytest.RNG.random(x)`
3. Replace `np.random.rand(x*y).reshape(x,y)` with `pytest.RNG.random(size=(x, y))`
4. Replace `np.random.uniform(x, y, [z])` with `pytest.RNG.uniform(x, y, size=z)`
5. Replace `np.random.permutation([x, y, z])` with `pytest.RNG.permutation([x, y, z])`
6. Replace `np.random.randint(x, y, z)` with `pytest.RNG.integers(x, y, z)`
7. Replace `np.random.choice([x, y], l, replace=True)` with `pytest.RNG.choice([x, y], l, replace=True)`
8. Replace `np.random.normal(size=x)` with` pytest.RNG.normal(size=x)`
9. Replace all `np.random` from docstrings, README, tutorials, etc