### PR TITLE
Drop redundant k clamp in _mpdist_vect and _aampdist_vect

### DIFF
--- a/stumpy/aampdist.py
+++ b/stumpy/aampdist.py
@@ -72,7 +72,7 @@ def _aampdist_vect(
 
     if k is None:
         percentage = np.clip(percentage, 0.0, 1.0)
-        k = min(math.ceil(percentage * (2 * Q.shape[0])), 2 * j - 1)
+        k = math.ceil(percentage * (2 * Q.shape[0]))
 
     k = min(int(k), P_ABBA.shape[0] - 1)
 

--- a/stumpy/mpdist.py
+++ b/stumpy/mpdist.py
@@ -101,7 +101,7 @@ def _mpdist_vect(
 
     if k is None:
         percentage = np.clip(percentage, 0.0, 1.0)
-        k = min(math.ceil(percentage * (2 * Q.shape[0])), 2 * j - 1)
+        k = math.ceil(percentage * (2 * Q.shape[0]))
 
     k = min(int(k), P_ABBA.shape[0] - 1)
 


### PR DESCRIPTION
# Pull Request Checklist

Below is a simple checklist but please do not hesitate to ask for assistance!

- [x] Read our [Contributing Guide](https://stumpy.readthedocs.io/en/latest/Contribute.html)
- [x] Referenced a Github issue (or create one if one doesn't already exist)
- [x] Left a meaningful comment on the original Github issue to discuss the detailed approach for your contribution
- [x] Forked, cloned, and checkedout the newest version of the code
- [x] Created a new branch
- [x] Made necessary code changes
- [x] Installed `black` (i.e., `python -m pip install black` or `conda install -c conda-forge black`)
- [x] Installed `flake8` (i.e., `python -m pip install flake8` or `conda install -c conda-forge flake8`)
- [x] Installed `pytest-cov` (i.e., `python -m pip install pytest-cov` or `conda install -c conda-forge pytest-cov`)
- [x] Ran `black --exclude=".*\.ipynb" --extend-exclude=".venv" --diff ./` in the root stumpy directory
- [x] Ran `flake8 --extend-exclude=.venv ./` in the root stumpy directory
- [ ] Ran `./setup.sh dev && ./test.sh` in the root stumpy directory

On the last item: I'm on Windows, so instead of `./test.sh` I ran the two affected suites directly — `pytest tests/test_mpdist.py tests/test_aampdist.py` → **82 passed**. Happy to run anything else you'd like. `black` reported 99 files unchanged and `flake8` was clean.

---

Closes #1082.

`P_ABBA` is allocated as `np.empty(2 * j, ...)`, so `P_ABBA.shape[0] - 1` **is** `2 * j - 1`. That means the `k = min(int(k), P_ABBA.shape[0] - 1)` on the following line already applies exactly the same upper bound as the `min(..., 2 * j - 1)` inside the `if k is None` branch, so the inner clamp is redundant:

```python
P_ABBA = np.empty(2 * j, dtype=np.float64)

if k is None:
    percentage = np.clip(percentage, 0.0, 1.0)
    k = math.ceil(percentage * (2 * Q.shape[0]))   # inner min(..., 2*j-1) removed

k = min(int(k), P_ABBA.shape[0] - 1)               # already bounds k by 2*j-1
```

Applied to `aampdist` as well, as you noted on the issue.

### Why it's behaviour-preserving
`min(min(a, b), b) == min(a, b)`, and the `int()` is a no-op because `math.ceil` already returns an `int`. I also checked it empirically over 20,000 randomised `(n, m, percentage)` combinations — including `percentage` values outside `[0, 1]` so the clipping path is exercised — and the resulting `k` was identical in every case.
