### PR TITLE
Add pyfftw sdp

### DIFF
--- a/stumpy/sdp.py
+++ b/stumpy/sdp.py
@@ -148,10 +148,19 @@ class _PYFFTW_SLIDING_DOT_PRODUCT:
         Cache of FFTW inverse transform objects with
         (next_fast_n, n_threads, planning_flag) as lookup keys.
 
+    Methods
+    -------
+    __call__(Q, T, n_threads=1, planning_flag="FFTW_ESTIMATE")
+        Compute the sliding dot product between `Q` and `T` using FFTW
+        via pyfftw, and cache FFTW objects if not already cached.
+
     Notes
     -----
     The class maintains internal caches of FFTW objects to avoid redundant planning
     operations when called multiple times with similar-sized inputs and parameters.
+    When `planning_flag=="FFTW_ESTIMATE"`, there will be no planning operation.
+    However, caching FFTW objects is still beneficial as the overhead of creating
+    those objects can be avoided in subsequent calls.
 
     Examples
     --------

--- a/stumpy/sdp.py
+++ b/stumpy/sdp.py
@@ -282,7 +282,7 @@ class _PYFFTW_SLIDING_DOT_PRODUCT:
             rfft_obj.update_arrays(real_arr, complex_arr)
             irfft_obj.update_arrays(complex_arr, real_arr)
 
-        # Compute the (circular) convolution between T and Q[::-1], 
+        # Compute the (circular) convolution between T and Q[::-1],
         # each zero-padded to length `next_fast_n` by performing
         # the following three steps:
 

--- a/stumpy/sdp.py
+++ b/stumpy/sdp.py
@@ -294,7 +294,7 @@ class _PYFFTW_SLIDING_DOT_PRODUCT:
         return real_arr[m - 1 : n]
 
 
-if FFTW_IS_AVAILABLE:
+if FFTW_IS_AVAILABLE:  # pragma: no cover
     _pyfftw_sliding_dot_product = _PYFFTW_SLIDING_DOT_PRODUCT(max_n=2**20)
 
 

--- a/stumpy/sdp.py
+++ b/stumpy/sdp.py
@@ -293,7 +293,7 @@ class _PYFFTW_SLIDING_DOT_PRODUCT:
         rfft_obj.input_array[:n] = T
         rfft_obj.input_array[n:] = 0.0
         rfft_obj.execute()
-        rfft_of_T = rfft_obj.output_array.copy()
+        rfft_T = rfft_obj.output_array.copy()
 
         # Step 2
         # Compute RFFT of Q (reversed, scaled, and zero-padded)
@@ -302,11 +302,11 @@ class _PYFFTW_SLIDING_DOT_PRODUCT:
         np.multiply(Q[::-1], 1.0 / next_fast_n, out=rfft_obj.input_array[:m])
         rfft_obj.input_array[m:] = 0.0
         rfft_obj.execute()
-        rfft_of_Q = rfft_obj.output_array
+        rfft_Q = rfft_obj.output_array
 
         # Step 3
         # Convert back to time domain by taking the inverse RFFT
-        np.multiply(rfft_of_T, rfft_of_Q, out=irfft_obj.input_array)
+        np.multiply(rfft_T, rfft_Q, out=irfft_obj.input_array)
         irfft_obj.execute()
 
         return irfft_obj.output_array[m - 1 : n]  # valid portion

--- a/stumpy/sdp.py
+++ b/stumpy/sdp.py
@@ -282,7 +282,7 @@ class _PYFFTW_SLIDING_DOT_PRODUCT:
             rfft_obj.update_arrays(real_arr, complex_arr)
             irfft_obj.update_arrays(complex_arr, real_arr)
 
-        # Compute the circular convolution between T and Q[::-1]
+        # Compute the (circular) convolution between T and Q[::-1]
         # using FFT, and then take the relevant slice of the output
 
         # Step 1

--- a/stumpy/sdp.py
+++ b/stumpy/sdp.py
@@ -6,6 +6,13 @@ from scipy.signal import convolve, oaconvolve
 
 from . import config
 
+try:  # pragma: no cover
+    import pyfftw
+
+    FFTW_IS_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    FFTW_IS_AVAILABLE = False
+
 
 @njit(fastmath=config.STUMPY_FASTMATH_TRUE)
 def _njit_sliding_dot_product(Q, T):
@@ -107,6 +114,188 @@ def _pocketfft_sliding_dot_product(Q, T):
     fft_2d = r2c(True, tmp, axis=-1)
 
     return c2r(False, np.multiply(fft_2d[0], fft_2d[1]), n=next_fast_n)[m - 1 : n]
