### PR TITLE
Add meaningful multivariate subsequence search tutorial

### DIFF
--- a/docs/Tutorial_Multivariate_Subsequence_Search.ipynb
+++ b/docs/Tutorial_Multivariate_Subsequence_Search.ipynb
@@ -1,0 +1,475 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Meaningful Multivariate Subsequence Search\n",
+    "\n",
+    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/stumpy-dev/stumpy/main?filepath=docs/Tutorial_Multivariate_Subsequence_Search.ipynb)\n",
+    "\n",
+    "## Finding Top-k Matches Across Channels With Different Units\n",
+    "\n",
+    "This tutorial is inspired by Eamonn Keogh's mini tutorial, [Meaningful Fast Top-k Subsequence Search for Multivariate Time Series](https://www.dropbox.com/scl/fi/vs0vei3i76wfd0m32n0cl/Meaningful-Fast-Top-k-Subsequence-Search-for-Multivariate-Time.pdf?rlkey=mm57cn45101f7pueytbq66dr6&e=1&dl=0), and the accompanying [source post](https://www.linkedin.com/posts/eamonn-keogh-96ab25143_timeseriesanalysis-patternmining-machinelearning-activity-7413378995796439040-b_ET). The central point is practical: raw subsequence distances can become meaningless when multivariate channels use different units or scales.\n",
+    "\n",
+    "Here, we will use `stumpy.match` to search for the top-k multivariate subsequence matches. We will first show how raw Euclidean distance can be distracted by a large-scale but irrelevant channel. Then we will use STUMPY's default z-normalized search and select only the query-relevant channels."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Getting Started\n",
+    "\n",
+    "Let's import the packages that we'll need to generate, analyze, and plot a small synthetic dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "\n",
+    "import numpy as np\n",
+    "import stumpy\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "for style in (\"./stumpy.mplstyle\", \"docs/stumpy.mplstyle\"):\n",
+    "    try:\n",
+    "        plt.style.use(style)\n",
+    "        break\n",
+    "    except OSError:\n",
+    "        pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating Flight-like Sensor Data\n",
+    "\n",
+    "Suppose that we are searching through a multivariate time series collected from a flight. The channels have different physical units: altitude, airspeed, outside temperature, and hydraulic pressure. Three short maneuver windows share the same shape in the first three channels. The pressure channel, however, contains a large pressure pulse in the query window and in one unrelated window.\n",
+    "\n",
+    "This is intentionally constructed so that raw distance can prefer the pressure-only distractor over the true repeated maneuvers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_flight_sensor_data(seed=12):\n",
+    "    rng = np.random.default_rng(seed)\n",
+    "    n = 720\n",
+    "    m = 64\n",
+    "    x = np.arange(n)\n",
+    "\n",
+    "    T = np.vstack(\n",
+    "        [\n",
+    "            32000 + 50 * np.sin(x / 70) + rng.normal(0, 4, n),\n",
+    "            450 + 3 * np.sin(x / 35) + rng.normal(0, 0.5, n),\n",
+    "            -40 + 1.0 * np.sin(x / 50) + rng.normal(0, 0.15, n),\n",
+    "            3000 + 120 * np.sin(x / 45) + rng.normal(0, 18, n),\n",
+    "        ]\n",
+    "    )\n",
+    "\n",
+    "    u = np.linspace(0, 1, m)\n",
+    "    maneuver = np.vstack(\n",
+    "        [\n",
+    "            -120 * np.sin(np.pi * u),\n",
+    "            -8 * np.sin(np.pi * u) + 2 * np.sin(2 * np.pi * u),\n",
+    "            -2.0 * np.sin(np.pi * u),\n",
+    "        ]\n",
+    "    )\n",
+    "\n",
+    "    maneuver_starts = np.array([112, 336, 552])\n",
+    "    for scale, start in zip([0.97, 1.0, 1.05], maneuver_starts):\n",
+    "        T[:3, start : start + m] += scale * maneuver\n",
+    "\n",
+    "    pressure_shape = 1800 * np.sin(np.pi * u) + 400 * np.sin(2 * np.pi * u)\n",
+    "    pressure_starts = np.array([336, 232])\n",
+    "    for start in pressure_starts:\n",
+    "        T[3, start : start + m] += pressure_shape\n",
+    "\n",
+    "    channel_names = [\n",
+    "        \"altitude (ft)\",\n",
+    "        \"airspeed (knots)\",\n",
+    "        \"temperature (deg C)\",\n",
+    "        \"hydraulic pressure (psi)\",\n",
+    "    ]\n",
+    "    known_events = {\n",
+    "        \"similar maneuver 1\": int(maneuver_starts[0]),\n",
+    "        \"query maneuver\": int(maneuver_starts[1]),\n",
+    "        \"similar maneuver 2\": int(maneuver_starts[2]),\n",
+    "        \"pressure-only distractor\": int(pressure_starts[1]),\n",
+    "    }\n",
+    "    relevant_dims = np.array([0, 1, 2])\n",
+    "\n",
+    "    return T, m, int(maneuver_starts[1]), relevant_dims, channel_names, known_events"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "T, m, query_idx, relevant_dims, channel_names, known_events = make_flight_sensor_data()\n",
+    "Q = T[:, query_idx : query_idx + m]\n",
+    "\n",
+    "T.shape, Q.shape, m, query_idx"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Each row in `T` is a sensor channel, and each column is a time point. The query `Q` is the window that starts at `query_idx`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def shade_known_windows(axs, known_events, m):\n",
+    "    colors = {\n",
+    "        \"similar maneuver 1\": \"C2\",\n",
+    "        \"query maneuver\": \"C1\",\n",
+    "        \"similar maneuver 2\": \"C2\",\n",
+    "        \"pressure-only distractor\": \"C3\",\n",
+    "    }\n",
+    "\n",
+    "    for label, start in known_events.items():\n",
+    "        for ax in axs:\n",
+    "            ax.axvspan(start, start + m, color=colors[label], alpha=0.12)\n",
+    "\n",
+    "    for label, start in known_events.items():\n",
+    "        axs[0].text(\n",
+    "            start,\n",
+    "            1.03,\n",
+    "            label,\n",
+    "            rotation=90,\n",
+    "            va=\"bottom\",\n",
+    "            fontsize=9,\n",
+    "            transform=axs[0].get_xaxis_transform(),\n",
+    "        )\n",
+    "\n",
+    "\n",
+    "fig, axs = plt.subplots(\n",
+    "    T.shape[0], 1, figsize=(14, 8), sharex=True, gridspec_kw={\"hspace\": 0.15}\n",
+    ")\n",
+    "\n",
+    "for ax, channel, name in zip(axs, T, channel_names):\n",
+    "    ax.plot(channel, lw=1)\n",
+    "    ax.set_ylabel(name)\n",
+    "\n",
+    "shade_known_windows(axs, known_events, m)\n",
+    "axs[-1].set_xlabel(\"Time\")\n",
+    "axs[0].set_title(\"Synthetic Multivariate Sensor Data\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The Query\n",
+    "\n",
+    "The query is the highlighted maneuver at time `336`. We will ask STUMPY to find the closest matching windows in the full time series."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axs = plt.subplots(\n",
+    "    Q.shape[0], 1, figsize=(10, 7), sharex=True, gridspec_kw={\"hspace\": 0.15}\n",
+    ")\n",
+    "\n",
+    "for ax, channel, name in zip(axs, Q, channel_names):\n",
+    "    ax.plot(channel, lw=2, color=\"C1\")\n",
+    "    ax.set_ylabel(name)\n",
+    "\n",
+    "axs[-1].set_xlabel(\"Relative time\")\n",
+    "axs[0].set_title(\"Multivariate Query Window\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## A Small Reporting Helper\n",
+    "\n",
+    "When the query is extracted from the same time series that we are searching, the closest match is the query itself. So, if we want the top `k` neighbors in addition to the self-match, we ask for `k + 1` matches and pass `query_idx`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def nearest_event(idx, known_events, tolerance=8):\n",
+    "    distance, label = min(\n",
+    "        (abs(idx - start), label) for label, start in known_events.items()\n",
+    "    )\n",
+    "    if distance <= tolerance:\n",
+    "        return label\n",
+    "    return \"\"\n",
+    "\n",
+    "\n",
+    "def print_matches(title, matches, known_events, limit=None):\n",
+    "    print(title)\n",
+    "    print(\"rank  start  distance  nearest known event\")\n",
+    "    for rank, (distance, idx) in enumerate(matches[:limit], start=1):\n",
+    "        idx = int(idx)\n",
+    "        print(\n",
+    "            f\"{rank:>4}  {idx:>5}  {float(distance):>8.3f}  \"\n",
+    "            f\"{nearest_event(idx, known_events)}\"\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Raw Multivariate Search Can Be Misleading\n",
+    "\n",
+    "First, let's turn z-normalization off by setting `normalize=False`. This computes a raw, non-normalized distance across the channels. Since hydraulic pressure is measured on a much larger numeric scale than the other channels, it can dominate the distance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raw_matches = stumpy.match(\n",
+    "    Q,\n",
+    "    T,\n",
+    "    max_matches=6,\n",
+    "    max_distance=np.inf,\n",
+    "    query_idx=query_idx,\n",
+    "    normalize=False,\n",
+    ")\n",
+    "\n",
+    "print_matches(\"Raw non-normalized matches\", raw_matches, known_events)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The first row is the self-match. The next row is the pressure-only distractor, not one of the other two maneuver windows. This is the failure mode: raw distance found a numerically similar pressure pulse, even though the maneuver channels do not match well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_query_and_matches(Q, T, matches, dims, channel_names, title, max_neighbors=3):\n",
+    "    neighbors = [(float(distance), int(idx)) for distance, idx in matches][\n",
+    "        1 : 1 + max_neighbors\n",
+    "    ]\n",
+    "    fig, axs = plt.subplots(\n",
+    "        len(dims),\n",
+    "        1,\n",
+    "        figsize=(12, 2.6 * len(dims)),\n",
+    "        sharex=True,\n",
+    "        gridspec_kw={\"hspace\": 0.15},\n",
+    "    )\n",
+    "    axs = np.atleast_1d(axs)\n",
+    "    x = np.arange(Q.shape[-1])\n",
+    "\n",
+    "    for ax, dim in zip(axs, dims):\n",
+    "        ax.plot(x, Q[dim], color=\"black\", lw=2, label=\"query\")\n",
+    "        for rank, (_, idx) in enumerate(neighbors, start=2):\n",
+    "            ax.plot(\n",
+    "                x,\n",
+    "                T[dim, idx : idx + Q.shape[-1]],\n",
+    "                lw=1.5,\n",
+    "                alpha=0.8,\n",
+    "                label=f\"rank {rank}: start {idx}\",\n",
+    "            )\n",
+    "        ax.set_ylabel(channel_names[dim])\n",
+    "\n",
+    "    axs[0].set_title(title)\n",
+    "    axs[-1].set_xlabel(\"Relative time\")\n",
+    "    axs[0].legend(loc=\"upper right\")\n",
+    "    plt.show()\n",
+    "\n",
+    "\n",
+    "plot_query_and_matches(\n",
+    "    Q,\n",
+    "    T,\n",
+    "    raw_matches,\n",
+    "    np.arange(T.shape[0]),\n",
+    "    channel_names,\n",
+    "    \"Raw Search: Top Matches After the Self-match\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Z-normalized Multivariate Search With `stumpy.match`\n",
+    "\n",
+    "By default, `stumpy.match` z-normalizes subsequences before computing distances. This compares shape rather than raw units, which is usually what we want for subsequence search across channels with different scales."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "znormalized_matches = stumpy.match(\n",
+    "    Q,\n",
+    "    T,\n",
+    "    max_matches=6,\n",
+    "    max_distance=np.inf,\n",
+    "    query_idx=query_idx,\n",
+    ")\n",
+    "\n",
+    "print_matches(\"Z-normalized matches across all channels\", znormalized_matches, known_events)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The true maneuver windows are now retrieved before the pressure-only distractor. The pressure channel no longer dominates just because its numbers are larger."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_query_and_matches(\n",
+    "    Q,\n",
+    "    T,\n",
+    "    znormalized_matches,\n",
+    "    np.arange(T.shape[0]),\n",
+    "    channel_names,\n",
+    "    \"Z-normalized Search Across All Channels\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Query-time Channel Selection\n",
+    "\n",
+    "In many multivariate searches, not every channel is relevant to the question. If the analyst knows that the query is about the maneuver shape, then altitude, airspeed, and temperature are relevant while the pressure pulse is not. We can express that directly by passing only those rows to `stumpy.match`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "selected_matches = stumpy.match(\n",
+    "    Q[relevant_dims],\n",
+    "    T[relevant_dims],\n",
+    "    max_matches=6,\n",
+    "    max_distance=np.inf,\n",
+    "    query_idx=query_idx,\n",
+    ")\n",
+    "\n",
+    "print_matches(\"Z-normalized matches on selected channels\", selected_matches, known_events)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is a query-time choice. We did not build an index or preprocess a special version of the data. We simply selected the rows that matter for the current search."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_query_and_matches(\n",
+    "    Q,\n",
+    "    T,\n",
+    "    selected_matches,\n",
+    "    relevant_dims,\n",
+    "    channel_names,\n",
+    "    \"Z-normalized Search on Selected Channels\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Extracting the Top-k Neighbors\n",
+    "\n",
+    "The `max_matches` argument controls how many matches are returned. Since our query is a subsequence of `T`, the first row is the self-match. The top `k` non-trivial neighbors are the next `k` rows."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "k = 2\n",
+    "top_k_neighbors = selected_matches[1 : k + 1]\n",
+    "\n",
+    "print_matches(f\"Top {k} non-trivial neighbors\", top_k_neighbors, known_events)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "- Raw multivariate subsequence distance can be dominated by whichever channel has the largest numeric scale.\n",
+    "- `stumpy.match` uses z-normalized subsequence distances by default, which makes shape-based search meaningful across channels with different units.\n",
+    "- For query-time channel selection, pass only the relevant rows of `Q` and `T`.\n",
+    "- Use `max_matches` for top-k search, and request one extra match when the query is itself a subsequence of the searched time series."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -23,6 +23,7 @@ Tutorials
     Tutorial_Matrix_Profiles_For_Streaming_Data.ipynb
     Tutorial_Pattern_Matching.ipynb
     Tutorial_AB_Joins.ipynb
+    Tutorial_Multivariate_Subsequence_Search.ipynb
     Tutorial_Consensus_Motif.ipynb
     Tutorial_Multidimensional_Motif_Discovery.ipynb
     Tutorial_Annotation_Vectors.ipynb


### PR DESCRIPTION
This PR adds a new tutorial inspired by Eamonn Keogh's multivariate top-k subsequence search example. The tutorial uses a self-contained synthetic sensor dataset to show why raw multivariate distances can be misleading, then demonstrates z-normalized stumpy.match and query-time channel selection for meaningful top-k matches.  

Validation:

- Executed the notebook end to end with nbconvert.
- Rendered the tutorial to HTML.
- Built the Sphinx docs and confirmed the new tutorial executes and renders.

Fixes #1137