### PR TITLE
fix: Ensure naive module is available in test_stump.py (closes #1160)

### DIFF
--- a/tests/test_stump.py
+++ b/tests/test_stump.py
@@ -1,6 +1,8 @@
 import functools
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))  # Add parent directory to path
 
-import naive
 import numpy as np
 import numpy.testing as npt
 import pandas as pd
@@ -9,6 +11,11 @@ import pytest
 
 from stumpy import config, rng
 from stumpy.stump import stump
+
+# Ensure naive module is available
+import naive
+if not hasattr(naive, 'stump'):
+    raise ImportError('naive module is not properly initialized. Please run pytest from the repository root or ensure tests/naive is in PYTHONPATH.')
 
 test_data = [
     (


### PR DESCRIPTION
## What
The test_stump.py test file fails when run with the command `STUMPY_SEED=2633420849 NUMBA_DISABLE_JIT=1 NUMBA_ENABLE_CUDASIM=1 pixi run tests custom tests/test_stump.py` because the 'naive' module used in the test is not found or not properly imported. The error arises from the import statement `import naive` which cannot locate the module, causing the entire test session to fail.

## Fix
Modify test_stump.py to ensure the naive module is accessible by adding the parent directory to sys.path and adding a check to give a clear error message if the naive module is missing. This ensures the test can locate the naive module regardless of the current working directory.

Closes #1160