### PR TITLE
Fixed #1151 Forward query_idx from aamp_match to core.mass_absolute

### DIFF
--- a/stumpy/aamp_motifs.py
+++ b/stumpy/aamp_motifs.py
@@ -398,7 +398,9 @@ def aamp_match(
 
     D = np.empty((d, n - m + 1))
     for i in range(d):
-        D[i, :] = core.mass_absolute(Q[i], T[i], T_subseq_isfinite[i], p=p)
+        D[i, :] = core.mass_absolute(
+            Q[i], T[i], T_subseq_isfinite[i], p=p, query_idx=query_idx
+        )
     D = np.mean(D, axis=0)
 
     return core._find_matches(

--- a/stumpy/core.py
+++ b/stumpy/core.py
@@ -1372,7 +1372,7 @@ def mass_absolute(Q, T, T_subseq_isfinite=None, p=2.0, query_idx=None):
 
     check_window_size(m, max_size=Q.shape[0])
 
-    if query_idx is not None:  # pragma: no cover
+    if query_idx is not None:
         query_idx = int(query_idx)
         T_isfinite_idx = np.isfinite(T[query_idx : query_idx + m])
         if not np.all(Q_isfinite == T_isfinite_idx) or not np.allclose(
@@ -1407,7 +1407,7 @@ def mass_absolute(Q, T, T_subseq_isfinite=None, p=2.0, query_idx=None):
         if T_subseq_isfinite is None:
             T, T_subseq_isfinite = preprocess_non_normalized(T, m)
         distance_profile[:] = _mass_absolute(Q, T, p)
-        if query_idx is not None:  # pragma: no cover
+        if query_idx is not None:
             distance_profile[query_idx] = 0.0
 
         distance_profile[~T_subseq_isfinite] = np.inf

--- a/tests/test_aamp_motifs.py
+++ b/tests/test_aamp_motifs.py
@@ -239,3 +239,22 @@ def test_aamp_match_T_subseq_isfinite(Q, T):
         )
 
         npt.assert_almost_equal(left, right)
+
+
+def test_aamp_match_query_idx():
+    T = np.random.uniform(-1000, 1000, [64])
+    m = 8
+    query_idx = 20
+    Q = T[query_idx : query_idx + m]
+
+    # `mass_absolute` zeroes the self-match distance when told where `Q` lives.
+    D = core.mass_absolute(Q, T, query_idx=query_idx)
+    npt.assert_almost_equal(D[query_idx], 0.0)
+
+    # A `Q` that is not the subsequence at `query_idx` must still return the
+    # self-match first, and must warn, exactly as `stumpy.match` does.
+    with pytest.warns(UserWarning):
+        out = aamp_match(Q + 0.5, T, query_idx=query_idx, max_distance=1.0)
+
+    assert out[0, 1] == query_idx
+    npt.assert_almost_equal(out[0, 0], 0.0)


### PR DESCRIPTION
Fixes #1151.

`aamp_match` accepts `query_idx` and forwards it to `core._find_matches`, but never forwards it to `core.mass_absolute`. The normalized twin, `motifs.match`, forwards it to both `core.mass` and `core._find_matches`.

`core._find_matches` seeds `candidate_idx = query_idx` and then breaks when `D[candidate_idx] > atol + max_distance`, so it depends on `D[query_idx] == 0` — which is what `core.mass_absolute`'s `query_idx` parameter exists to establish.

`query_idx` was added to `core.mass` **and** `core.mass_absolute` in #860; #856 wired it into `core.mass` from `motifs.match` the next day, but `aamp_motifs.py` was not updated. `core.mass_absolute`'s `query_idx` branches have been unreachable ever since — which is why they carry `# pragma: no cover`. They are now covered, so the pragmas are removed.

### Changes

* `stumpy/aamp_motifs.py` — forward `query_idx` to `core.mass_absolute`.
* `stumpy/core.py` — drop the two `# pragma: no cover` markers on `mass_absolute`'s now-reachable `query_idx` branches.
* `tests/test_aamp_motifs.py` — add `test_aamp_match_query_idx`. There was previously no `query_idx` test in either `tests/test_motifs.py` or `tests/test_aamp_motifs.py`.

### Behaviour

For a correct self-join this is a **no-op**: `_mass_absolute` uses `scipy.spatial.distance.cdist`, which returns exactly `0.0` for the identical row, so `D[query_idx]` was already the minimum and the self-match was already returned first.

What it restores is the behaviour when `query_idx` does **not** describe `Q` — the case `mass_absolute`'s warning exists to catch:

| | `match` | `aamp_match` before | `aamp_match` after |
| --- | --- | --- | --- |
| rows returned | `(1, 2)` | `(0,)` | `(1, 2)` |
| self-match first | yes | no | yes |
| warns | yes | **no** | yes |

### Verification

* Correct usage: output byte-identical to `main` (`np.array_equal` → `True`), single- and multi-dimensional.
* `aamp_motifs` (the internal caller, which always passes `query_idx=candidate_idx` with the real subsequence): identical `motif_distances` and `motif_indices` across 30 seeds.
* `tests/test_aamp_motifs.py`, `tests/test_motifs.py`, `tests/test_precision.py`: all pass under `NUMBA_DISABLE_JIT=1`.
* The new test alone covers `core.py:1375`, `:1376`, `:1410`, `:1411` with no partial branches, so `coverage report --fail-under=100` still passes with the pragmas gone.
* `black --check`, `isort --profile black --check-only`, `flake8`: clean.
