### PR TITLE
Add STUMPY_SEED test reproducibility (#707)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -4,3 +4,22 @@
 # to fix eventual module import errors that can arise, for example when
 # running tests from inside VS code.
 # See https://stackoverflow.com/a/34520971
+
+import os
+
+import numpy as np
+
+# Set STUMPY_SEED for reproducible test failures.
+# If not already set (e.g., by test.sh), generate a random seed.
+# The seed is printed so it can be noted and reused to reproduce failures:
+#   STUMPY_SEED=12345 pytest tests/test_stump.py
+if "STUMPY_SEED" not in os.environ:  # pragma: no cover
+    os.environ["STUMPY_SEED"] = str(np.random.default_rng().integers(2**31))
+
+# Seed the legacy np.random globally for all tests:
+np.random.seed(int(os.environ["STUMPY_SEED"]))
+
+
+def pytest_configure(config):
+    """Print STUMPY_SEED so failed tests can be reproduced."""
+    print(f"\nSTUMPY_SEED={os.environ['STUMPY_SEED']}")

--- a/test.sh
+++ b/test.sh
@@ -347,6 +347,10 @@ convert_notebooks()
 #   Main  #
 ###########
 
+# Set STUMPY_SEED for reproducible test failures
+export STUMPY_SEED=${STUMPY_SEED:-$RANDOM}
+echo "STUMPY_SEED=$STUMPY_SEED"
+
 if [[ $test_mode == "show" ]]; then
     echo "Show development/test environment"
     show

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -1,0 +1,22 @@
+import os
+
+import numpy as np
+import numpy.testing as npt
+
+
+def test_stumpy_seed_env_var_is_set():
+    """conftest.py should always set STUMPY_SEED in the environment."""
+    assert "STUMPY_SEED" in os.environ
+    seed_val = os.environ["STUMPY_SEED"]
+    assert seed_val.isdigit()
+    assert 0 <= int(seed_val) < 2**31
+
+
+def test_stumpy_seed_produces_deterministic_rng():
+    """Same STUMPY_SEED should produce identical random sequences."""
+    seed = int(os.environ["STUMPY_SEED"])
+    np.random.seed(seed)
+    arr1 = np.random.uniform(-1000, 1000, [64])
+    np.random.seed(seed)
+    arr2 = np.random.uniform(-1000, 1000, [64])
+    npt.assert_array_equal(arr1, arr2)


### PR DESCRIPTION
Add STUMPY_SEED test reproducibility to allow reproducing failed unit tests, resolving #707.

# Pull Request Checklist

Below is a simple checklist but please do not hesitate to ask for assistance!

- [x] Read our [Contributing Guide](https://stumpy.readthedocs.io/en/latest/Contribute.html)
- [x] Referenced a Github issue (or create one if one doesn't already exist)
- [x] Left a meaningful comment on the original Github issue to discuss the detailed approach for your contribution
- [x] Created a new branch
- [x] Made necessary code changes
- [x] Installed `black` (i.e., `python -m pip install black` or `conda install -c conda-forge black`)
- [x] Installed `flake8` (i.e., `python -m pip install flake8` or `conda install -c conda-forge flake8`)
- [x] Installed `pytest-cov` (i.e., `python -m pip install pytest-cov` or `conda install -c conda-forge pytest-cov`)
- [x] Ran `black --exclude=".*\.ipynb" --extend-exclude=".venv" --diff ./` in the root stumpy directory
- [x] Ran `flake8 --extend-exclude=.venv ./` in the root stumpy directory
- [x] Ran `./setup.sh dev && ./test.sh` in the root stumpy directory