+
+
+class _PYFFTW_SLIDING_DOT_PRODUCT:
+    """
+    A class to compute the sliding dot product using FFTW via pyfftw.
+
+    This class uses FFTW (via pyfftw) to efficiently compute the sliding dot product
+    between a query sequence Q and a time series T. It preallocates arrays and caches
+    FFTW objects to optimize repeated computations with similar-sized inputs.
+
+    Parameters
+    ----------
+    max_n : int, default=2**20
+        Maximum length to preallocate arrays for. This will be the size of the
+        real-valued array. A complex-valued array of size `1 + (max_n // 2)`
+        will also be preallocated. If inputs exceed this size, arrays will be
+        reallocated to accommodate larger sizes.
+
+    Attributes
+    ----------
+    real_arr : pyfftw.empty_aligned
+        Preallocated real-valued array for FFTW computations.
+
+    complex_arr : pyfftw.empty_aligned
+        Preallocated complex-valued array for FFTW computations.
+
+    rfft_objects : dict
+        Cache of FFTW forward transform objects, keyed by
+        (next_fast_n, n_threads, planning_flag).
+
+    irfft_objects : dict
+        Cache of FFTW inverse transform objects, keyed by
+        (next_fast_n, n_threads, planning_flag).
+
+    Notes
+    -----
+    The class maintains internal caches of FFTW objects to avoid redundant planning
+    operations when called multiple times with similar-sized inputs and parameters.
+
+    Examples
+    --------
+    >>> sdp_obj = _PYFFTW_SLIDING_DOT_PRODUCT(max_n=1000)
+    >>> Q = np.array([1, 2, 3])
+    >>> T = np.array([4, 5, 6, 7, 8])
+    >>> result = sdp_obj(Q, T)
+
+    References
+    ----------
+    `FFTW documentation <http://www.fftw.org/>`__
+
+    `pyfftw documentation <https://pyfftw.readthedocs.io/>`__
+    """
+
+    def __init__(self, max_n=2**20):
+        """
+        Initialize the `_PYFFTW_SLIDING_DOT_PRODUCT` object, which can be called
+        to compute the sliding dot product using FFTW via pyfftw.
+
+        Parameters
+        ----------
+        max_n : int, default=2**20
+            Maximum length to preallocate arrays for. This will be the size of the
+            real-valued array. A complex-valued array of size `1 + (max_n // 2)`
+            will also be preallocated.
+
+        Returns
+        -------
+        None
+        """
+        # Preallocate arrays
+        self.real_arr = pyfftw.empty_aligned(max_n, dtype="float64")
+        self.complex_arr = pyfftw.empty_aligned(1 + (max_n // 2), dtype="complex128")
+
+        # Store FFTW objects, keyed by (next_fast_n, n_threads, planning_flag)
+        self.rfft_objects = {}
+        self.irfft_objects = {}
+
+    def __call__(self, Q, T, n_threads=1, planning_flag="FFTW_ESTIMATE"):
+        """
+        Compute the sliding dot product between `Q` and `T` using FFTW via pyfftw,
+        and cache FFTW objects if not already cached.
+
+        Parameters
+        ----------
+        Q : numpy.ndarray
+            Query array or subsequence.
+
+        T : numpy.ndarray
+            Time series or sequence.
+
+        n_threads : int, default=1
+            Number of threads to use for FFTW computations.
+
+        planning_flag : str, default="FFTW_ESTIMATE"
+            The planning flag that will be used in FFTW for planning.
+            See pyfftw documentation for details. Current options, ordered
+            ascendingly by the level of aggressiveness in planning, are:
+            "FFTW_ESTIMATE", "FFTW_MEASURE", "FFTW_PATIENT", and "FFTW_EXHAUSTIVE".
+            The more aggressive the planning, the longer the planning time, but
+            the faster the execution time.
+
+        Returns
+        -------
+        out : numpy.ndarray
+            Sliding dot product between `Q` and `T`.
+
+        Notes
+        -----
+        The planning_flag is defaulted to "FFTW_ESTIMATE" to be aligned with
+        MATLAB's FFTW usage (as of version R2025b)
+        See: https://www.mathworks.com/help/matlab/ref/fftw.html
+
+        This implementation is inspired by the answer on StackOverflow:
+        https://stackoverflow.com/a/30615425/2955541
+        """
+        m = Q.shape[0]
+        n = T.shape[0]
+        next_fast_n = pyfftw.next_fast_len(n)
+
+        # Update preallocated arrays if needed
+        if next_fast_n > len(self.real_arr):
+            self.real_arr = pyfftw.empty_aligned(next_fast_n, dtype="float64")
+            self.complex_arr = pyfftw.empty_aligned(
+                1 + (next_fast_n // 2), dtype="complex128"
+            )
+
+        real_arr = self.real_arr[:next_fast_n]
+        complex_arr = self.complex_arr[: 1 + (next_fast_n // 2)]
+
+        # Get or create FFTW objects
+        key = (next_fast_n, n_threads, planning_flag)
+
+        rfft_obj = self.rfft_objects.get(key, None)
+        if rfft_obj is None:
+            rfft_obj = pyfftw.FFTW(
+                input_array=real_arr,
+                output_array=complex_arr,
+                direction="FFTW_FORWARD",
+                flags=(planning_flag,),
+                threads=n_threads,
+            )
+            self.rfft_objects[key] = rfft_obj
+        else:
+            rfft_obj.update_arrays(real_arr, complex_arr)
+
+        irfft_obj = self.irfft_objects.get(key, None)
+        if irfft_obj is None:
+            irfft_obj = pyfftw.FFTW(
+                input_array=complex_arr,
+                output_array=real_arr,
+                direction="FFTW_BACKWARD",
+                flags=(planning_flag, "FFTW_DESTROY_INPUT"),
+                threads=n_threads,
+            )
+            self.irfft_objects[key] = irfft_obj
+        else:
+            irfft_obj.update_arrays(complex_arr, real_arr)
+
+        # RFFT(T)
+        real_arr[:n] = T
+        real_arr[n:] = 0.0
+        rfft_obj.execute()  # output is in complex_arr
+        complex_arr_T = complex_arr.copy()
+
+        # RFFT(Q)
+        # Scale by 1/next_fast_n to account for
+        # FFTW's unnormalized inverse FFT via execute()
+        np.multiply(Q[::-1], 1.0 / next_fast_n, out=real_arr[:m])
+        real_arr[m:] = 0.0
+        rfft_obj.execute()  # output is in complex_arr
+
+        # RFFT(T) * RFFT(Q)
+        np.multiply(complex_arr, complex_arr_T, out=complex_arr)
+
+        # IRFFT (input is in complex_arr)
+        irfft_obj.execute()  # output is in real_arr
+
+        return real_arr[m - 1 : n]
+
+
+if FFTW_IS_AVAILABLE:
+    _pyfftw_sliding_dot_product = _PYFFTW_SLIDING_DOT_PRODUCT(max_n=2**20)
 
 
 def _sliding_dot_product(Q, T):

--- a/stumpy/sdp.py
+++ b/stumpy/sdp.py
@@ -282,8 +282,9 @@ class _PYFFTW_SLIDING_DOT_PRODUCT:
             rfft_obj.update_arrays(real_arr, complex_arr)
             irfft_obj.update_arrays(complex_arr, real_arr)
 
-        # Compute the (circular) convolution between T and Q[::-1]
-        # using FFT, and then take the relevant slice of the output
+        # Compute the (circular) convolution between T and Q[::-1], 
+        # each zero-padded to length `next_fast_n` by performing
+        # the following three steps:
 
         # Step 1
         # Compute RFFT of T (zero-padded)

--- a/stumpy/sdp.py
+++ b/stumpy/sdp.py
@@ -191,7 +191,7 @@ class _PYFFTW_SLIDING_DOT_PRODUCT:
         real_dtype : str, default="float64"
             The real data type to use for the preallocated arrays. Must be either
             "float64" or "longdouble". The complex data type will be set to
-            "complex128" or "clongdouble" respectively.
+            "complex128" or "clongdouble", respectively.
 
         Returns
         -------

--- a/stumpy/sdp.py
+++ b/stumpy/sdp.py
@@ -327,10 +327,6 @@ class _PYFFTW_SLIDING_DOT_PRODUCT:
         return irfft_obj.output_array[m - 1 : n]  # valid portion
 
 
-if PYFFTW_IS_AVAILABLE:  # pragma: no cover
-    _pyfftw_sliding_dot_product = _PYFFTW_SLIDING_DOT_PRODUCT(max_n=2**20)
-
-
 def _sliding_dot_product(Q, T):
     """
     Compute the sliding dot product between `Q` and `T`

--- a/stumpy/sdp.py
+++ b/stumpy/sdp.py
@@ -116,11 +116,11 @@ def _pocketfft_sliding_dot_product(Q, T):
     return c2r(False, np.multiply(fft_2d[0], fft_2d[1]), n=next_fast_n)[m - 1 : n]
 
 
-class _PYFFTW_SLIDING_DOT_PRODUCT:
+def _make_pyfftw_sliding_dot_product(max_n=2**20, real_dtype="float64"):
     """
-    A class to compute the sliding dot product using FFTW via pyfftw.
+    A closure to compute the sliding dot product using FFTW via pyfftw.
 
-    This class uses FFTW (via pyfftw) to efficiently compute the sliding dot product
+    This closure uses FFTW (via pyfftw) to efficiently compute the sliding dot product
     between a query sequence, Q, and a time series, T. It preallocates arrays and caches
     FFTW objects to optimize repeated computations with similar-sized inputs.
 
@@ -128,96 +128,55 @@ class _PYFFTW_SLIDING_DOT_PRODUCT:
     ----------
     max_n : int, default=2**20
         Maximum length to preallocate arrays for. This will be the size of the
-        real-valued array. A complex-valued array of size `1 + (max_n // 2)`
+        real-valued array. A complex-valued array of size 1 + (max_n // 2)
         will also be preallocated. If inputs exceed this size, arrays will be
         reallocated to accommodate larger sizes.
 
-    Attributes
-    ----------
-    real_arr : pyfftw.empty_aligned
-        Preallocated real-valued array for FFTW computations.
+    real_dtype : str, default="float64"
+        The real data type to use for the preallocated arrays. Must be either
+        "float64" or "longdouble". The complex data type will be set to
+        "complex128" or "clongdouble", respectively.
 
-    complex_arr : pyfftw.empty_aligned
-        Preallocated complex-valued array for FFTW computations.
-
-    rfft_objects : dict
-        Cache of FFTW forward transform objects with
-        (next_fast_n, n_threads, planning_flag) as lookup keys.
-
-    irfft_objects : dict
-        Cache of FFTW inverse transform objects with
-        (next_fast_n, n_threads, planning_flag) as lookup keys.
-
-    Methods
+    Returns
     -------
-    __call__(Q, T, n_threads=1, planning_flag="FFTW_ESTIMATE")
-        Compute the sliding dot product between `Q` and `T` using FFTW
-        via pyfftw, and cache FFTW objects if not already cached.
+    sliding_dot_product : callable
+        A callable that computes the sliding dot product between Q and T using FFTW
+        via pyfftw, and caches FFTW objects if not already cached.
 
     Notes
     -----
-    The class maintains internal caches of FFTW objects to avoid redundant planning
+    The closure maintains internal caches of FFTW objects to avoid redundant planning
     operations when called multiple times with similar-sized inputs and parameters.
-    When `planning_flag=="FFTW_ESTIMATE"`, there will be no planning operation.
+    When planning_flag == "FFTW_ESTIMATE", there will be no planning operation.
     However, caching FFTW objects is still beneficial as the overhead of creating
     those objects can be avoided in subsequent calls.
 
-    Examples
-    --------
-    >>> sdp_obj = _PYFFTW_SLIDING_DOT_PRODUCT(max_n=1000)
-    >>> Q = np.array([1, 2, 3])
-    >>> T = np.array([4, 5, 6, 7, 8])
-    >>> result = sdp_obj(Q, T)
-
     References
     ----------
-    `FFTW documentation <http://www.fftw.org/>`__
-
-    `pyfftw documentation <https://pyfftw.readthedocs.io/>`__
+    FFTW documentation: http://www.fftw.org/
+    pyfftw documentation: https://pyfftw.readthedocs.io/
     """
+    REAL_TO_COMPLEX_MAP = {
+        "float64": "complex128",
+        "longdouble": "clongdouble",
+    }
+    if real_dtype not in ["float64", "longdouble"]:  # pragma: no cover
+        raise ValueError(
+            f"Invalid real_dtype: {real_dtype}. Must be 'float64' or 'longdouble'."
+        )
+    complex_dtype = REAL_TO_COMPLEX_MAP[real_dtype]
 
-    def __init__(self, max_n=2**20, real_dtype="float64"):
+    # Preallocate arrays
+    real_arr = pyfftw.empty_aligned(max_n, dtype=real_dtype)
+    complex_arr = pyfftw.empty_aligned(1 + (max_n // 2), dtype=complex_dtype)
+
+    # Store FFTW objects, keyed by (next_fast_n, n_threads, planning_flag)
+    rfft_objects = {}
+    irfft_objects = {}
+
+    def sliding_dot_product(Q, T, n_threads=1, planning_flag="FFTW_ESTIMATE"):
         """
-        Initialize the `_PYFFTW_SLIDING_DOT_PRODUCT` object, which can be called
-        to compute the sliding dot product using FFTW via pyfftw.
-
-        Parameters
-        ----------
-        max_n : int, default=2**20
-            Maximum length to preallocate arrays for. This will be the size of the
-            real-valued array. A complex-valued array of size `1 + (max_n // 2)`
-            will also be preallocated.
-
-        real_dtype : str, default="float64"
-            The real data type to use for the preallocated arrays. Must be either
-            "float64" or "longdouble". The complex data type will be set to
-            "complex128" or "clongdouble", respectively.
-
-        Returns
-        -------
-        None
-        """
-        REAL_TO_COMPLEX_MAP = {
-            "float64": "complex128",
-            "longdouble": "clongdouble",
-        }
-        if real_dtype not in ["float64", "longdouble"]:  # pragma: no cover
-            raise ValueError(
-                f"Invalid real_dtype: {real_dtype}. Must be 'float64' or 'longdouble'."
-            )
-        complex_dtype = REAL_TO_COMPLEX_MAP[real_dtype]
-
-        # Preallocate arrays
-        self.real_arr = pyfftw.empty_aligned(max_n, dtype=real_dtype)
-        self.complex_arr = pyfftw.empty_aligned(1 + (max_n // 2), dtype=complex_dtype)
-
-        # Store FFTW objects, keyed by (next_fast_n, n_threads, planning_flag)
-        self.rfft_objects = {}
-        self.irfft_objects = {}
-
-    def __call__(self, Q, T, n_threads=1, planning_flag="FFTW_ESTIMATE"):
-        """
-        Compute the sliding dot product between `Q` and `T` using FFTW via pyfftw,
+        Compute the sliding dot product between Q and T using FFTW via pyfftw,
         and cache FFTW objects if not already cached.
 
         Parameters
@@ -242,7 +201,7 @@ class _PYFFTW_SLIDING_DOT_PRODUCT:
         Returns
         -------
         out : numpy.ndarray
-            Sliding dot product between `Q` and `T`.
+            Sliding dot product between Q and T.
 
         Notes
         -----
@@ -253,52 +212,54 @@ class _PYFFTW_SLIDING_DOT_PRODUCT:
         This implementation is inspired by the answer on StackOverflow:
         https://stackoverflow.com/a/30615425/2955541
         """
+        nonlocal real_arr, complex_arr
+
         m = Q.shape[0]
         n = T.shape[0]
         next_fast_n = pyfftw.next_fast_len(n)
 
         # Update preallocated arrays if needed
-        if next_fast_n > len(self.real_arr):
-            self.real_arr = pyfftw.empty_aligned(next_fast_n, dtype=self.real_arr.dtype)
-            self.complex_arr = pyfftw.empty_aligned(
-                1 + (next_fast_n // 2), dtype=self.complex_arr.dtype
+        if next_fast_n > len(real_arr):
+            real_arr = pyfftw.empty_aligned(next_fast_n, dtype=real_arr.dtype)
+            complex_arr = pyfftw.empty_aligned(
+                1 + (next_fast_n // 2), dtype=complex_arr.dtype
             )
 
-        real_arr = self.real_arr[:next_fast_n]
-        complex_arr = self.complex_arr[: 1 + (next_fast_n // 2)]
+        real_view = real_arr[:next_fast_n]
+        complex_view = complex_arr[: 1 + (next_fast_n // 2)]
 
         # Get or create FFTW objects
         key = (next_fast_n, n_threads, planning_flag)
 
-        rfft_obj = self.rfft_objects.get(key, None)
-        irfft_obj = self.irfft_objects.get(key, None)
+        rfft_obj = rfft_objects.get(key, None)
+        irfft_obj = irfft_objects.get(key, None)
 
         if rfft_obj is None or irfft_obj is None:
             rfft_obj = pyfftw.FFTW(
-                input_array=real_arr,
-                output_array=complex_arr,
+                input_array=real_view,
+                output_array=complex_view,
                 direction="FFTW_FORWARD",
                 flags=(planning_flag,),
                 threads=n_threads,
             )
             irfft_obj = pyfftw.FFTW(
-                input_array=complex_arr,
-                output_array=real_arr,
+                input_array=complex_view,
+                output_array=real_view,
                 direction="FFTW_BACKWARD",
                 flags=(planning_flag, "FFTW_DESTROY_INPUT"),
                 threads=n_threads,
             )
-            self.rfft_objects[key] = rfft_obj
-            self.irfft_objects[key] = irfft_obj
+            rfft_objects[key] = rfft_obj
+            irfft_objects[key] = irfft_obj
         else:
             # Update the input and output arrays of the cached FFTW objects
             # in case their original input and output arrays were reallocated
             # in a previous call
-            rfft_obj.update_arrays(real_arr, complex_arr)
-            irfft_obj.update_arrays(complex_arr, real_arr)
+            rfft_obj.update_arrays(real_view, complex_view)
+            irfft_obj.update_arrays(complex_view, real_view)
 
         # Compute the (circular) convolution between T and Q[::-1],
-        # each zero-padded to length `next_fast_n` by performing
+        # each zero-padded to length next_fast_n by performing
         # the following three steps:
 
         # Step 1
@@ -312,7 +273,7 @@ class _PYFFTW_SLIDING_DOT_PRODUCT:
 
         # Step 2
         # Compute RFFT of Q (reversed, scaled, and zero-padded)
-        # Scaling is required because the thin wrapper `execute`
+        # Scaling is required because the thin wrapper execute
         # that will be called below does not perform normalization
         np.multiply(Q[::-1], 1.0 / next_fast_n, out=rfft_obj.input_array[:m])
         rfft_obj.input_array[m:] = 0.0
@@ -326,9 +287,11 @@ class _PYFFTW_SLIDING_DOT_PRODUCT:
 
         return irfft_obj.output_array[m - 1 : n]  # valid portion
 
+    return sliding_dot_product
+
 
 if PYFFTW_IS_AVAILABLE:  # pragma: no cover
-    _pyfftw_sliding_dot_product = _PYFFTW_SLIDING_DOT_PRODUCT(
+    _pyfftw_sliding_dot_product = _make_pyfftw_sliding_dot_product(
         max_n=2**20, real_dtype="float64"
     )
 

--- a/stumpy/sdp.py
+++ b/stumpy/sdp.py
@@ -328,7 +328,9 @@ class _PYFFTW_SLIDING_DOT_PRODUCT:
 
 
 if PYFFTW_IS_AVAILABLE:  # pragma: no cover
-    _pyfftw_sliding_dot_product = _PYFFTW_SLIDING_DOT_PRODUCT(max_n=2**20)
+    _pyfftw_sliding_dot_product = _PYFFTW_SLIDING_DOT_PRODUCT(
+        max_n=2**20, real_dtype="float64"
+    )
 
 
 def _sliding_dot_product(Q, T):

--- a/stumpy/sdp.py
+++ b/stumpy/sdp.py
@@ -201,7 +201,7 @@ class _PYFFTW_SLIDING_DOT_PRODUCT:
             "float64": "complex128",
             "longdouble": "clongdouble",
         }
-        if real_dtype not in ["float64", "longdouble"]:
+        if real_dtype not in ["float64", "longdouble"]:  # pragma: no cover
             raise ValueError(
                 f"Invalid real_dtype: {real_dtype}. Must be 'float64' or 'longdouble'."
             )

--- a/stumpy/sdp.py
+++ b/stumpy/sdp.py
@@ -327,6 +327,10 @@ class _PYFFTW_SLIDING_DOT_PRODUCT:
         return irfft_obj.output_array[m - 1 : n]  # valid portion
 
 
+if PYFFTW_IS_AVAILABLE:  # pragma: no cover
+    _pyfftw_sliding_dot_product = _PYFFTW_SLIDING_DOT_PRODUCT(max_n=2**20)
+
+
 def _sliding_dot_product(Q, T):
     """
     Compute the sliding dot product between `Q` and `T`

--- a/stumpy/sdp.py
+++ b/stumpy/sdp.py
@@ -176,7 +176,7 @@ class _PYFFTW_SLIDING_DOT_PRODUCT:
     `pyfftw documentation <https://pyfftw.readthedocs.io/>`__
     """
 
-    def __init__(self, max_n=2**20):
+    def __init__(self, max_n=2**20, real_dtype="float64"):
         """
         Initialize the `_PYFFTW_SLIDING_DOT_PRODUCT` object, which can be called
         to compute the sliding dot product using FFTW via pyfftw.
@@ -188,13 +188,28 @@ class _PYFFTW_SLIDING_DOT_PRODUCT:
             real-valued array. A complex-valued array of size `1 + (max_n // 2)`
             will also be preallocated.
 
+        real_dtype : str, default="float64"
+            The real data type to use for the preallocated arrays. Must be either
+            "float64" or "longdouble". The complex data type will be set to
+            "complex128" or "clongdouble" respectively.
+
         Returns
         -------
         None
         """
+        REAL_TO_COMPLEX_MAP = {
+            "float64": "complex128",
+            "longdouble": "clongdouble",
+        }
+        if real_dtype not in ["float64", "longdouble"]:
+            raise ValueError(
+                f"Invalid real_dtype: {real_dtype}. Must be 'float64' or 'longdouble'."
+            )
+        complex_dtype = REAL_TO_COMPLEX_MAP[real_dtype]
+
         # Preallocate arrays
-        self.real_arr = pyfftw.empty_aligned(max_n, dtype="float64")
-        self.complex_arr = pyfftw.empty_aligned(1 + (max_n // 2), dtype="complex128")
+        self.real_arr = pyfftw.empty_aligned(max_n, dtype=real_dtype)
+        self.complex_arr = pyfftw.empty_aligned(1 + (max_n // 2), dtype=complex_dtype)
 
         # Store FFTW objects, keyed by (next_fast_n, n_threads, planning_flag)
         self.rfft_objects = {}
@@ -244,9 +259,9 @@ class _PYFFTW_SLIDING_DOT_PRODUCT:
 
         # Update preallocated arrays if needed
         if next_fast_n > len(self.real_arr):
-            self.real_arr = pyfftw.empty_aligned(next_fast_n, dtype="float64")
+            self.real_arr = pyfftw.empty_aligned(next_fast_n, dtype=self.real_arr.dtype)
             self.complex_arr = pyfftw.empty_aligned(
-                1 + (next_fast_n // 2), dtype="complex128"
+                1 + (next_fast_n // 2), dtype=self.complex_arr.dtype
             )
 
         real_arr = self.real_arr[:next_fast_n]

--- a/stumpy/sdp.py
+++ b/stumpy/sdp.py
@@ -140,9 +140,9 @@ def _make_pyfftw_sliding_dot_product(init_len=2**20, real_dtype="float64"):
     init_len : int, default 2**20
         Initial length to preallocate arrays for. This will be the size of the
         real-valued array. A complex-valued array of size 1 + (init_len // 2)
-        will also be preallocated. If the length of input arrays exceed
-        ``init_len``, the preallocated arrays will be resized to accommodate
-        larger sizes.
+        will also be preallocated. If the length of input arrays exceeds
+        ``init_len``, then the preallocated arrays will automatically be
+        resized to accommodate larger sizes.
 
     real_dtype : str, default "float64"
         The real data type to use for the preallocated arrays. Must be either
@@ -155,7 +155,7 @@ def _make_pyfftw_sliding_dot_product(init_len=2**20, real_dtype="float64"):
         A callable object that computes the sliding dot product between ``Q``
         and ``T`` using FFTW via pyfftw, and caches FFTW objects if not already
         cached. The callable object automatically resizes the preallocated arrays
-        if the length of input arrays exceed the current initial length.
+        if the length of input arrays exceeds the current initial length.
         In addition, the callable object has the method `set_init_len` to set
         the length of the preallocated arrays to a new initial length.
 
@@ -276,7 +276,7 @@ def _make_pyfftw_sliding_dot_product(init_len=2**20, real_dtype="float64"):
             irfft_obj.update_arrays(complex_view, real_view)
 
         # Compute the (circular) convolution between T and Q[::-1],
-        # each zero-padded to the length `next_fast_n`, by performing
+        # each zero-padded to the length of `next_fast_n`, by performing
         # the following three steps:
 
         # Step 1
@@ -290,8 +290,14 @@ def _make_pyfftw_sliding_dot_product(init_len=2**20, real_dtype="float64"):
 
         # Step 2
         # Compute RFFT of Q (reversed, scaled, and zero-padded)
-        # Scaling is required because the thin wrapper execute
-        # that will be called below does not perform normalization
+        # Note that scaling by `1.0 / next_fast_n` needs to be applied
+        # at some point in the process to ensure that the final result is correct.
+        # This scaling can be applied to "zero_padded T" or its RFFT, or to
+        # "zero_padded reversed Q" or its RFFT. Or, it can be applied to
+        # the multiplication of the two RFFTs, or to the final result after the IRFFT!
+        # Here, we choose to apply the scaling to "reversed zero_padded Q" before its
+        # RFFT to reduce the number of floating point operations for such scaling
+        # process.
         np.multiply(Q[::-1], 1.0 / next_fast_n, out=rfft_obj.input_array[:m])
         rfft_obj.input_array[m:] = 0.0
         rfft_obj.execute()
@@ -304,9 +310,9 @@ def _make_pyfftw_sliding_dot_product(init_len=2**20, real_dtype="float64"):
 
         return irfft_obj.output_array[m - 1 : n]  # valid portion
 
-    def set_init_len(init_len):  # pragma: no cover
+    def update_init_len(init_len):  # pragma: no cover
         """
-        Set the preallocated arrays to a new initial length.
+        Update the size of the preallocated arrays to a new initial length
 
         Parameters
         ----------
@@ -321,7 +327,7 @@ def _make_pyfftw_sliding_dot_product(init_len=2**20, real_dtype="float64"):
         real_arr = pyfftw.empty_aligned(init_len, dtype=real_arr.dtype)
         complex_arr = pyfftw.empty_aligned(1 + (init_len // 2), dtype=complex_arr.dtype)
 
-    sliding_dot_product.set_init_len = set_init_len
+    sliding_dot_product.update_init_len = update_init_len
     return sliding_dot_product
 
 

--- a/stumpy/sdp.py
+++ b/stumpy/sdp.py
@@ -128,7 +128,7 @@ def _pocketfft_sliding_dot_product(Q, T):
 
 def _make_pyfftw_sliding_dot_product(max_n=2**20, real_dtype="float64"):
     """
-    A closure to compute the sliding dot product using FFTW via pyfftw.
+    A closure to compute the sliding dot product using FFTW via pyfftw
 
     This closure returns a callable that computes the sliding dot product between
     a query array, ``Q``, and a time series, ``T``. It preallocates arrays and caches
@@ -189,8 +189,8 @@ def _make_pyfftw_sliding_dot_product(max_n=2**20, real_dtype="float64"):
 
     def sliding_dot_product(Q, T, n_threads=1, planning_flag="FFTW_ESTIMATE"):
         """
-        Compute the sliding dot product between ``Q`` and `T`` using FFTW via pyfftw,
-        and cache FFTW objects if not already cached.
+        Compute the sliding dot product between ``Q`` and ``T`` using FFTW via pyfftw,
+        and cache FFTW objects if not already cached
 
         Parameters
         ----------
@@ -200,10 +200,10 @@ def _make_pyfftw_sliding_dot_product(max_n=2**20, real_dtype="float64"):
         T : numpy.ndarray
             Time series or sequence.
 
-        n_threads : int, default=1
+        n_threads : int, default 1
             Number of threads to use for FFTW computations.
 
-        planning_flag : str, default="FFTW_ESTIMATE"
+        planning_flag : str, default "FFTW_ESTIMATE"
             The planning flag that will be used in FFTW for planning.
             See pyfftw documentation for details. Current options, ordered
             ascendingly by the level of aggressiveness in planning, are:
@@ -302,7 +302,7 @@ def _make_pyfftw_sliding_dot_product(max_n=2**20, real_dtype="float64"):
 
     def set_max_n(max_n):  # pragma: no cover
         """
-        Reset the preallocated arrays to a new maximum length.
+        Set the preallocated arrays to a new maximum length
 
         Parameters
         ----------
@@ -342,6 +342,6 @@ def _sliding_dot_product(Q, T):
     Returns
     -------
     out : numpy.ndarray
-        Sliding dot product between `Q` and `T`.
+        Sliding dot product between ``Q`` and ``T``
     """
     return _convolve_sliding_dot_product(Q, T)

--- a/stumpy/sdp.py
+++ b/stumpy/sdp.py
@@ -275,40 +275,59 @@ def _make_pyfftw_sliding_dot_product(init_len=2**20, real_dtype="float64"):
             rfft_obj.update_arrays(real_view, complex_view)
             irfft_obj.update_arrays(complex_view, real_view)
 
-        # Compute the (circular) convolution between T and Q[::-1],
-        # each zero-padded to the length of `next_fast_n`, by performing
-        # the following three steps:
+        # Compute the circular convolution between T and Q[::-1], where both
+        # arrays are zero-padded to length `next_fast_n`.
+        #
+        # Let T' and Q' denote the zero-padded versions of T and Q[::-1],
+        # respectively, and let C denote their circular convolution:
+        #
+        # C = IFFT(FFT(T') * FFT(Q'))
+        #
+        # Since T' and Q' are real-valued, we can use the real-valued Fourier
+        # transforms instead:
+        #
+        # C = IRFFT(RFFT(T') * RFFT(Q'))
+        #
+        # By convention, the forward Fourier transform is unnormalized, while
+        # the inverse Fourier transform applies a factor of `1 / next_fast_n`.
+        # However, the `execute` method used below is a thin wrapper around the
+        # FFT implementation and performs no normalization. Therefore, the
+        # convolution must instead be computed as:
+        #
+        # C = (1 / next_fast_n) * IRFFT(RFFT(T') * RFFT(Q'))
+        #
+        # By linearity of the Fourier transform, this scaling factor can be
+        # applied either before or after the transform:
+        #
+        # C = IRFFT(RFFT(T') * ((1 / next_fast_n) * RFFT(Q')))
+        #   = IRFFT(RFFT(T') * RFFT((1 / next_fast_n) * Q'))
+        #
+        # Applying the scaling to Q before computing its RFFT reduces
+        # the number of multiplications since `len(Q)` is often
+        # much smaller than `next_fast_n`.
+        #
+        # The convolution is therefore computed in three steps:
+        # 1. Compute the (unnormalized) RFFT of the zero-padded T.
+        # 2. Compute the (unnormalized) RFFT of the reversed, scaled, and
+        #    zero-padded Q.
+        # 3. Multiply the RFFT outputs and compute the (unnormalized) inverse RFFT.
 
         # Step 1
-        # Compute RFFT of T (zero-padded)
-        # Must make a copy of output to avoid losing it when the output array
-        # is overwritten when computing the RFFT of Q in the "Step 2" below
+        # Compute (unnormalized) RFFT of T (zero-padded)
         rfft_obj.input_array[:n] = T
         rfft_obj.input_array[n:] = 0.0
         rfft_obj.execute()
-        rfft_T = rfft_obj.output_array.copy()
+        rfft_T = rfft_obj.output_array.copy()  # To avoid losing it in step 2
 
         # Step 2
-        # Compute RFFT of Q (reversed, scaled, and zero-padded)
-        # Note that, by convention, the FFT transform is not normalized,
-        # and the inverse FFT transform is normalized by `1/next_fast_n`
-        # And that is actually needed to make sure the computed
-        # circular convolution is correct.
-        # To reduce the number of floating point operations, we can apply
-        # the scaling to (reversed) Q before taking its RFFT. This is possible
-        # thanks to the linearity of the FFT transform, i.e. FFT(ax) = aFFT(x).
+        # Compute (unnormalized) RFFT of Q (reversed, scaled, and zero-padded)
         np.multiply(Q[::-1], 1.0 / next_fast_n, out=rfft_obj.input_array[:m])
         rfft_obj.input_array[m:] = 0.0
         rfft_obj.execute()
         rfft_Q = rfft_obj.output_array
 
         # Step 3
-        # Convert back to time domain by taking the inverse RFFT
-        # The (thin wrapper) "execute" method does not normalize the output.
-        # Note that the output of the inverse RFFT should be normalized
-        # by `1/next_fast_n` to make sure the computed circular convolution
-        # is correct. However, we have already applied the scaling to Q in
-        # "Step 2" above, so we do not need to apply it again here.
+        # Convert back to time domain by taking the (unnormalized) inverse RFFT
         np.multiply(rfft_T, rfft_Q, out=irfft_obj.input_array)
         irfft_obj.execute()
 

--- a/stumpy/sdp.py
+++ b/stumpy/sdp.py
@@ -146,7 +146,10 @@ def _make_pyfftw_sliding_dot_product(max_n=2**20, real_dtype="float64"):
     -------
     sliding_dot_product : callable
         A callable that computes the sliding dot product between Q and T using FFTW
-        via pyfftw, and caches FFTW objects if not already cached.
+        via pyfftw, and caches FFTW objects if not already cached. The callable
+        automatically resizes the preallocated arrays if the inputs exceed
+        the current maximum size. In addition, the callable has a method
+        `reset_arr(max_n)` to reset the preallocated arrays to a new maximum length.
 
     Notes
     -----
@@ -292,6 +295,25 @@ def _make_pyfftw_sliding_dot_product(max_n=2**20, real_dtype="float64"):
 
         return irfft_obj.output_array[m - 1 : n]  # valid portion
 
+    def reset_arr(max_n):  # pragma: no cover
+        """
+        Reset the preallocated arrays to a new maximum length.
+
+        Parameters
+        ----------
+        max_n : int
+            New maximum length for the preallocated arrays.
+
+        Returns
+        -------
+        None
+        """
+        nonlocal real_arr, complex_arr
+        complex_dtype = REAL_TO_COMPLEX_MAP[real_dtype]
+        real_arr = pyfftw.empty_aligned(max_n, dtype=real_dtype)
+        complex_arr = pyfftw.empty_aligned(1 + (max_n // 2), dtype=complex_dtype)
+
+    sliding_dot_product.reset_arr = reset_arr
     return sliding_dot_product
 
 

--- a/stumpy/sdp.py
+++ b/stumpy/sdp.py
@@ -1,3 +1,8 @@
+# This file contains different implementations of
+# the sliding dot product (sdp). The name of any
+# callable object that computes the sliding dot product
+# should end with 'sliding_dot_product'.
+
 import numpy as np
 from numba import njit
 from scipy.fft import next_fast_len

--- a/stumpy/sdp.py
+++ b/stumpy/sdp.py
@@ -300,7 +300,7 @@ def _make_pyfftw_sliding_dot_product(max_n=2**20, real_dtype="float64"):
 
         return irfft_obj.output_array[m - 1 : n]  # valid portion
 
-    def reset_arr(max_n):  # pragma: no cover
+    def set_max_n(max_n):  # pragma: no cover
         """
         Reset the preallocated arrays to a new maximum length.
 
@@ -314,11 +314,10 @@ def _make_pyfftw_sliding_dot_product(max_n=2**20, real_dtype="float64"):
         None
         """
         nonlocal real_arr, complex_arr
-        complex_dtype = REAL_TO_COMPLEX_MAP[real_dtype]
-        real_arr = pyfftw.empty_aligned(max_n, dtype=real_dtype)
-        complex_arr = pyfftw.empty_aligned(1 + (max_n // 2), dtype=complex_dtype)
+        real_arr = pyfftw.empty_aligned(max_n, dtype=real_arr.dtype)
+        complex_arr = pyfftw.empty_aligned(1 + (max_n // 2), dtype=complex_arr.dtype)
 
-    sliding_dot_product.reset_arr = reset_arr
+    sliding_dot_product.set_max_n = set_max_n
     return sliding_dot_product
 
 

--- a/stumpy/sdp.py
+++ b/stumpy/sdp.py
@@ -136,13 +136,13 @@ def _make_pyfftw_sliding_dot_product(max_n=2**20, real_dtype="float64"):
 
     Parameters
     ----------
-    max_n : int, default=2**20
+    max_n : int, default 2**20
         Maximum length to preallocate arrays for. This will be the size of the
         real-valued array. A complex-valued array of size 1 + (max_n // 2)
         will also be preallocated. If inputs exceed this size, arrays will be
         reallocated to accommodate larger sizes.
 
-    real_dtype : str, default="float64"
+    real_dtype : str, default "float64"
         The real data type to use for the preallocated arrays. Must be either
         "float64" or "longdouble". The complex data type will be set to
         "complex128" or "clongdouble", respectively.

--- a/stumpy/sdp.py
+++ b/stumpy/sdp.py
@@ -5,7 +5,6 @@ from scipy.signal import convolve, oaconvolve
 
 from . import config
 
-
 # _duccfft replaced _pocketfft in scipy 1.18
 try:
     from scipy.fft._duccfft.basic import c2r, r2c

--- a/stumpy/sdp.py
+++ b/stumpy/sdp.py
@@ -295,6 +295,7 @@ def _make_pyfftw_sliding_dot_product(init_len=2**20, real_dtype="float64"):
         # convolution must instead be computed as:
         #
         # C = (1 / next_fast_n) * IRFFT(RFFT(T') * RFFT(Q'))
+        # where RFFT and IRFFT are unnormalized.
         #
         # By linearity of the Fourier transform, this scaling factor can be
         # applied either before or after the transform:
@@ -302,8 +303,8 @@ def _make_pyfftw_sliding_dot_product(init_len=2**20, real_dtype="float64"):
         # C = IRFFT(RFFT(T') * ((1 / next_fast_n) * RFFT(Q')))
         #   = IRFFT(RFFT(T') * RFFT((1 / next_fast_n) * Q'))
         #
-        # Applying the scaling to Q before computing its RFFT reduces
-        # the number of multiplications since `len(Q)` is often
+        # Applying the scaling to original Q before padding it with zeros
+        # can reduce the number of multiplications since `len(Q)` is often
         # much smaller than `next_fast_n`.
         #
         # The convolution is therefore computed in three steps:

--- a/stumpy/sdp.py
+++ b/stumpy/sdp.py
@@ -130,8 +130,8 @@ def _make_pyfftw_sliding_dot_product(max_n=2**20, real_dtype="float64"):
     """
     A closure to compute the sliding dot product using FFTW via pyfftw.
 
-    This closure uses FFTW (via pyfftw) to efficiently compute the sliding dot product
-    between a query sequence, Q, and a time series, T. It preallocates arrays and caches
+    This closure returns a callable that computes the sliding dot product between
+    a query array, ``Q``, and a time series, ``T``. It preallocates arrays and caches
     FFTW objects to optimize repeated computations with similar-sized inputs.
 
     Parameters
@@ -154,7 +154,7 @@ def _make_pyfftw_sliding_dot_product(max_n=2**20, real_dtype="float64"):
         via pyfftw, and caches FFTW objects if not already cached. The callable
         automatically resizes the preallocated arrays if the inputs exceed
         the current maximum size. In addition, the callable has a method
-        `reset_arr(max_n)` to reset the preallocated arrays to a new maximum length.
+        `set_max_n` to set the preallocated arrays to a new maximum length.
 
     Notes
     -----
@@ -189,7 +189,7 @@ def _make_pyfftw_sliding_dot_product(max_n=2**20, real_dtype="float64"):
 
     def sliding_dot_product(Q, T, n_threads=1, planning_flag="FFTW_ESTIMATE"):
         """
-        Compute the sliding dot product between Q and T using FFTW via pyfftw,
+        Compute the sliding dot product between ``Q`` and `T`` using FFTW via pyfftw,
         and cache FFTW objects if not already cached.
 
         Parameters
@@ -214,7 +214,7 @@ def _make_pyfftw_sliding_dot_product(max_n=2**20, real_dtype="float64"):
         Returns
         -------
         out : numpy.ndarray
-            Sliding dot product between Q and T.
+            Sliding dot product between ``Q`` and ``T``.
 
         Notes
         -----
@@ -329,7 +329,7 @@ if PYFFTW_IS_AVAILABLE:  # pragma: no cover
 
 def _sliding_dot_product(Q, T):
     """
-    Compute the sliding dot product between `Q` and `T`
+    Compute the sliding dot product between ``Q`` and ``T``
 
     Parameters
     ----------

--- a/stumpy/sdp.py
+++ b/stumpy/sdp.py
@@ -130,17 +130,19 @@ def _make_pyfftw_sliding_dot_product(init_len=2**20, real_dtype="float64"):
     """
     A closure to compute the sliding dot product using FFTW via pyfftw
 
-    This closure returns a callable that computes the sliding dot product between
-    a query array, ``Q``, and a time series, ``T``. It preallocates arrays and caches
-    FFTW objects to optimize repeated computations with similar-sized inputs.
+    This closure returns a callable object that computes the sliding dot product
+    between a query array, ``Q``, and a time series, ``T``. It preallocates arrays
+    and caches FFTW objects to optimize repeated computations with similar-sized
+    inputs.
 
     Parameters
     ----------
     init_len : int, default 2**20
         Initial length to preallocate arrays for. This will be the size of the
         real-valued array. A complex-valued array of size 1 + (init_len // 2)
-        will also be preallocated. If inputs exceed this size, arrays will be
-        reallocated to accommodate larger sizes.
+        will also be preallocated. If the length of input arrays exceed
+        ``init_len``, the preallocated arrays will be resized to accommodate
+        larger sizes.
 
     real_dtype : str, default "float64"
         The real data type to use for the preallocated arrays. Must be either
@@ -150,11 +152,12 @@ def _make_pyfftw_sliding_dot_product(init_len=2**20, real_dtype="float64"):
     Returns
     -------
     sliding_dot_product : callable
-        A callable that computes the sliding dot product between Q and T using FFTW
-        via pyfftw, and caches FFTW objects if not already cached. The callable
-        automatically resizes the preallocated arrays if the inputs exceed
-        the current initial length. In addition, the callable has a method
-        `set_init_len` to set the preallocated arrays to a new initial length.
+        A callable object that computes the sliding dot product between ``Q``
+        and ``T`` using FFTW via pyfftw, and caches FFTW objects if not already
+        cached. The callable object automatically resizes the preallocated arrays
+        if the length of input arrays exceed the current initial length.
+        In addition, the callable object has the method `set_init_len` to set
+        the length of the preallocated arrays to a new initial length.
 
     Notes
     -----
@@ -209,7 +212,8 @@ def _make_pyfftw_sliding_dot_product(init_len=2**20, real_dtype="float64"):
             ascendingly by the level of aggressiveness in planning, are:
             "FFTW_ESTIMATE", "FFTW_MEASURE", "FFTW_PATIENT", and "FFTW_EXHAUSTIVE".
             The more aggressive the planning, the longer the planning time, but
-            the faster the execution time.
+            the faster the execution time. Note that when ``planning_flag`` is
+            set to "FFTW_ESTIMATE" (default), there will be no planning operation!
 
         Returns
         -------
@@ -272,13 +276,13 @@ def _make_pyfftw_sliding_dot_product(init_len=2**20, real_dtype="float64"):
             irfft_obj.update_arrays(complex_view, real_view)
 
         # Compute the (circular) convolution between T and Q[::-1],
-        # each zero-padded to length next_fast_n by performing
+        # each zero-padded to the length `next_fast_n`, by performing
         # the following three steps:
 
         # Step 1
         # Compute RFFT of T (zero-padded)
-        # Must make a copy of output to avoid losing it when the array is
-        # overwritten when computing the RFFT of Q in the next step
+        # Must make a copy of output to avoid losing it when the output array
+        # is overwritten when computing the RFFT of Q in the "Step 2" below
         rfft_obj.input_array[:n] = T
         rfft_obj.input_array[n:] = 0.0
         rfft_obj.execute()

--- a/stumpy/sdp.py
+++ b/stumpy/sdp.py
@@ -126,7 +126,7 @@ def _pocketfft_sliding_dot_product(Q, T):
     return c2r(False, np.multiply(fft_2d[0], fft_2d[1]), n=next_fast_n)[m - 1 : n]
 
 
-def _make_pyfftw_sliding_dot_product(max_n=2**20, real_dtype="float64"):
+def _make_pyfftw_sliding_dot_product(init_len=2**20, real_dtype="float64"):
     """
     A closure to compute the sliding dot product using FFTW via pyfftw
 
@@ -136,9 +136,9 @@ def _make_pyfftw_sliding_dot_product(max_n=2**20, real_dtype="float64"):
 
     Parameters
     ----------
-    max_n : int, default 2**20
-        Maximum length to preallocate arrays for. This will be the size of the
-        real-valued array. A complex-valued array of size 1 + (max_n // 2)
+    init_len : int, default 2**20
+        Initial length to preallocate arrays for. This will be the size of the
+        real-valued array. A complex-valued array of size 1 + (init_len // 2)
         will also be preallocated. If inputs exceed this size, arrays will be
         reallocated to accommodate larger sizes.
 
@@ -153,8 +153,8 @@ def _make_pyfftw_sliding_dot_product(max_n=2**20, real_dtype="float64"):
         A callable that computes the sliding dot product between Q and T using FFTW
         via pyfftw, and caches FFTW objects if not already cached. The callable
         automatically resizes the preallocated arrays if the inputs exceed
-        the current maximum size. In addition, the callable has a method
-        `set_max_n` to set the preallocated arrays to a new maximum length.
+        the current initial length. In addition, the callable has a method
+        `set_init_len` to set the preallocated arrays to a new initial length.
 
     Notes
     -----
@@ -180,8 +180,8 @@ def _make_pyfftw_sliding_dot_product(max_n=2**20, real_dtype="float64"):
     complex_dtype = REAL_TO_COMPLEX_MAP[real_dtype]
 
     # Preallocate arrays
-    real_arr = pyfftw.empty_aligned(max_n, dtype=real_dtype)
-    complex_arr = pyfftw.empty_aligned(1 + (max_n // 2), dtype=complex_dtype)
+    real_arr = pyfftw.empty_aligned(init_len, dtype=real_dtype)
+    complex_arr = pyfftw.empty_aligned(1 + (init_len // 2), dtype=complex_dtype)
 
     # Store FFTW objects, keyed by (next_fast_n, n_threads, planning_flag)
     rfft_objects = {}
@@ -300,30 +300,30 @@ def _make_pyfftw_sliding_dot_product(max_n=2**20, real_dtype="float64"):
 
         return irfft_obj.output_array[m - 1 : n]  # valid portion
 
-    def set_max_n(max_n):  # pragma: no cover
+    def set_init_len(init_len):  # pragma: no cover
         """
-        Set the preallocated arrays to a new maximum length
+        Set the preallocated arrays to a new initial length.
 
         Parameters
         ----------
-        max_n : int
-            New maximum length for the preallocated arrays.
+        init_len : int
+            New initial length for the preallocated arrays.
 
         Returns
         -------
         None
         """
         nonlocal real_arr, complex_arr
-        real_arr = pyfftw.empty_aligned(max_n, dtype=real_arr.dtype)
-        complex_arr = pyfftw.empty_aligned(1 + (max_n // 2), dtype=complex_arr.dtype)
+        real_arr = pyfftw.empty_aligned(init_len, dtype=real_arr.dtype)
+        complex_arr = pyfftw.empty_aligned(1 + (init_len // 2), dtype=complex_arr.dtype)
 
-    sliding_dot_product.set_max_n = set_max_n
+    sliding_dot_product.set_init_len = set_init_len
     return sliding_dot_product
 
 
 if PYFFTW_IS_AVAILABLE:  # pragma: no cover
     _pyfftw_sliding_dot_product = _make_pyfftw_sliding_dot_product(
-        max_n=2**20, real_dtype="float64"
+        init_len=2**20, real_dtype="float64"
     )
 
 

--- a/stumpy/sdp.py
+++ b/stumpy/sdp.py
@@ -290,14 +290,13 @@ def _make_pyfftw_sliding_dot_product(init_len=2**20, real_dtype="float64"):
 
         # Step 2
         # Compute RFFT of Q (reversed, scaled, and zero-padded)
-        # Note that scaling by `1.0 / next_fast_n` needs to be applied
-        # at some point in the process to ensure that the final result is correct.
-        # This scaling can be applied to "zero_padded T" or its RFFT, or to
-        # "zero_padded reversed Q" or its RFFT. Or, it can be applied to
-        # the multiplication of the two RFFTs, or to the final result after the IRFFT!
-        # Here, we choose to apply the scaling to "reversed zero_padded Q" before its
-        # RFFT to reduce the number of floating point operations for such scaling
-        # process.
+        # Note that, by convention, the FFT transform is not normalized,
+        # and the inverse FFT transform is normalized by `1/next_fast_n`
+        # And that is actually needed to make sure the computed
+        # circular convolution is correct.
+        # To reduce the number of floating point operations, we can apply
+        # the scaling to (reversed) Q before taking its RFFT. This is possible
+        # thanks to the linearity of the FFT transform, i.e. FFT(ax) = aFFT(x).
         np.multiply(Q[::-1], 1.0 / next_fast_n, out=rfft_obj.input_array[:m])
         rfft_obj.input_array[m:] = 0.0
         rfft_obj.execute()
@@ -305,6 +304,11 @@ def _make_pyfftw_sliding_dot_product(init_len=2**20, real_dtype="float64"):
 
         # Step 3
         # Convert back to time domain by taking the inverse RFFT
+        # The (thin wrapper) "execute" method does not normalize the output.
+        # Note that the output of the inverse RFFT should be normalized
+        # by `1/next_fast_n` to make sure the computed circular convolution
+        # is correct. However, we have already applied the scaling to Q in
+        # "Step 2" above, so we do not need to apply it again here.
         np.multiply(rfft_T, rfft_Q, out=irfft_obj.input_array)
         irfft_obj.execute()
 

--- a/test.sh
+++ b/test.sh
@@ -172,8 +172,8 @@ check_fftw_pyfftw()
 gen_pyfftw_coveragerc()
 {
     gen_coveragerc_boilerplate
-    echo "    class .*PYFFTW*" >> .coveragerc_override
-    echo "    def test_.*pyfftw*" >> .coveragerc_override
+    echo "    def .*pyfftw.*" >> .coveragerc_override
+    echo "    def test_.*pyfftw.*" >> .coveragerc_override
 }
 
 set_coveragerc()

--- a/test.sh
+++ b/test.sh
@@ -163,9 +163,9 @@ check_fftw_pyfftw()
 {
     if ! python -c "import pyfftw" &> /dev/null;
     then
-        echo "pyFFTW cannot be imported."
+        echo "pyFFTW cannot be imported"
     else
-        echo "pyFFTW can be imported!"
+        echo "pyFFTW was successfully imported"
     fi
 }
 

--- a/test.sh
+++ b/test.sh
@@ -161,12 +161,11 @@ gen_ray_coveragerc()
 
 check_fftw_pyfftw()
 {
-    if ! command -v fftw-wisdom &> /dev/null \
-    || ! python -c "import pyfftw" &> /dev/null;
+    if ! python -c "import pyfftw" &> /dev/null;
     then
-        echo "FFTW and/or pyFFTW Not Installed"
+        echo "pyFFTW cannot be imported."
     else
-        echo "FFTW and pyFFTW Installed"
+        echo "pyFFTW can be imported!"
     fi
 }
 

--- a/test.sh
+++ b/test.sh
@@ -159,7 +159,7 @@ gen_ray_coveragerc()
     echo "    def test_.*_ray*" >> .coveragerc_override
 }
 
-check_fftw_pyfftw()
+check_pyfftw()
 {
     if ! python -c "import pyfftw" &> /dev/null;
     then
@@ -188,13 +188,12 @@ set_coveragerc()
         echo "Ray installed"
     fi
 
-    if ! command -v fftw-wisdom &> /dev/null \
-    || ! python -c "import pyfftw" &> /dev/null;
+    if ! python -c "import pyfftw" &> /dev/null;
     then
-        echo "FFTW and/or pyFFTW not Installed"
+        echo "pyFFTW cannot be imported"
         gen_pyfftw_coveragerc
     else
-        echo "FFTW and pyFFTW Installed"
+        echo "pyFFTW was successfully imported"
     fi
 
     if [ -f .coveragerc_override ]; then
@@ -391,7 +390,7 @@ check_print
 check_pkg_imports
 check_naive
 check_ray
-check_fftw_pyfftw
+check_pyfftw
 
 
 if [[ -z $NUMBA_DISABLE_JIT || $NUMBA_DISABLE_JIT -eq 0 ]]; then

--- a/tests/test_sdp.py
+++ b/tests/test_sdp.py
@@ -74,7 +74,7 @@ def get_sdp_function_names():
         if func_name.endswith("sliding_dot_product"):
             out.append(func_name)
 
-    if sdp.FFTW_IS_AVAILABLE:  # pragma: no cover
+    if sdp.PYFFTW_IS_AVAILABLE:  # pragma: no cover
         out.append("_pyfftw_sliding_dot_product")
 
     return out
@@ -158,7 +158,7 @@ def test_sdp_power2():
 
 
 def test_pyfftw_sdp_max_n():
-    if not sdp.FFTW_IS_AVAILABLE:  # pragma: no cover
+    if not sdp.PYFFTW_IS_AVAILABLE:  # pragma: no cover
         pytest.skip("Skipping Test pyFFTW Not Installed")
 
     # When `len(T)` larger than `max_n` in pyfftw_sdp,

--- a/tests/test_sdp.py
+++ b/tests/test_sdp.py
@@ -74,7 +74,7 @@ def get_sdp_function_names():
         if func_name.endswith("sliding_dot_product"):
             out.append(func_name)
 
-    if sdp.FFTW_IS_AVAILABLE:
+    if sdp.FFTW_IS_AVAILABLE:  # pragma: no cover
         out.append("_pyfftw_sliding_dot_product")
 
     return out

--- a/tests/test_sdp.py
+++ b/tests/test_sdp.py
@@ -177,3 +177,62 @@ def test_pyfftw_sdp_max_n():
     np.testing.assert_allclose(comp, ref)
 
     return
+
+
+def test_pyfftw_sdp_longdoube():
+    if not sdp.PYFFTW_IS_AVAILABLE:  # pragma: no cover
+        pytest.skip("Skipping Test pyFFTW Not Installed")
+
+    # This test checks that the pyfftw_sdp can be initialized with longdouble data type
+    max_n = 2**10
+    sdp_func = sdp._PYFFTW_SLIDING_DOT_PRODUCT(max_n, real_dtype="longdouble")
+
+    T = np.random.rand(max_n)
+    Q = np.random.rand(2**8)
+
+    comp = sdp_func(Q, T)
+    ref = naive.rolling_window_dot_product(Q, T)
+
+    np.testing.assert_allclose(comp, ref)
+
+    return
+
+
+def test_pyfftw_sdp_multithreaded():
+    if not sdp.PYFFTW_IS_AVAILABLE:  # pragma: no cover
+        pytest.skip("Skipping Test pyFFTW Not Installed")
+
+    # This test checks that the pyfftw_sdp can be initialized
+    # with multiple threads
+    max_n = 2**10
+    sdp_func = sdp._PYFFTW_SLIDING_DOT_PRODUCT(max_n)
+
+    T = np.random.rand(max_n)
+    Q = np.random.rand(2**8)
+
+    comp = sdp_func(Q, T, n_threads=2)
+    ref = naive.rolling_window_dot_product(Q, T)
+
+    np.testing.assert_allclose(comp, ref)
+
+    return
+
+
+def test_pyfftw_sdp_multithreaded_longdouble():
+    if not sdp.PYFFTW_IS_AVAILABLE:  # pragma: no cover
+        pytest.skip("Skipping Test pyFFTW Not Installed")
+
+    # This test checks that the pyfftw_sdp can be initialized
+    # with multiple threads and longdouble data type
+    max_n = 2**10
+    sdp_func = sdp._PYFFTW_SLIDING_DOT_PRODUCT(max_n, real_dtype="longdouble")
+
+    T = np.random.rand(max_n)
+    Q = np.random.rand(2**8)
+
+    comp = sdp_func(Q, T, n_threads=2)
+    ref = naive.rolling_window_dot_product(Q, T)
+
+    np.testing.assert_allclose(comp, ref)
+
+    return

--- a/tests/test_sdp.py
+++ b/tests/test_sdp.py
@@ -70,14 +70,9 @@ test_inputs = [
 
 def get_sdp_function_names():
     out = []
-    for func_name, _ in inspect.getmembers(sdp, inspect.isfunction):
+    for func_name, _ in inspect.getmembers(sdp, callable):
         if func_name.endswith("sliding_dot_product"):
             out.append(func_name)
-
-    if sdp.PYFFTW_IS_AVAILABLE:  # pragma: no cover
-        callable_obj = sdp._PYFFTW_SLIDING_DOT_PRODUCT(max_n=2**20)
-        setattr(sdp, "_pyfftw_sliding_dot_product", callable_obj)
-        out.append("_pyfftw_sliding_dot_product")
 
     return out
 
@@ -163,17 +158,16 @@ def test_pyfftw_sdp_max_n():
     if not sdp.PYFFTW_IS_AVAILABLE:  # pragma: no cover
         pytest.skip("Skipping Test pyFFTW Not Installed")
 
-    # When `len(T)` larger than `max_n` in pyfftw_sdp,
+    # When `len(T)` larger than `real_arr` in pyfftw_sdp,
     # the internal preallocated arrays should be resized.
     # This test checks that functionality.
-    max_n = 2**10
-    sdp_func = sdp._PYFFTW_SLIDING_DOT_PRODUCT(max_n)
 
-    # len(T) > max_n to trigger array resizing
-    T = np.random.rand(max_n + 1)
-    Q = np.random.rand(2**8)
+    # len(T) > real_arr to trigger array resizing
+    real_arr_len = len(sdp._pyfftw_sliding_dot_product.real_arr)
+    T = np.random.rand(real_arr_len + 1)
+    Q = np.random.rand(2**2)
 
-    comp = sdp_func(Q, T)
+    comp = sdp._pyfftw_sliding_dot_product(Q, T)
     ref = naive.rolling_window_dot_product(Q, T)
 
     np.testing.assert_allclose(comp, ref)
@@ -206,13 +200,10 @@ def test_pyfftw_sdp_multithreaded():
 
     # This test checks that the pyfftw_sdp can be initialized
     # with multiple threads
-    max_n = 2**10
-    sdp_func = sdp._PYFFTW_SLIDING_DOT_PRODUCT(max_n)
+    T = np.random.rand(2**5)
+    Q = np.random.rand(2**4)
 
-    T = np.random.rand(max_n)
-    Q = np.random.rand(2**8)
-
-    comp = sdp_func(Q, T, n_threads=2)
+    comp = sdp._pyfftw_sliding_dot_product(Q, T, n_threads=2)
     ref = naive.rolling_window_dot_product(Q, T)
 
     np.testing.assert_allclose(comp, ref)

--- a/tests/test_sdp.py
+++ b/tests/test_sdp.py
@@ -70,11 +70,13 @@ test_inputs = [
 
 def get_sdp_function_names():
     out = []
-    for func_name, func in inspect.getmembers(sdp, inspect.isfunction):
+    for func_name, _ in inspect.getmembers(sdp, inspect.isfunction):
         if func_name.endswith("sliding_dot_product"):
             out.append(func_name)
 
     if sdp.PYFFTW_IS_AVAILABLE:  # pragma: no cover
+        callable_obj = sdp._PYFFTW_SLIDING_DOT_PRODUCT(max_n=2**20)
+        setattr(sdp, "_pyfftw_sliding_dot_product", callable_obj)
         out.append("_pyfftw_sliding_dot_product")
 
     return out

--- a/tests/test_sdp.py
+++ b/tests/test_sdp.py
@@ -70,8 +70,10 @@ test_inputs = [
 
 def get_sdp_function_names():
     out = []
-    for func_name, _ in inspect.getmembers(sdp, callable):
-        if func_name.endswith("sliding_dot_product"):
+    for func_name, func in inspect.getmembers(sdp, callable):
+        if func_name.endswith("sliding_dot_product") and inspect.signature(
+            func
+        ).parameters.keys() >= {"Q", "T"}:
             out.append(func_name)
 
     return out
@@ -162,12 +164,16 @@ def test_pyfftw_sdp_max_n():
     # the internal preallocated arrays should be resized.
     # This test checks that functionality.
 
-    # len(T) > real_arr to trigger array resizing
-    real_arr_len = len(sdp._pyfftw_sliding_dot_product.real_arr)
-    T = np.random.rand(real_arr_len + 1)
+    max_n = 2**10
+    _pyfftw_sliding_dot_product = sdp._make_pyfftw_sliding_dot_product(
+        max_n=max_n, real_dtype="float64"
+    )
+
+    # len(T) > max_n to trigger array resizing
+    T = np.random.rand(max_n + 1)
     Q = np.random.rand(2**2)
 
-    comp = sdp._pyfftw_sliding_dot_product(Q, T)
+    comp = _pyfftw_sliding_dot_product(Q, T)
     ref = naive.rolling_window_dot_product(Q, T)
 
     np.testing.assert_allclose(comp, ref)
@@ -181,7 +187,7 @@ def test_pyfftw_sdp_longdoube():
 
     # This test checks that the pyfftw_sdp can be initialized with longdouble data type
     max_n = 2**10
-    sdp_func = sdp._PYFFTW_SLIDING_DOT_PRODUCT(max_n, real_dtype="longdouble")
+    sdp_func = sdp._make_pyfftw_sliding_dot_product(max_n, real_dtype="longdouble")
 
     T = np.random.rand(max_n)
     Q = np.random.rand(2**8)
@@ -218,7 +224,7 @@ def test_pyfftw_sdp_multithreaded_longdouble():
     # This test checks that the pyfftw_sdp can be initialized
     # with multiple threads and longdouble data type
     max_n = 2**10
-    sdp_func = sdp._PYFFTW_SLIDING_DOT_PRODUCT(max_n, real_dtype="longdouble")
+    sdp_func = sdp._make_pyfftw_sliding_dot_product(max_n, real_dtype="longdouble")
 
     T = np.random.rand(max_n)
     Q = np.random.rand(2**8)

--- a/tests/test_sdp.py
+++ b/tests/test_sdp.py
@@ -156,21 +156,21 @@ def test_sdp_power2():
     return
 
 
-def test_pyfftw_sdp_max_n():
+def test_pyfftw_sdp_init_len():
     if not sdp.PYFFTW_IS_AVAILABLE:  # pragma: no cover
         pytest.skip("Skipping Test pyFFTW Not Installed")
 
-    # When `len(T)` larger than original `max_n`,
+    # When `len(T)` larger than original `init_len`,
     # the callable object returned by `_make_pyfftw_sliding_dot_product`
     # should still work correctly. This test checks that functionality.
 
-    max_n = 2**10
+    init_len = 2**10
     _pyfftw_sliding_dot_product = sdp._make_pyfftw_sliding_dot_product(
-        max_n=max_n, real_dtype="float64"
+        init_len=init_len, real_dtype="float64"
     )
 
-    # len(T) > max_n to trigger internal array resizing
-    T = np.random.rand(max_n + 1)
+    # len(T) > init_len to trigger internal array resizing
+    T = np.random.rand(init_len + 1)
     Q = np.random.rand(2**2)
 
     comp = _pyfftw_sliding_dot_product(Q, T)
@@ -188,10 +188,12 @@ def test_pyfftw_sdp_longdoube():
     # This test checks that the callable object
     # returned by `_make_pyfftw_sliding_dot_product`
     # can support `real_dtype="longdouble"`
-    max_n = 2**10
-    sdp_func = sdp._make_pyfftw_sliding_dot_product(max_n, real_dtype="longdouble")
+    init_len = 2**10
+    sdp_func = sdp._make_pyfftw_sliding_dot_product(
+        init_len=init_len, real_dtype="longdouble"
+    )
 
-    T = np.random.rand(max_n)
+    T = np.random.rand(init_len)
     Q = np.random.rand(2**8)
 
     comp = sdp_func(Q, T)
@@ -227,10 +229,12 @@ def test_pyfftw_sdp_multithreaded_longdouble():
     # This test checks that the callable object
     # returned by `_make_pyfftw_sliding_dot_product`
     # can support  multithreading and `real_dtype="longdouble"`
-    max_n = 2**10
-    sdp_func = sdp._make_pyfftw_sliding_dot_product(max_n, real_dtype="longdouble")
+    init_len = 2**10
+    sdp_func = sdp._make_pyfftw_sliding_dot_product(
+        init_len=init_len, real_dtype="longdouble"
+    )
 
-    T = np.random.rand(max_n)
+    T = np.random.rand(init_len)
     Q = np.random.rand(2**8)
 
     comp = sdp_func(Q, T, n_threads=2)

--- a/tests/test_sdp.py
+++ b/tests/test_sdp.py
@@ -160,16 +160,16 @@ def test_pyfftw_sdp_max_n():
     if not sdp.PYFFTW_IS_AVAILABLE:  # pragma: no cover
         pytest.skip("Skipping Test pyFFTW Not Installed")
 
-    # When `len(T)` larger than `real_arr` in pyfftw_sdp,
-    # the internal preallocated arrays should be resized.
-    # This test checks that functionality.
+    # When `len(T)` larger than original `max_n`,
+    # the callable object returned by `_make_pyfftw_sliding_dot_product`
+    # should still work correctly. This test checks that functionality.
 
     max_n = 2**10
     _pyfftw_sliding_dot_product = sdp._make_pyfftw_sliding_dot_product(
         max_n=max_n, real_dtype="float64"
     )
 
-    # len(T) > max_n to trigger array resizing
+    # len(T) > max_n to trigger internal array resizing
     T = np.random.rand(max_n + 1)
     Q = np.random.rand(2**2)
 
@@ -185,7 +185,9 @@ def test_pyfftw_sdp_longdoube():
     if not sdp.PYFFTW_IS_AVAILABLE:  # pragma: no cover
         pytest.skip("Skipping Test pyFFTW Not Installed")
 
-    # This test checks that the pyfftw_sdp can be initialized with longdouble data type
+    # This test checks that the callable object
+    # returned by `_make_pyfftw_sliding_dot_product`
+    # can support `real_dtype="longdouble"`
     max_n = 2**10
     sdp_func = sdp._make_pyfftw_sliding_dot_product(max_n, real_dtype="longdouble")
 
@@ -204,8 +206,9 @@ def test_pyfftw_sdp_multithreaded():
     if not sdp.PYFFTW_IS_AVAILABLE:  # pragma: no cover
         pytest.skip("Skipping Test pyFFTW Not Installed")
 
-    # This test checks that the pyfftw_sdp can be initialized
-    # with multiple threads
+    # This test checks that the callable object
+    # returned by `_make_pyfftw_sliding_dot_product`
+    # can support multithreading.
     T = np.random.rand(2**5)
     Q = np.random.rand(2**4)
 
@@ -221,8 +224,9 @@ def test_pyfftw_sdp_multithreaded_longdouble():
     if not sdp.PYFFTW_IS_AVAILABLE:  # pragma: no cover
         pytest.skip("Skipping Test pyFFTW Not Installed")
 
-    # This test checks that the pyfftw_sdp can be initialized
-    # with multiple threads and longdouble data type
+    # This test checks that the callable object
+    # returned by `_make_pyfftw_sliding_dot_product`
+    # can support  multithreading and `real_dtype="longdouble"`
     max_n = 2**10
     sdp_func = sdp._make_pyfftw_sliding_dot_product(max_n, real_dtype="longdouble")
 

--- a/tests/test_sdp.py
+++ b/tests/test_sdp.py
@@ -3,6 +3,7 @@ import warnings
 from operator import eq, lt
 
 import naive
+import numpy as np
 import pytest
 from numpy import testing as npt
 


### PR DESCRIPTION
This is to address `PR 3` described in https://github.com/stumpy-dev/stumpy/pull/1118#issuecomment-3854039523. Have copied the corresponding notes below:

> 1. Add `_PYFFTW_SLIDING_DOT_PRODUCT` to `sdp.py`
> 2. Add unit tests that demonstrate that `_PYFFTW_SLIDING_DOT_PRODUCT` matches the results of `naive_rolling_window_dot_product`
> 3. Handle the `test.sh` `check_fftw_pyfftw` stuff here too