### PR TITLE
refactor: migrate to new NumPy RNG API

### DIFF
--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -3717,7 +3717,7 @@ def check_ignore_trivial(T_A, T_B, ignore_trivial):
     import numpy as np
     import warnings
 
-    T = np.random.rand(10_000)
+    T = np.random.default_rng().random(10_000)
     m = 50
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message="Arrays T_A, T_B are equal")
@@ -4493,7 +4493,7 @@ def check_self_join(ignore_trivial):
     import numpy as np
     import warnings
 
-    T = np.random.rand(10_000)
+    T = np.random.default_rng().random(10_000)
     m = 50
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message="`ignore_trivial` cannot be `False`")

--- a/stumpy/floss.py
+++ b/stumpy/floss.py
@@ -84,13 +84,13 @@ def _iac(
     IAC : numpy.ndarray
         Idealized arc curve (IAC)
     """
-    np.random.seed(seed)
+    rng = np.random.default_rng(seed)
 
-    I = np.random.randint(0, width, size=width, dtype=np.int64)
+    I = rng.integers(0, width, size=width, dtype=np.int64)
     if bidirectional is False:  # Idealized 1-dimensional matrix profile index
         I[:-1] = width
         for i in range(width - 1):
-            I[i] = np.random.randint(i + 1, width, dtype=np.int64)
+            I[i] = rng.integers(i + 1, width, dtype=np.int64)
 
     target_AC = _nnmark(I)
 

--- a/stumpy/scraamp.py
+++ b/stumpy/scraamp.py
@@ -78,7 +78,7 @@ def _preprocess_prescraamp(T_A, m, T_B=None, s=None):
         else:  # AB-join
             s = int(np.ceil(m / config.STUMPY_EXCL_ZONE_DENOM))
 
-    indices = np.random.permutation(range(0, l, s)).astype(np.int64)
+    indices = np.random.default_rng().permutation(range(0, l, s)).astype(np.int64)
 
     return (T_A, T_B, T_A_subseq_isfinite, T_B_subseq_isfinite, indices, s, excl_zone)
 
@@ -718,7 +718,7 @@ class scraamp:
             core._merge_topk_PI(self._P, P, self._I, I)
 
         if self._ignore_trivial:
-            self._diags = np.random.permutation(
+            self._diags = np.random.default_rng().permutation(
                 range(self._excl_zone + 1, self._n_A - self._m + 1)
             ).astype(np.int64)
             if self._diags.shape[0] == 0:  # pragma: no cover
@@ -728,7 +728,7 @@ class scraamp:
                     f"Please try a value of `m <= {max_m}`"
                 )
         else:
-            self._diags = np.random.permutation(
+            self._diags = np.random.default_rng().permutation(
                 range(-(self._n_A - self._m + 1) + 1, self._n_B - self._m + 1)
             ).astype(np.int64)
 

--- a/stumpy/scrump.py
+++ b/stumpy/scrump.py
@@ -116,7 +116,7 @@ def _preprocess_prescrump(
         else:  # AB-join
             s = int(np.ceil(m / config.STUMPY_EXCL_ZONE_DENOM))
 
-    indices = np.random.permutation(range(0, l, s)).astype(np.int64)
+    indices = np.random.default_rng().permutation(range(0, l, s)).astype(np.int64)
 
     return (
         T_A,
@@ -997,7 +997,7 @@ class scrump:
             core._merge_topk_PI(self._P, P, self._I, I)
 
         if self._ignore_trivial:
-            self._diags = np.random.permutation(
+            self._diags = np.random.default_rng().permutation(
                 range(self._excl_zone + 1, self._n_A - self._m + 1)
             ).astype(np.int64)
             if self._diags.shape[0] == 0:  # pragma: no cover
@@ -1007,7 +1007,7 @@ class scrump:
                     f"Please try a value of `m <= {max_m}`"
                 )
         else:
-            self._diags = np.random.permutation(
+            self._diags = np.random.default_rng().permutation(
                 range(-(self._n_A - self._m + 1) + 1, self._n_B - self._m + 1)
             ).astype(np.int64)
 


### PR DESCRIPTION
## Summary

Closes #1112

Updates stumpy core files to use the new NumPy random number generator API (`np.random.default_rng()`) instead of the legacy API.

## Changes

- `floss.py`: `np.random.seed()` + `np.random.randint()` → `default_rng().integers()`
- `scraamp.py`: `np.random.permutation()` → `default_rng().permutation()`
- `scrump.py`: `np.random.permutation()` → `default_rng().permutation()`
- `core.py`: Updated docstring examples to use new API

## Note

This PR only updates the core stumpy files. Test files and docstrings will be updated in a follow-up PR as recommended by the issue description.

## References

- [NumPy Random Generator Migration Guide](https://numpy.org/doc/1.22/reference/random/index.html#quick-start)